### PR TITLE
Add initial v5 documentation

### DIFF
--- a/docs/v5/health-check.md
+++ b/docs/v5/health-check.md
@@ -1,0 +1,29 @@
+# Health Check Module
+
+The Health Check endpoint verifies that the V5 API is running correctly.
+
+## Endpoint
+
+```http
+GET /api/v5/health-check
+```
+
+### Parameters
+
+This endpoint does not accept any parameters.
+
+### Response
+
+```json
+{ "status": "ok" }
+```
+
+HTTP status code: **200**
+
+### Possible Errors
+
+The health check performs no validation and should always return `200`. A different status code indicates a misconfiguration or network issue.
+
+## Associated Test
+
+The behaviour is covered by `tests/Feature/V5HealthCheckTest.php` which asserts the JSON response above.

--- a/docs/v5/v5-overview.md
+++ b/docs/v5/v5-overview.md
@@ -1,0 +1,52 @@
+# Boukii V5 Overview
+
+This documentation introduces the structure and conventions used in the `app/V5` namespace. Boukii V5 groups all new modules under this directory and exposes them via the `/api/v5` route prefix.
+
+## Modular Structure
+
+Modules live in `app/V5/Modules`. Each module contains `Controllers`, `Services` and `Repositories`. Base classes located under `app/V5` provide common behaviour:
+
+- `BaseV5Controller` – extends Laravel's base controller and wraps JSON responses via the `respond()` helper.
+- `BaseService` – holds a reference to a module's repository and encapsulates business logic.
+- `BaseRepository` – entry point for database models or other data sources.
+
+This layout encourages loose coupling and mirrors the folder hierarchy under `Modules/*`.
+
+## Naming Conventions
+
+- Classes inside `Modules/*` follow the singular module name, e.g. `HealthCheckService`.
+- Controllers must extend `BaseV5Controller` and are grouped under `Controllers`.
+- Services extend `BaseService` and live under `Services`.
+- Repositories extend `BaseRepository` and live under `Repositories`.
+
+## Base Route
+
+All endpoints are prefixed with `/api/v5`. The first endpoint implemented is the health check:
+
+```http
+GET /api/v5/health-check
+```
+
+It returns:
+
+```json
+{ "status": "ok" }
+```
+
+Use this route to confirm that the V5 API is reachable.
+
+## Running V5 Tests
+
+Feature tests for V5 reside under `tests/Feature`, currently starting with `V5HealthCheckTest.php`. Run all tests with:
+
+```bash
+php artisan test
+```
+
+You can run only V5 tests by filtering:
+
+```bash
+php artisan test --filter=V5
+```
+
+Make sure Composer dependencies are installed before executing the test suite.


### PR DESCRIPTION
## Summary
- introduce `docs/v5` folder with overview and health-check module documentation

## Testing
- `php artisan test --filter=V5HealthCheckTest` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c9ba5e3883208079d65099437b64