### PR TITLE
Fix docs for dashboard summary keys

### DIFF
--- a/booking-system-v3-api-specification.md
+++ b/booking-system-v3-api-specification.md
@@ -953,12 +953,12 @@ GET /dashboard/summary
 ```typescript
 {
   success: boolean;
-  data: {
-    new_reservations: number;
-    courses_this_week: number;
-    performance_improvement: number;
-    revenue_today: number;
-  };
+    data: {
+      privateCourses: number;
+      groupCourses: number;
+      activeReservationsToday: number;
+      salesToday: number;
+    };
 }
 ```
 

--- a/frontend-api-usage.md
+++ b/frontend-api-usage.md
@@ -449,10 +449,10 @@ export interface ExportOptions {
 ### DashboardSummary
 ```typescript
 export interface DashboardSummary {
-  new_reservations: number;
-  courses_this_week: number;
-  performance_improvement: number;
-  revenue_today: number;
+  privateCourses: number;
+  groupCourses: number;
+  activeReservationsToday: number;
+  salesToday: number;
 }
 ```
 


### PR DESCRIPTION
## Summary
- document English fields for `/api/v3/admin/dashboard/summary`

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: Could not parse 'delectus' timezone)*

------
https://chatgpt.com/codex/tasks/task_e_688750f3e3208320802e52c9b583e1b3