### PR TITLE
Add Admin V3 dashboard controller and services

### DIFF
--- a/app/Http/Controllers/Admin/V3/DashboardController.php
+++ b/app/Http/Controllers/Admin/V3/DashboardController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Admin\V3;
+
+use App\Http\Controllers\AppBaseController;
+use App\Services\Admin\V3\CourseStatsService;
+use App\Services\Admin\V3\DashboardSummaryService;
+use App\Services\Admin\V3\ReservationService;
+use App\Services\Admin\V3\SalesService;
+use App\Services\Admin\V3\WeatherService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DashboardController extends AppBaseController
+{
+    protected DashboardSummaryService $summaryService;
+
+    protected CourseStatsService $courseStatsService;
+
+    protected SalesService $salesService;
+
+    protected ReservationService $reservationService;
+
+    protected WeatherService $weatherService;
+
+    public function __construct(
+        DashboardSummaryService $summaryService,
+        CourseStatsService $courseStatsService,
+        SalesService $salesService,
+        ReservationService $reservationService,
+        WeatherService $weatherService
+    ) {
+        $this->summaryService = $summaryService;
+        $this->courseStatsService = $courseStatsService;
+        $this->salesService = $salesService;
+        $this->reservationService = $reservationService;
+        $this->weatherService = $weatherService;
+    }
+
+    public function summary(Request $request): JsonResponse
+    {
+        $this->ensureSchoolInRequest($request);
+        $data = $this->summaryService->getSummary($request);
+
+        return $this->sendResponse($data, 'Dashboard summary retrieved');
+    }
+
+    public function courseStats(Request $request): JsonResponse
+    {
+        $this->ensureSchoolInRequest($request);
+        $data = $this->courseStatsService->getCourseStats($request);
+
+        return $this->sendResponse($data, 'Course statistics retrieved');
+    }
+
+    public function sales(Request $request): JsonResponse
+    {
+        $this->ensureSchoolInRequest($request);
+        $data = $this->salesService->getSalesData($request);
+
+        return $this->sendResponse($data, 'Sales data retrieved');
+    }
+
+    public function reservations(Request $request): JsonResponse
+    {
+        $this->ensureSchoolInRequest($request);
+        $data = $this->reservationService->getReservationData($request);
+
+        return $this->sendResponse($data, 'Reservation data retrieved');
+    }
+
+    public function weather(Request $request): JsonResponse
+    {
+        $this->ensureSchoolInRequest($request);
+        $data = $this->weatherService->getWeather($request);
+
+        return $this->sendResponse($data, 'Weather information retrieved');
+    }
+}

--- a/app/Services/Admin/V3/CourseStatsService.php
+++ b/app/Services/Admin/V3/CourseStatsService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Admin\V3;
+
+use Illuminate\Http\Request;
+
+class CourseStatsService
+{
+    public function getCourseStats(Request $request): array
+    {
+        return [
+            'totalCourses' => 10,
+            'topCourses' => [
+                ['id' => 1, 'name' => 'Ski Basics', 'bookings' => 50],
+                ['id' => 2, 'name' => 'Advanced Ski', 'bookings' => 30],
+            ],
+        ];
+    }
+}

--- a/app/Services/Admin/V3/DashboardSummaryService.php
+++ b/app/Services/Admin/V3/DashboardSummaryService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services\Admin\V3;
+
+use Illuminate\Http\Request;
+
+class DashboardSummaryService
+{
+    public function getSummary(Request $request): array
+    {
+        return [
+            'totalBookings' => 120,
+            'upcomingBookings' => 34,
+            'revenueToday' => 1500,
+        ];
+    }
+}

--- a/app/Services/Admin/V3/ReservationService.php
+++ b/app/Services/Admin/V3/ReservationService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services\Admin\V3;
+
+use Illuminate\Http\Request;
+
+class ReservationService
+{
+    public function getReservationData(Request $request): array
+    {
+        return [
+            'pending' => 5,
+            'confirmed' => 20,
+            'cancelled' => 2,
+        ];
+    }
+}

--- a/app/Services/Admin/V3/SalesService.php
+++ b/app/Services/Admin/V3/SalesService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Admin\V3;
+
+use Illuminate\Http\Request;
+
+class SalesService
+{
+    public function getSalesData(Request $request): array
+    {
+        return [
+            'totalSales' => 10000,
+            'monthly' => [
+                ['month' => '2023-01', 'value' => 800],
+                ['month' => '2023-02', 'value' => 950],
+            ],
+        ];
+    }
+}

--- a/app/Services/Admin/V3/WeatherService.php
+++ b/app/Services/Admin/V3/WeatherService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Services\Admin\V3;
+
+use Illuminate\Http\Request;
+
+class WeatherService
+{
+    public function getWeather(Request $request): array
+    {
+        return [
+            'temperature' => 15,
+            'condition' => 'Sunny',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add new Admin/V3/DashboardController delegating to services
- scaffold DashboardSummaryService, CourseStatsService, SalesService, ReservationService and WeatherService
- support JSON responses for V3 dashboard endpoints

## Testing
- `vendor/bin/phpunit tests/Feature/ExampleTest.php`


------
https://chatgpt.com/codex/tasks/task_e_688635f8d9748320b4591135cb3e364d