### PR TITLE
Add dashboard docs

### DIFF
--- a/booking-system-v3-api-specification.md
+++ b/booking-system-v3-api-specification.md
@@ -942,6 +942,59 @@ GET /bookings/{id}/profitability
 GET /analytics/optimization-suggestions?type={type}&timeframe={timeframe}
 ```
 
+## 🖥️ **Dashboard V3**
+
+### **Dashboard Summary**
+```http
+GET /dashboard/summary
+```
+
+**Response Example:**
+```typescript
+{
+  success: boolean;
+  data: {
+    new_reservations: number;
+    courses_this_week: number;
+    performance_improvement: number;
+    revenue_today: number;
+  };
+}
+```
+
+### **Sales Data**
+```http
+GET /dashboard/sales
+```
+
+**Response Example:**
+```typescript
+{
+  success: boolean;
+  data: {
+    totalSales: number;
+    monthly: Array<{ month: string; value: number }>;
+  };
+}
+```
+
+### **Reservation Status**
+```http
+GET /dashboard/reservations
+```
+
+**Response Example:**
+```typescript
+{
+  success: boolean;
+  data: {
+    pending: number;
+    confirmed: number;
+    cancelled: number;
+  };
+}
+```
+
 ---
 
 ## 💬 **Comunicaciones**
@@ -1057,6 +1110,19 @@ POST /bookings/{id}/duplicate-smart
 ### **32. Pronóstico del Tiempo**
 ```http
 GET /weather/forecast?location={location}&dates[]={dates}&include_ski_conditions={boolean}
+```
+
+**Response Example:**
+```typescript
+{
+  success: boolean;
+  data: Array<{
+    temperature: number;
+    wind: string;
+    visibility: string;
+    snow: string;
+  }>;
+}
 ```
 
 ### **33. Condiciones de Esquí**
@@ -1236,7 +1302,7 @@ GET /system/health
 5. **Documentar casos de uso** específicos
 6. **Configurar monitoreo** y alertas
 7. **Planificar testing** integral
-8. **Preparar migración** desde V2
+8. **Preparar migración** desde V2. Consulta la sección *Migración desde V2* en `frontend-api-usage.md` para detalles sobre cambios de rutas y estructuras.
 
 ---
 

--- a/frontend-api-usage.md
+++ b/frontend-api-usage.md
@@ -22,6 +22,10 @@ interface ApiResponse {
 }
 ```
 
+## Migración desde V2
+
+Las rutas de la API V3 cambian respecto a la versión anterior. Actualiza los endpoints de analytics a los nuevos prefijos `/dashboard` y revisa las estructuras de respuesta descritas a continuación para adaptar tu frontend.
+
 ## Endpoints por Funcionalidad
 
 ### 1. Autenticación
@@ -311,6 +315,16 @@ interface VoucherData {
 - **Endpoint**: `DELETE /admin/analytics/cache/clear`
 - **Endpoint**: `GET /admin/analytics/cache/status`
 
+#### Dashboard V3
+- **Endpoint**: `GET /dashboard/summary`
+- **Response**: `DashboardSummary` interface
+- **Endpoint**: `GET /dashboard/sales`
+- **Response**: `SalesData` interface
+- **Endpoint**: `GET /dashboard/reservations`
+- **Response**: `ReservationStats` interface
+- **Endpoint**: `GET /dashboard/weather`
+- **Response**: `WeatherInfo[]`
+
 **Servicio**: `AnalyticsProfessionalService`
 
 ### 8. Exportación de Analytics
@@ -429,6 +443,43 @@ export interface ExportOptions {
     start: string;
     end: string;
   };
+}
+```
+
+### DashboardSummary
+```typescript
+export interface DashboardSummary {
+  new_reservations: number;
+  courses_this_week: number;
+  performance_improvement: number;
+  revenue_today: number;
+}
+```
+
+### SalesData
+```typescript
+export interface SalesData {
+  totalSales: number;
+  monthly: Array<{ month: string; value: number }>;
+}
+```
+
+### ReservationStats
+```typescript
+export interface ReservationStats {
+  pending: number;
+  confirmed: number;
+  cancelled: number;
+}
+```
+
+### WeatherInfo
+```typescript
+export interface WeatherInfo {
+  temperature: number;
+  wind: string;
+  visibility: string;
+  snow: string;
 }
 ```
 


### PR DESCRIPTION
## Summary
- document new dashboard endpoints in API spec
- add weather response example
- include migration notes from v2
- update frontend usage with dashboard routes and structures

## Testing
- `composer install --no-interaction`
- `php vendor/bin/phpunit --stop-on-failure` *(fails: Runtime error)*

------
https://chatgpt.com/codex/tasks/task_e_6886423c35408320a93f6a4acf72643d