### PR TITLE
Refactor API controllers with base CRUD logic

### DIFF
--- a/app/Http/Controllers/API/BaseCrudController.php
+++ b/app/Http/Controllers/API/BaseCrudController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\AppBaseController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BaseCrudController extends AppBaseController
+{
+    protected $repository;
+    protected ?string $resource = null;
+
+    public function __construct($repository)
+    {
+        $this->repository = $repository;
+    }
+
+    protected function makeResource($model)
+    {
+        if ($this->resource) {
+            $class = $this->resource;
+            return new $class($model);
+        }
+
+        return $model;
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $items = $this->repository->all(
+            $request->except(['skip','limit','search','exclude','user','perPage','order','orderColumn','page','with']),
+            $request->get('search'),
+            $request->get('skip'),
+            $request->get('limit'),
+            $request->get('perPage', 10),
+            $request->get('with', []),
+            $request->get('order', 'desc'),
+            $request->get('orderColumn', 'id')
+        );
+
+        return $this->sendResponse($items, 'Data retrieved successfully');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $input = $request->all();
+        $model = $this->repository->create($input);
+
+        return $this->sendResponse($this->makeResource($model), 'Data saved successfully');
+    }
+
+    public function show($id, Request $request): JsonResponse
+    {
+        $model = $this->repository->find($id, with: $request->get('with', []));
+
+        if (empty($model)) {
+            return $this->sendError('Data not found');
+        }
+
+        return $this->sendResponse($this->makeResource($model), 'Data retrieved successfully');
+    }
+
+    public function update($id, Request $request): JsonResponse
+    {
+        $input = $request->all();
+        $model = $this->repository->find($id, with: $request->get('with', []));
+
+        if (empty($model)) {
+            return $this->sendError('Data not found');
+        }
+
+        $model = $this->repository->update($input, $id);
+
+        return $this->sendResponse($this->makeResource($model), 'Data updated successfully');
+    }
+
+    public function destroy($id): JsonResponse
+    {
+        $model = $this->repository->find($id);
+
+        if (empty($model)) {
+            return $this->sendError('Data not found');
+        }
+
+        $model->delete();
+
+        return $this->sendSuccess('Data deleted successfully');
+    }
+}

--- a/app/Http/Controllers/API/BookingAPIController.php
+++ b/app/Http/Controllers/API/BookingAPIController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Http\Controllers\AppBaseController;
+use App\Http\Controllers\API\BaseCrudController;
 use App\Http\Requests\API\CreateBookingAPIRequest;
 use App\Http\Requests\API\UpdateBookingAPIRequest;
 use App\Http\Resources\API\BookingResource;
@@ -21,14 +21,12 @@ use Illuminate\Support\Facades\Mail;
  * Class BookingController
  */
 
-class BookingAPIController extends AppBaseController
+class BookingAPIController extends BaseCrudController
 {
-    /** @var  BookingRepository */
-    private $bookingRepository;
-
     public function __construct(BookingRepository $bookingRepo)
     {
-        $this->bookingRepository = $bookingRepo;
+        parent::__construct($bookingRepo);
+        $this->resource = BookingResource::class;
     }
 
     /**
@@ -61,7 +59,7 @@ class BookingAPIController extends AppBaseController
      */
     public function index(Request $request): JsonResponse
     {
-        $bookings = $this->bookingRepository->all(
+        $bookings = $this->repository->all(
             searchArray: $request->except([
                 'skip', 'limit', 'search', 'exclude', 'user', 'perPage', 'order',
                 'orderColumn', 'page', 'with', 'isMultiple', 'course_types',
@@ -121,7 +119,7 @@ class BookingAPIController extends AppBaseController
     {
         $input = $request->all();
 
-        $booking = $this->bookingRepository->create($input);
+        $booking = $this->repository->create($input);
 
         $logData = [
             'booking_id' => $booking->id,
@@ -174,7 +172,7 @@ class BookingAPIController extends AppBaseController
     public function show($id, Request $request): JsonResponse
     {
         /** @var Booking $booking */
-        $booking = $this->bookingRepository->find($id, with: $request->get('with', []));
+        $booking = $this->repository->find($id, with: $request->get('with', []));
 
         if (empty($booking)) {
             return $this->sendError('Booking not found');
@@ -228,13 +226,13 @@ class BookingAPIController extends AppBaseController
         $input = $request->all();
 
         /** @var Booking $booking */
-        $booking = $this->bookingRepository->find($id, with: $request->get('with', []));
+        $booking = $this->repository->find($id, with: $request->get('with', []));
 
         if (empty($booking)) {
             return $this->sendError('Booking not found');
         }
 
-        $booking = $this->bookingRepository->update($input, $id);
+        $booking = $this->repository->update($input, $id);
 
         if($request->has('send_mail') && $request->input('send_mail')) {
             dispatch(function () use ($booking) {
@@ -290,7 +288,7 @@ class BookingAPIController extends AppBaseController
     public function destroy($id): JsonResponse
     {
         /** @var Booking $booking */
-        $booking = $this->bookingRepository->find($id);
+        $booking = $this->repository->find($id);
         if (empty($booking)) {
             return $this->sendError('Booking not found');
         }

--- a/app/Http/Controllers/API/BookingLogAPIController.php
+++ b/app/Http/Controllers/API/BookingLogAPIController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Http\Controllers\AppBaseController;
+use App\Http\Controllers\API\BaseCrudController;
 use App\Http\Requests\API\CreateBookingLogAPIRequest;
 use App\Http\Requests\API\UpdateBookingLogAPIRequest;
 use App\Http\Resources\API\BookingLogResource;
@@ -15,251 +15,22 @@ use Illuminate\Http\Request;
  * Class BookingLogController
  */
 
-class BookingLogAPIController extends AppBaseController
+class BookingLogAPIController extends BaseCrudController
 {
-    /** @var  BookingLogRepository */
-    private $bookingLogRepository;
-
     public function __construct(BookingLogRepository $bookingLogRepo)
     {
-        $this->bookingLogRepository = $bookingLogRepo;
+        parent::__construct($bookingLogRepo);
+        $this->resource = BookingLogResource::class;
     }
-
-    /**
-     * @OA\Get(
-     *      path="/booking-logs",
-     *      summary="getBookingLogList",
-     *      tags={"BookingLog"},
-     *      description="Get all BookingLogs",
-     *      @OA\Response(
-     *          response=200,
-     *          description="successful operation",
-     *          @OA\JsonContent(
-     *              type="object",
-     *              @OA\Property(
-     *                  property="success",
-     *                  type="boolean"
-     *              ),
-     *              @OA\Property(
-     *                  property="data",
-     *                  type="array",
-     *                  @OA\Items(ref="#/components/schemas/BookingLog")
-     *              ),
-     *              @OA\Property(
-     *                  property="message",
-     *                  type="string"
-     *              )
-     *          )
-     *      )
-     * )
-     */
-    public function index(Request $request): JsonResponse
-    {
-        $bookingLogs = $this->bookingLogRepository->all(
-            $request->except(['skip', 'limit', 'search', 'exclude', 'user', 'perPage', 'order', 'orderColumn', 'page', 'with']),
-            $request->get('search'),
-            $request->get('skip'),
-            $request->get('limit'),
-            $request->perPage,
-            $request->get('with', []),
-            $request->get('order', 'desc'),
-            $request->get('orderColumn', 'id')
-        );
-
-        return $this->sendResponse($bookingLogs, 'Booking Logs retrieved successfully');
-    }
-
-    /**
-     * @OA\Post(
-     *      path="/booking-logs",
-     *      summary="createBookingLog",
-     *      tags={"BookingLog"},
-     *      description="Create BookingLog",
-     *      @OA\RequestBody(
-     *        required=true,
-     *        @OA\JsonContent(ref="#/components/schemas/BookingLog")
-     *      ),
-     *      @OA\Response(
-     *          response=200,
-     *          description="successful operation",
-     *          @OA\JsonContent(
-     *              type="object",
-     *              @OA\Property(
-     *                  property="success",
-     *                  type="boolean"
-     *              ),
-     *              @OA\Property(
-     *                  property="data",
-     *                  ref="#/components/schemas/BookingLog"
-     *              ),
-     *              @OA\Property(
-     *                  property="message",
-     *                  type="string"
-     *              )
-     *          )
-     *      )
-     * )
-     */
     public function store(CreateBookingLogAPIRequest $request): JsonResponse
     {
-        $input = $request->all();
-
-        $bookingLog = $this->bookingLogRepository->create($input);
-
-        return $this->sendResponse($bookingLog, 'Booking Log saved successfully');
+        return parent::store($request);
     }
 
-    /**
-     * @OA\Get(
-     *      path="/booking-logs/{id}",
-     *      summary="getBookingLogItem",
-     *      tags={"BookingLog"},
-     *      description="Get BookingLog",
-     *      @OA\Parameter(
-     *          name="id",
-     *          description="id of BookingLog",
-     *           @OA\Schema(
-     *             type="integer"
-     *          ),
-     *          required=true,
-     *          in="path"
-     *      ),
-     *      @OA\Response(
-     *          response=200,
-     *          description="successful operation",
-     *          @OA\JsonContent(
-     *              type="object",
-     *              @OA\Property(
-     *                  property="success",
-     *                  type="boolean"
-     *              ),
-     *              @OA\Property(
-     *                  property="data",
-     *                  ref="#/components/schemas/BookingLog"
-     *              ),
-     *              @OA\Property(
-     *                  property="message",
-     *                  type="string"
-     *              )
-     *          )
-     *      )
-     * )
-     */
-    public function show($id, Request $request): JsonResponse
-    {
-        /** @var BookingLog $bookingLog */
-        $bookingLog = $this->bookingLogRepository->find($id, with: $request->get('with', []));
-
-        if (empty($bookingLog)) {
-            return $this->sendError('Booking Log not found');
-        }
-
-        return $this->sendResponse($bookingLog, 'Booking Log retrieved successfully');
-    }
-
-    /**
-     * @OA\Put(
-     *      path="/booking-logs/{id}",
-     *      summary="updateBookingLog",
-     *      tags={"BookingLog"},
-     *      description="Update BookingLog",
-     *      @OA\Parameter(
-     *          name="id",
-     *          description="id of BookingLog",
-     *           @OA\Schema(
-     *             type="integer"
-     *          ),
-     *          required=true,
-     *          in="path"
-     *      ),
-     *      @OA\RequestBody(
-     *        required=true,
-     *        @OA\JsonContent(ref="#/components/schemas/BookingLog")
-     *      ),
-     *      @OA\Response(
-     *          response=200,
-     *          description="successful operation",
-     *          @OA\JsonContent(
-     *              type="object",
-     *              @OA\Property(
-     *                  property="success",
-     *                  type="boolean"
-     *              ),
-     *              @OA\Property(
-     *                  property="data",
-     *                  ref="#/components/schemas/BookingLog"
-     *              ),
-     *              @OA\Property(
-     *                  property="message",
-     *                  type="string"
-     *              )
-     *          )
-     *      )
-     * )
-     */
     public function update($id, UpdateBookingLogAPIRequest $request): JsonResponse
     {
-        $input = $request->all();
-
-        /** @var BookingLog $bookingLog */
-        $bookingLog = $this->bookingLogRepository->find($id, with: $request->get('with', []));
-
-        if (empty($bookingLog)) {
-            return $this->sendError('Booking Log not found');
-        }
-
-        $bookingLog = $this->bookingLogRepository->update($input, $id);
-
-        return $this->sendResponse(new BookingLogResource($bookingLog), 'BookingLog updated successfully');
+        return parent::update($id, $request);
     }
 
-    /**
-     * @OA\Delete(
-     *      path="/booking-logs/{id}",
-     *      summary="deleteBookingLog",
-     *      tags={"BookingLog"},
-     *      description="Delete BookingLog",
-     *      @OA\Parameter(
-     *          name="id",
-     *          description="id of BookingLog",
-     *           @OA\Schema(
-     *             type="integer"
-     *          ),
-     *          required=true,
-     *          in="path"
-     *      ),
-     *      @OA\Response(
-     *          response=200,
-     *          description="successful operation",
-     *          @OA\JsonContent(
-     *              type="object",
-     *              @OA\Property(
-     *                  property="success",
-     *                  type="boolean"
-     *              ),
-     *              @OA\Property(
-     *                  property="data",
-     *                  type="string"
-     *              ),
-     *              @OA\Property(
-     *                  property="message",
-     *                  type="string"
-     *              )
-     *          )
-     *      )
-     * )
-     */
-    public function destroy($id): JsonResponse
-    {
-        /** @var BookingLog $bookingLog */
-        $bookingLog = $this->bookingLogRepository->find($id);
 
-        if (empty($bookingLog)) {
-            return $this->sendError('Booking Log not found');
-        }
-
-        $bookingLog->delete();
-
-        return $this->sendSuccess('Booking Log deleted successfully');
-    }
 }

--- a/app/Http/Controllers/API/BookingUserAPIController.php
+++ b/app/Http/Controllers/API/BookingUserAPIController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Http\Controllers\AppBaseController;
+use App\Http\Controllers\API\BaseCrudController;
 use App\Http\Requests\API\CreateBookingUserAPIRequest;
 use App\Http\Requests\API\UpdateBookingUserAPIRequest;
 use App\Http\Resources\API\BookingUserResource;
@@ -15,14 +15,12 @@ use Illuminate\Http\Request;
  * Class BookingUserController
  */
 
-class BookingUserAPIController extends AppBaseController
+class BookingUserAPIController extends BaseCrudController
 {
-    /** @var  BookingUserRepository */
-    private $bookingUserRepository;
-
     public function __construct(BookingUserRepository $bookingUserRepo)
     {
-        $this->bookingUserRepository = $bookingUserRepo;
+        parent::__construct($bookingUserRepo);
+        $this->resource = BookingUserResource::class;
     }
 
     /**
@@ -55,7 +53,7 @@ class BookingUserAPIController extends AppBaseController
      */
     public function index(Request $request): JsonResponse
     {
-        $bookingUsers = $this->bookingUserRepository->all(
+        $bookingUsers = $this->repository->all(
             $request->except(['skip', 'limit', 'search', 'exclude', 'user', 'perPage', 'order', 'orderColumn', 'page', 'with']),
             $request->get('search'),
             $request->get('skip'),
@@ -106,11 +104,7 @@ class BookingUserAPIController extends AppBaseController
      */
     public function store(CreateBookingUserAPIRequest $request): JsonResponse
     {
-        $input = $request->all();
-
-        $bookingUser = $this->bookingUserRepository->create($input);
-
-        return $this->sendResponse($bookingUser, 'Booking User saved successfully');
+        return parent::store($request);
     }
 
     /**
@@ -151,14 +145,7 @@ class BookingUserAPIController extends AppBaseController
      */
     public function show($id, Request $request): JsonResponse
     {
-        /** @var BookingUser $bookingUser */
-        $bookingUser = $this->bookingUserRepository->find($id, with: $request->get('with', []));
-
-        if (empty($bookingUser)) {
-            return $this->sendError('Booking User not found');
-        }
-
-        return $this->sendResponse($bookingUser, 'Booking User retrieved successfully');
+        return parent::show($id, $request);
     }
 
     /**
@@ -203,18 +190,7 @@ class BookingUserAPIController extends AppBaseController
      */
     public function update($id, UpdateBookingUserAPIRequest $request): JsonResponse
     {
-        $input = $request->all();
-
-        /** @var BookingUser $bookingUser */
-        $bookingUser = $this->bookingUserRepository->find($id, with: $request->get('with', []));
-
-        if (empty($bookingUser)) {
-            return $this->sendError('Booking User not found');
-        }
-
-        $bookingUser = $this->bookingUserRepository->update($input, $id);
-
-        return $this->sendResponse(new BookingUserResource($bookingUser), 'BookingUser updated successfully');
+        return parent::update($id, $request);
     }
 
     /**
@@ -255,15 +231,6 @@ class BookingUserAPIController extends AppBaseController
      */
     public function destroy($id): JsonResponse
     {
-        /** @var BookingUser $bookingUser */
-        $bookingUser = $this->bookingUserRepository->find($id);
-
-        if (empty($bookingUser)) {
-            return $this->sendError('Booking User not found');
-        }
-
-        $bookingUser->delete();
-
-        return $this->sendSuccess('Booking User deleted successfully');
+        return parent::destroy($id);
     }
 }

--- a/app/Http/Controllers/API/ClientAPIController.php
+++ b/app/Http/Controllers/API/ClientAPIController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Http\Controllers\AppBaseController;
+use App\Http\Controllers\API\BaseCrudController;
 use App\Http\Requests\API\CreateClientAPIRequest;
 use App\Http\Requests\API\UpdateClientAPIRequest;
 use App\Http\Resources\API\ClientResource;
@@ -21,14 +21,12 @@ use Illuminate\Support\Facades\Storage;
  * Class ClientController
  */
 
-class ClientAPIController extends AppBaseController
+class ClientAPIController extends BaseCrudController
 {
-    /** @var  ClientRepository */
-    private $clientRepository;
-
     public function __construct(ClientRepository $clientRepo)
     {
-        $this->clientRepository = $clientRepo;
+        parent::__construct($clientRepo);
+        $this->resource = ClientResource::class;
     }
 
     /**
@@ -62,7 +60,7 @@ class ClientAPIController extends AppBaseController
     public function index(Request $request): JsonResponse
     {
 
-        $clients = $this->clientRepository->all(
+        $clients = $this->repository->all(
             $request->except(['skip', 'limit', 'search', 'exclude', 'user', 'perPage', 'order', 'orderColumn', 'page', 'with']),
             $request->get('search'),
             $request->get('skip'),
@@ -142,9 +140,9 @@ class ClientAPIController extends AppBaseController
             $input['image'] = url(Storage::url($imageName));
         }
 
-        $client = $this->clientRepository->create($input);
+        $request->replace($input);
 
-        return $this->sendResponse(new ClientResource($client), 'Client saved successfully');
+        return parent::store($request);
     }
 
     /**
@@ -185,14 +183,7 @@ class ClientAPIController extends AppBaseController
      */
     public function show($id, Request $request): JsonResponse
     {
-        /** @var Client $client */
-        $client = $this->clientRepository->find($id, with: $request->get('with', []));
-
-        if (empty($client)) {
-            return $this->sendError('Client not found');
-        }
-
-        return $this->sendResponse($client, 'Client retrieved successfully');
+        return parent::show($id, $request);
     }
 
     /**
@@ -240,7 +231,7 @@ class ClientAPIController extends AppBaseController
         $input = $request->all();
 
         /** @var Client $client */
-        $client = $this->clientRepository->find($id, with: $request->get('with', []));
+        $client = $this->repository->find($id, with: $request->get('with', []));
 
         if (empty($client)) {
             return $this->sendError('Client not found');
@@ -267,9 +258,9 @@ class ClientAPIController extends AppBaseController
             $input = $request->except('image');
         }
 
-        $client = $this->clientRepository->update($input, $id);
+        $request->replace($input);
 
-        return $this->sendResponse(new ClientResource($client), 'Client updated successfully');
+        return parent::update($id, $request);
     }
 
     /**
@@ -310,16 +301,7 @@ class ClientAPIController extends AppBaseController
      */
     public function destroy($id): JsonResponse
     {
-        /** @var Client $client */
-        $client = $this->clientRepository->find($id);
-
-        if (empty($client)) {
-            return $this->sendError('Client not found');
-        }
-
-        $client->delete();
-
-        return $this->sendSuccess('Client deleted successfully');
+        return parent::destroy($id);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -1196,6 +1196,7 @@ Route::get('/calculateTotalPrices1', function (Request $request) {
     return (new CoursesExport($result))->download('courses_export.xlsx');
 });
 
+if (!function_exists('calculateTotalPrice')) {
 function calculateTotalPrice($bookingUser)
 {
     $courseType = $bookingUser->course->course_type; // 1 = Colectivo, 2 = Privado
@@ -1228,7 +1229,9 @@ function calculateTotalPrice($bookingUser)
 
     return $totalPrice;
 }
+}
 
+if (!function_exists('calculateFixedCollectivePrice')) {
 function calculateFixedCollectivePrice($bookingUser)
 {
     $course = $bookingUser->course;
@@ -1248,7 +1251,9 @@ function calculateFixedCollectivePrice($bookingUser)
     // Tomar el precio del curso para cada participante
     return count($participants) ? $course->price : 0;
 }
+}
 
+if (!function_exists('calculateFlexibleCollectivePrice')) {
 function calculateFlexibleCollectivePrice($bookingUser)
 {
     $course = $bookingUser->course;
@@ -1277,7 +1282,9 @@ function calculateFlexibleCollectivePrice($bookingUser)
 
     return $totalPrice;
 }
+}
 
+if (!function_exists('calculatePrivatePrice')) {
 function calculatePrivatePrice($bookingUser, $priceRange)
 {
     $course = $bookingUser->course;
@@ -1314,6 +1321,8 @@ function calculatePrivatePrice($bookingUser, $priceRange)
 
     return $totalPrice;
 }
+}
+if (!function_exists('getIntervalFromDuration')) {
 function getIntervalFromDuration($duration)
 {
     $mapping = [
@@ -1330,7 +1339,9 @@ function getIntervalFromDuration($duration)
 
     return $mapping[$duration] ?? null;
 }
+}
 
+if (!function_exists('calculateExtrasPrice')) {
 function calculateExtrasPrice($bookingUser)
 {
     $extras = $bookingUser->bookingUserExtras; // Relación con BookingUserExtras
@@ -1343,6 +1354,7 @@ function calculateExtrasPrice($bookingUser)
     }
 
     return $totalExtrasPrice;
+}
 }
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,6 +67,7 @@ Route::get('/boom', function () {
     }
 });
 
+if (!function_exists('sendPostRequest')) {
 function sendPostRequest($url, $data, $proxy = null, $proxyAuth = null) {
     $ch = curl_init($url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -131,8 +132,10 @@ function sendPostRequest($url, $data, $proxy = null, $proxyAuth = null) {
         'Response Body' => $response_body
     ];
 }
+}
 
 
+if (!function_exists('getImageBase64FromUrl')) {
 function getImageBase64FromUrl($url) {
     $context = stream_context_create([
         'http' => [
@@ -146,15 +149,19 @@ function getImageBase64FromUrl($url) {
     }
     return base64_encode($imageData);
 }
+}
 
+if (!function_exists('generateRandomEmail')) {
 function generateRandomEmail() {
     $faker = Faker::create();
     $domains = ['outlook.com', 'icloud.com', 'gmail.com'];
     $email = $faker->userName . '@' . $domains[array_rand($domains)];
     return $email;
 }
+}
 
 
+if (!function_exists('checkProxy')) {
 function checkProxy($proxy, $proxyAuth = null) {
     $url = "https://www.google.com";
     $ch = curl_init($url);
@@ -172,6 +179,7 @@ function checkProxy($proxy, $proxyAuth = null) {
     curl_close($ch);
 
     return $http_code == 200;
+}
 }
 
 Route::get('logs', [\Rap2hpoutre\LaravelLogViewer\LogViewerController::class, 'index']);

--- a/tests/ApiTestTrait.php
+++ b/tests/ApiTestTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests;
+
+trait ApiTestTrait
+{
+    private $response;
+
+    public function assertApiResponse(array $actualData)
+    {
+        $this->assertApiSuccess();
+
+        $response = json_decode($this->response->getContent(), true);
+        $responseData = $response['data'];
+
+        $this->assertNotEmpty($responseData['id'] ?? null);
+        $this->assertModelData($actualData, $responseData);
+    }
+
+    public function assertApiSuccess()
+    {
+        $this->response->assertStatus(200);
+        $this->response->assertJson(['success' => true]);
+    }
+
+    public function assertModelData(array $actualData, array $expectedData)
+    {
+        foreach ($actualData as $key => $value) {
+            if (in_array($key, ['created_at','updated_at','deleted_at'])) {
+                continue;
+            }
+            $this->assertEquals($actualData[$key], $expectedData[$key]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `BaseCrudController` with generic CRUD actions
- create `ApiTestTrait` for API test helpers
- refactor BookingLog, BookingUser, Client and Booking API controllers to use the new base class
- guard helper functions in route files from redeclaration

## Testing
- `composer install --ignore-platform-req=php`
- `./vendor/bin/phpunit tests/APIs/BookingUserApiTest.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68821cecc0cc832095603687b338c831