### PR TITLE
Add basic API utilities

### DIFF
--- a/app/Http/Controllers/SkiConditionsController.php
+++ b/app/Http/Controllers/SkiConditionsController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class SkiConditionsController extends AppBaseController
+{
+    public function current()
+    {
+        $data = [
+            'condition' => 'powder',
+            'snow_depth_cm' => 120,
+            'last_updated' => now()->toIso8601String(),
+        ];
+
+        return $this->sendResponse($data, 'Ski conditions retrieved');
+    }
+}

--- a/app/Http/Controllers/System/HealthCheckController.php
+++ b/app/Http/Controllers/System/HealthCheckController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\System;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Http\JsonResponse;
+
+class HealthCheckController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        return response()->json(['status' => 'ok']);
+    }
+}

--- a/app/Http/Controllers/System/SystemValidationController.php
+++ b/app/Http/Controllers/System/SystemValidationController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\System;
+
+use App\Http\Controllers\AppBaseController;
+
+class SystemValidationController extends AppBaseController
+{
+    public function validateSystem()
+    {
+        return $this->sendResponse(['system' => 'ok'], 'System validation successful');
+    }
+}

--- a/app/Http/Controllers/WeatherForecastController.php
+++ b/app/Http/Controllers/WeatherForecastController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class WeatherForecastController extends AppBaseController
+{
+    public function forecast12Hours()
+    {
+        $data = [
+            'location' => 'Demo Mountain',
+            'forecast' => [
+                [
+                    'time' => now()->addHour()->format('H:00'),
+                    'temperature' => -1,
+                    'condition' => 'snow'
+                ]
+            ]
+        ];
+
+        return $this->sendResponse($data, '12 hour forecast retrieved');
+    }
+
+    public function forecast5Days()
+    {
+        $data = [
+            'location' => 'Demo Mountain',
+            'forecast' => [
+                [
+                    'date' => now()->format('Y-m-d'),
+                    'low' => -5,
+                    'high' => 2,
+                    'condition' => 'sunny'
+                ]
+            ]
+        ];
+
+        return $this->sendResponse($data, '5 day forecast retrieved');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1573,3 +1573,18 @@ Route::prefix('')
 Route::prefix('slug')
     ->group(base_path('routes/api/bookingPage.php'));
 /* API IFRAME */
+
+/* WEATHER */
+Route::prefix('weather')
+    ->group(base_path('routes/api/weather.php'));
+/* WEATHER */
+
+/* EXTERNAL */
+Route::prefix('external')
+    ->group(base_path('routes/api/external.php'));
+/* EXTERNAL */
+
+/* SYSTEM */
+Route::prefix('system')
+    ->group(base_path('routes/api/system.php'));
+/* SYSTEM */

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SkiConditionsController;
+
+Route::get('ski-conditions', [SkiConditionsController::class, 'current']);

--- a/routes/api/system.php
+++ b/routes/api/system.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\System\SystemValidationController;
+use App\Http\Controllers\System\HealthCheckController;
+
+Route::get('validate', [SystemValidationController::class, 'validateSystem']);
+Route::get('health', HealthCheckController::class);

--- a/routes/api/weather.php
+++ b/routes/api/weather.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\WeatherForecastController;
+
+Route::prefix('forecast')->group(function () {
+    Route::get('12h', [WeatherForecastController::class, 'forecast12Hours']);
+    Route::get('5d', [WeatherForecastController::class, 'forecast5Days']);
+});

--- a/tests/Feature/BasicApiRoutesTest.php
+++ b/tests/Feature/BasicApiRoutesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class BasicApiRoutesTest extends TestCase
+{
+    /** @test */
+    public function weather_forecast_endpoints_return_success()
+    {
+        $this->getJson('/api/weather/forecast/12h')
+            ->assertStatus(200)
+            ->assertJsonStructure(['success','data' => ['location','forecast']]);
+
+        $this->getJson('/api/weather/forecast/5d')
+            ->assertStatus(200)
+            ->assertJsonStructure(['success','data' => ['location','forecast']]);
+    }
+
+    /** @test */
+    public function ski_conditions_endpoint_returns_success()
+    {
+        $this->getJson('/api/external/ski-conditions')
+            ->assertStatus(200)
+            ->assertJsonStructure(['success','data' => ['condition','snow_depth_cm','last_updated']]);
+    }
+
+    /** @test */
+    public function system_validation_and_health_endpoints_work()
+    {
+        $this->getJson('/api/system/validate')
+            ->assertStatus(200)
+            ->assertJsonStructure(['success','data'=>['system']]);
+
+        $this->getJson('/api/system/health')
+            ->assertStatus(200)
+            ->assertJson(['status' => 'ok']);
+    }
+}


### PR DESCRIPTION
## Summary
- add controllers for weather forecast, ski conditions, health and validation
- register new route groups for weather, external and system
- provide placeholder responses for these endpoints
- add feature tests verifying API behaviour

## Testing
- `vendor/bin/phpunit --filter BasicApiRoutesTest`

------
https://chatgpt.com/codex/tasks/task_e_68856e8ea82c8320960fe9bee21c3ea6