### PR TITLE
Add v3 admin dashboard routes

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -33,6 +33,10 @@ class RouteServiceProvider extends ServiceProvider
                 ->prefix('api')
                 ->group(base_path('routes/api.php'));
 
+            Route::middleware('api')
+                ->prefix('api/v3/admin')
+                ->group(base_path('routes/api/admin_v3.php'));
+
             Route::middleware('web')
                 ->group(base_path('routes/web.php'));
         });

--- a/routes/api/admin_v3.php
+++ b/routes/api/admin_v3.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('dashboard')->group(function () {
+    Route::get('/summary', function () {
+        return response()->json(['message' => 'summary']);
+    });
+
+    Route::get('/courses', function () {
+        return response()->json(['message' => 'courses']);
+    });
+
+    Route::get('/weather', function () {
+        return response()->json(['message' => 'weather']);
+    });
+
+    Route::get('/sales', function () {
+        return response()->json(['message' => 'sales']);
+    });
+
+    Route::get('/reservations', function () {
+        return response()->json(['message' => 'reservations']);
+    });
+});


### PR DESCRIPTION
## Summary
- add new `routes/api/admin_v3.php` with dashboard endpoints
- register admin v3 route file in `RouteServiceProvider`

## Testing
- `composer install --no-progress`
- `vendor/bin/phpunit` *(fails: `........E..` then interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68863207343c8320b255a0659558f0ac