### PR TITLE
Add typed requests for admin dashboard

### DIFF
--- a/app/Http/Controllers/Admin/V3/DashboardController.php
+++ b/app/Http/Controllers/Admin/V3/DashboardController.php
@@ -9,7 +9,11 @@ use App\Services\Admin\V3\ReservationService;
 use App\Services\Admin\V3\SalesService;
 use App\Services\Admin\V3\WeatherService;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
+use App\Http\Requests\Admin\V3\DashboardSummaryRequest;
+use App\Http\Requests\Admin\V3\DashboardCourseStatsRequest;
+use App\Http\Requests\Admin\V3\DashboardSalesRequest;
+use App\Http\Requests\Admin\V3\DashboardReservationsRequest;
+use App\Http\Requests\Admin\V3\DashboardWeatherRequest;
 
 class DashboardController extends AppBaseController
 {
@@ -37,7 +41,7 @@ class DashboardController extends AppBaseController
         $this->weatherService = $weatherService;
     }
 
-    public function summary(Request $request): JsonResponse
+    public function summary(DashboardSummaryRequest $request): JsonResponse
     {
         $this->ensureSchoolInRequest($request);
         $data = $this->summaryService->getSummary($request);
@@ -45,7 +49,7 @@ class DashboardController extends AppBaseController
         return $this->sendResponse($data, 'Dashboard summary retrieved');
     }
 
-    public function courseStats(Request $request): JsonResponse
+    public function courseStats(DashboardCourseStatsRequest $request): JsonResponse
     {
         $this->ensureSchoolInRequest($request);
         $data = $this->courseStatsService->getCourseStats($request);
@@ -53,7 +57,7 @@ class DashboardController extends AppBaseController
         return $this->sendResponse($data, 'Course statistics retrieved');
     }
 
-    public function sales(Request $request): JsonResponse
+    public function sales(DashboardSalesRequest $request): JsonResponse
     {
         $this->ensureSchoolInRequest($request);
         $data = $this->salesService->getSalesData($request);
@@ -61,7 +65,7 @@ class DashboardController extends AppBaseController
         return $this->sendResponse($data, 'Sales data retrieved');
     }
 
-    public function reservations(Request $request): JsonResponse
+    public function reservations(DashboardReservationsRequest $request): JsonResponse
     {
         $this->ensureSchoolInRequest($request);
         $data = $this->reservationService->getReservationData($request);
@@ -69,7 +73,7 @@ class DashboardController extends AppBaseController
         return $this->sendResponse($data, 'Reservation data retrieved');
     }
 
-    public function weather(Request $request): JsonResponse
+    public function weather(DashboardWeatherRequest $request): JsonResponse
     {
         $this->ensureSchoolInRequest($request);
         $data = $this->weatherService->getWeather($request);

--- a/app/Http/Requests/Admin/V3/DashboardCourseStatsRequest.php
+++ b/app/Http/Requests/Admin/V3/DashboardCourseStatsRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Admin\V3;
+
+use InfyOm\Generator\Request\APIRequest;
+
+class DashboardCourseStatsRequest extends APIRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+            'school_id' => 'nullable|integer|exists:schools,id',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/V3/DashboardReservationsRequest.php
+++ b/app/Http/Requests/Admin/V3/DashboardReservationsRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Admin\V3;
+
+use InfyOm\Generator\Request\APIRequest;
+
+class DashboardReservationsRequest extends APIRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+            'school_id' => 'nullable|integer|exists:schools,id',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/V3/DashboardSalesRequest.php
+++ b/app/Http/Requests/Admin/V3/DashboardSalesRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Admin\V3;
+
+use InfyOm\Generator\Request\APIRequest;
+
+class DashboardSalesRequest extends APIRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+            'school_id' => 'nullable|integer|exists:schools,id',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/V3/DashboardSummaryRequest.php
+++ b/app/Http/Requests/Admin/V3/DashboardSummaryRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Admin\V3;
+
+use InfyOm\Generator\Request\APIRequest;
+
+class DashboardSummaryRequest extends APIRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+            'school_id' => 'nullable|integer|exists:schools,id',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/V3/DashboardWeatherRequest.php
+++ b/app/Http/Requests/Admin/V3/DashboardWeatherRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Admin\V3;
+
+use InfyOm\Generator\Request\APIRequest;
+
+class DashboardWeatherRequest extends APIRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+            'school_id' => 'nullable|integer|exists:schools,id',
+            'station_id' => 'nullable|integer|exists:stations,id',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add request classes validating optional dates and school
- wire up new requests in the Dashboard controller

## Testing
- `vendor/bin/pint --test` *(fails: 634 style issues)*
- `vendor/bin/phpunit` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68863f0fa5c083208de0e1bf8fb5cabc