### PR TITLE
Add AIController with stubbed AI routes

### DIFF
--- a/app/Http/Controllers/API/AIController.php
+++ b/app/Http/Controllers/API/AIController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\AppBaseController;
+use App\Services\AI\AIService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AIController extends AppBaseController
+{
+    protected AIService $aiService;
+
+    public function __construct(AIService $aiService)
+    {
+        $this->aiService = $aiService;
+    }
+
+    public function smartSuggestions(Request $request): JsonResponse
+    {
+        $data = $this->aiService->getSmartSuggestions($request->all());
+        return $this->sendResponse($data, 'Smart suggestions retrieved');
+    }
+
+    public function courseRecommendations(Request $request): JsonResponse
+    {
+        $data = $this->aiService->getCourseRecommendations($request->all());
+        return $this->sendResponse($data, 'Course recommendations retrieved');
+    }
+
+    public function predictiveAnalysis(Request $request): JsonResponse
+    {
+        $data = $this->aiService->runPredictiveAnalysis($request->all());
+        return $this->sendResponse($data, 'Predictive analysis result');
+    }
+}

--- a/app/Services/AI/AIService.php
+++ b/app/Services/AI/AIService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\AI;
+
+class AIService
+{
+    public function getSmartSuggestions(array $context = []): array
+    {
+        return [
+            'suggestions' => [
+                'Consider enrolling in our upcoming courses',
+                'Check your dashboard for personalized tips',
+            ],
+        ];
+    }
+
+    public function getCourseRecommendations(array $userData = []): array
+    {
+        return [
+            'courses' => [
+                ['id' => 1, 'name' => 'Intro to AI'],
+                ['id' => 2, 'name' => 'Advanced Robotics'],
+            ],
+        ];
+    }
+
+    public function runPredictiveAnalysis(array $data = []): array
+    {
+        return [
+            'predictions' => [
+                'completion_rate' => 0.95,
+                'dropout_risk' => 0.05,
+            ],
+        ];
+    }
+}

--- a/routes/api/public.php
+++ b/routes/api/public.php
@@ -200,5 +200,11 @@ Route::middleware(['guest'])->group(function () {
     Route::get('bookings/{id}/edit-data', [\App\Http\Controllers\API\SmartBookingController::class, 'editData']);
     Route::put('bookings/{id}/smart-update', [\App\Http\Controllers\API\SmartBookingController::class, 'smartUpdate']);
     Route::post('bookings/resolve-conflicts', [\App\Http\Controllers\API\SmartBookingController::class, 'resolveConflicts']);
+
+    Route::prefix('ai')->group(function () {
+        Route::post('smart-suggestions', [\App\Http\Controllers\API\AIController::class, 'smartSuggestions']);
+        Route::post('course-recommendations', [\App\Http\Controllers\API\AIController::class, 'courseRecommendations']);
+        Route::post('predictive-analysis', [\App\Http\Controllers\API\AIController::class, 'predictiveAnalysis']);
+    });
 });
 

--- a/tests/APIs/AiApiTest.php
+++ b/tests/APIs/AiApiTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\APIs;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
+
+class AiApiTest extends TestCase
+{
+    use WithoutMiddleware, DatabaseTransactions;
+
+    /** @test */
+    public function test_smart_suggestions_endpoint()
+    {
+        $this->response = $this->json('POST', '/api/ai/smart-suggestions', []);
+        $this->response->assertStatus(200);
+        $this->response->assertJsonStructure(['success', 'data' => ['suggestions'], 'message']);
+    }
+
+    /** @test */
+    public function test_course_recommendations_endpoint()
+    {
+        $this->response = $this->json('POST', '/api/ai/course-recommendations', []);
+        $this->response->assertStatus(200);
+        $this->response->assertJsonStructure(['success', 'data' => ['courses'], 'message']);
+    }
+
+    /** @test */
+    public function test_predictive_analysis_endpoint()
+    {
+        $this->response = $this->json('POST', '/api/ai/predictive-analysis', []);
+        $this->response->assertStatus(200);
+        $this->response->assertJsonStructure(['success', 'data' => ['predictions'], 'message']);
+    }
+}


### PR DESCRIPTION
## Summary
- add AIController with `smartSuggestions`, `courseRecommendations`, and `predictiveAnalysis`
- implement simple AIService returning mocked data
- expose new endpoints under `/ai` route prefix
- create tests for new AI endpoints

## Testing
- `./vendor/bin/phpunit tests/APIs/AiApiTest.php --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688559268dc0832085f07687d7cb040f