### PR TITLE
Add basic v5 skeleton with health check

### DIFF
--- a/app/V5/BaseV5Controller.php
+++ b/app/V5/BaseV5Controller.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\V5;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use App\V5\Services\BaseService;
+
+class BaseV5Controller extends Controller
+{
+    protected BaseService $service;
+
+    public function __construct(BaseService $service)
+    {
+        $this->service = $service;
+    }
+
+    protected function respond(array $data, int $status = 200): JsonResponse
+    {
+        return response()->json($data, $status);
+    }
+}

--- a/app/V5/Modules/HealthCheck/Controllers/HealthCheckController.php
+++ b/app/V5/Modules/HealthCheck/Controllers/HealthCheckController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\V5\Modules\HealthCheck\Controllers;
+
+use App\V5\BaseV5Controller;
+use App\V5\Modules\HealthCheck\Services\HealthCheckService;
+use Illuminate\Http\JsonResponse;
+
+class HealthCheckController extends BaseV5Controller
+{
+    public function __construct(HealthCheckService $service)
+    {
+        parent::__construct($service);
+    }
+
+    public function index(): JsonResponse
+    {
+        $data = $this->service->check();
+        return $this->respond($data);
+    }
+}

--- a/app/V5/Modules/HealthCheck/Repositories/HealthCheckRepository.php
+++ b/app/V5/Modules/HealthCheck/Repositories/HealthCheckRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\V5\Modules\HealthCheck\Repositories;
+
+use App\V5\Repositories\BaseRepository;
+
+class HealthCheckRepository extends BaseRepository
+{
+    public function status(): array
+    {
+        return ['status' => 'ok'];
+    }
+}

--- a/app/V5/Modules/HealthCheck/Services/HealthCheckService.php
+++ b/app/V5/Modules/HealthCheck/Services/HealthCheckService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\V5\Modules\HealthCheck\Services;
+
+use App\V5\Services\BaseService;
+use App\V5\Modules\HealthCheck\Repositories\HealthCheckRepository;
+
+class HealthCheckService extends BaseService
+{
+    public function __construct(HealthCheckRepository $repository)
+    {
+        parent::__construct($repository);
+    }
+
+    public function check(): array
+    {
+        /** @var HealthCheckRepository $repo */
+        $repo = $this->repository;
+        return $repo->status();
+    }
+}

--- a/app/V5/Repositories/BaseRepository.php
+++ b/app/V5/Repositories/BaseRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\V5\Repositories;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BaseRepository
+{
+    protected ?Model $model;
+
+    public function __construct(Model $model = null)
+    {
+        $this->model = $model;
+    }
+}

--- a/app/V5/Services/BaseService.php
+++ b/app/V5/Services/BaseService.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\V5\Services;
+
+use App\V5\Repositories\BaseRepository;
+
+class BaseService
+{
+    protected BaseRepository $repository;
+
+    public function __construct(BaseRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1588,3 +1588,9 @@ Route::prefix('external')
 Route::prefix('system')
     ->group(base_path('routes/api/system.php'));
 /* SYSTEM */
+
+/* BOUKII V5 */
+Route::prefix('v5')->group(function () {
+    Route::get('health-check', [\App\V5\Modules\HealthCheck\Controllers\HealthCheckController::class, 'index']);
+});
+/* BOUKII V5 */

--- a/tests/Feature/V5HealthCheckTest.php
+++ b/tests/Feature/V5HealthCheckTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class V5HealthCheckTest extends TestCase
+{
+    /** @test */
+    public function health_check_endpoint_returns_ok()
+    {
+        $this->getJson('/api/v5/health-check')
+            ->assertStatus(200)
+            ->assertExactJson(['status' => 'ok']);
+    }
+}


### PR DESCRIPTION
## Summary
- add base classes for v5 controllers, services and repositories
- implement `HealthCheck` module under `app/V5/Modules`
- expose `/api/v5/health-check` endpoint
- add feature test for the health check route

## Testing
- `./vendor/bin/phpunit tests/Feature/V5HealthCheckTest.php --no-progress --color=never`

------
https://chatgpt.com/codex/tasks/task_e_6887c0d71a188320a9842f0960fb29d5