### PR TITLE
Refactor auth login flow

### DIFF
--- a/app/Http/Controllers/Teach/AuthController.php
+++ b/app/Http/Controllers/Teach/AuthController.php
@@ -3,14 +3,8 @@
 namespace App\Http\Controllers\Teach;
 
 use App\Http\Controllers\AppBaseController;
-use App\Models\User;
+use App\Services\Auth\LoginService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
-use Response;
-use Validator;
-
-;
 
 /**
  * Class UserController
@@ -19,10 +13,11 @@ use Validator;
 
 class AuthController extends AppBaseController
 {
+    protected LoginService $loginService;
 
-    public function __construct()
+    public function __construct(LoginService $loginService)
     {
-
+        $this->loginService = $loginService;
     }
 
 
@@ -67,35 +62,13 @@ class AuthController extends AppBaseController
      */
     public function login(Request $request)
     {
-        $credentials = $request->validate([
-            'email' => ['required', 'email'],
-            'password' => ['required'],
-        ]);
+        $result = $this->loginService->authenticate($request, ['monitor', 3]);
 
-        // Buscar usuarios por correo electrónico y tipo
-        $users = User::where('email', $credentials['email'])
-            ->where(function ($query) {
-                $query->where('type', 'monitor')
-                    ->orWhere('type', 3);
-            })
-            ->get();
-
-        foreach ($users as $user) {
-            // Verificar si la contraseña es correcta
-            if (Hash::check($credentials['password'], $user->password)) {
-                // Cargar escuelas relacionadas si las hay
-                if ($user->type == 'monitor' || $user->type == 3) {
-                    $success['token'] = $user->createToken('Boukii')->plainTextToken;
-                    $user->load('monitors');
-                    $user->tokenCan('teach:all');
-                    $success['user'] =  $user;
-                    return $this->sendResponse($success, 'User login successfully.');
-                }
-            }
+        if (!$result) {
+            return $this->sendError('Unauthorized.', 401);
         }
 
-        // Si no se encuentra ningún usuario o la contraseña no coincide
-        return $this->sendError('Unauthorized.', 401);
+        return $this->sendResponse($result, 'User login successfully.');
 
     }
 

--- a/app/Services/Auth/LoginService.php
+++ b/app/Services/Auth/LoginService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Services\Auth;
+
+use App\Models\School;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+
+class LoginService
+{
+    /**
+     * Autenticar usuario segun tipos permitidos.
+     */
+    public function authenticate(Request $request, array $allowedTypes, ?School $school = null): ?array
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $usersQuery = User::query()
+            ->where('email', $credentials['email'])
+            ->where(function ($query) use ($allowedTypes) {
+                foreach ($allowedTypes as $type) {
+                    $query->orWhere('type', $type);
+                }
+            });
+
+        if ($school) {
+            $relations = ['schools', 'clients.schools'];
+            if (Schema::hasTable('clients_utilizers')) {
+                $relations[] = 'clients.utilizers';
+            }
+            $usersQuery->with($relations);
+        }
+
+        $users = $usersQuery->get();
+
+        foreach ($users as $user) {
+            if (!Hash::check($credentials['password'], $user->password)) {
+                continue;
+            }
+
+            switch ($user->type) {
+                case 'superadmin':
+                case '4':
+                    $token = $user->createToken('Boukii', ['permissions:all'])->plainTextToken;
+                    break;
+                case 'admin':
+                case '1':
+                    $user->load('schools');
+                    $token = $user->createToken('Boukii', ['admin:all'])->plainTextToken;
+                    break;
+                case 'monitor':
+                case '3':
+                    $user->load('monitors');
+                    $token = $user->createToken('Boukii', ['teach:all'])->plainTextToken;
+                    break;
+                case 'client':
+                case '2':
+                    if (!$school) {
+                        continue 2;
+                    }
+                    foreach ($user->clients as $client) {
+                        if ($client->schools->contains('id', $school->id)) {
+                            if (\Illuminate\Support\Facades\Schema::hasTable('clients_utilizers')) {
+                                $user->load('clients.utilizers.sports', 'clients.sports');
+                            }
+                            $token = $user->createToken('Boukii', ['client:all'])->plainTextToken;
+                            break 2;
+                        }
+                    }
+                    continue 2;
+                default:
+                    continue 2;
+            }
+
+            return [
+                'token' => $token,
+                'user' => $user,
+            ];
+        }
+
+        return null;
+    }
+}

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\School;
+use App\Models\Client;
+use App\Models\ClientsSchool;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+
+class LoginTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['activitylog.enabled' => false]);
+
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('schools', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('description');
+            $table->string('slug');
+            $table->boolean('active')->default(1);
+            $table->json('settings')->nullable();
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->bigInteger('id')->primary();
+            $table->string('email')->nullable();
+            $table->string('password');
+            $table->string('type', 100);
+            $table->boolean('active')->default(1);
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('clients', function (Blueprint $table) {
+            $table->bigInteger('id')->primary();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->date('birth_date');
+            $table->string('telephone')->default('');
+            $table->bigInteger('user_id')->nullable();
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('clients_schools', function (Blueprint $table) {
+            $table->bigInteger('id')->primary();
+            $table->bigInteger('client_id');
+            $table->bigInteger('school_id');
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('school_users', function (Blueprint $table) {
+            $table->bigInteger('id')->primary();
+            $table->bigInteger('school_id');
+            $table->bigInteger('user_id');
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('monitors', function (Blueprint $table) {
+            $table->bigInteger('id')->primary();
+            $table->bigInteger('user_id')->nullable();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->boolean('active')->default(1);
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('clients_schools');
+        Schema::dropIfExists('school_users');
+        Schema::dropIfExists('clients');
+        Schema::dropIfExists('monitors');
+        Schema::dropIfExists('users');
+        Schema::dropIfExists('schools');
+        Schema::dropIfExists('personal_access_tokens');
+        parent::tearDown();
+    }
+
+    public function test_admin_login()
+    {
+        $user = User::create([
+            'id' => 1,
+            'email' => 'admin@test.com',
+            'password' => Hash::make('password'),
+            'type' => 'admin',
+            'active' => 1,
+        ]);
+
+        $response = $this->postJson('/api/admin/login', [
+            'email' => 'admin@test.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.user.id', $user->id);
+    }
+
+    public function test_teach_login()
+    {
+        $user = User::create([
+            'id' => 2,
+            'email' => 'monitor@test.com',
+            'password' => Hash::make('password'),
+            'type' => 'monitor',
+            'active' => 1,
+        ]);
+
+        $response = $this->postJson('/api/teach/login', [
+            'email' => 'monitor@test.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.user.id', $user->id);
+    }
+
+    public function test_booking_page_login()
+    {
+        $school = School::create([
+            'name' => 'My School',
+            'description' => 'desc',
+            'slug' => 'myschool',
+            'active' => 1,
+            'settings' => json_encode([]),
+        ]);
+
+        $user = User::create([
+            'id' => 3,
+            'email' => 'client@test.com',
+            'password' => Hash::make('password'),
+            'type' => 'client',
+            'active' => 1,
+        ]);
+
+        $client = Client::withoutEvents(function () use ($user) {
+            return Client::create([
+                'id' => 4,
+                'first_name' => 'Name',
+                'last_name' => 'Surname',
+                'birth_date' => '1990-01-01',
+                'telephone' => '',
+                'user_id' => $user->id,
+            ]);
+        });
+
+        ClientsSchool::create([
+            'id' => 5,
+            'client_id' => $client->id,
+            'school_id' => $school->id,
+        ]);
+
+        $response = $this->withHeaders(['slug' => $school->slug])->postJson('/api/slug/login', [
+            'email' => 'client@test.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.user.id', $user->id);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize login logic in `LoginService`
- use new service in admin, teach and booking page auth controllers
- add feature tests for login routes

## Testing
- `APP_KEY=base64:B02IlDF19zvT4yBWt0ABErhuGHXWxN3LcPlY5h5UhJw= DB_CONNECTION=sqlite DB_DATABASE=/tmp/testdb.sqlite ./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6882467b75548320a23de1f785276ae8