### PR TITLE
Add Season module skeleton in V5

### DIFF
--- a/app/V5/Models/Season.php
+++ b/app/V5/Models/Season.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\V5\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Season extends Model
+{
+    use HasFactory;
+
+    protected $table = 'seasons';
+
+    protected $fillable = [
+        'name',
+        'start_date',
+        'end_date',
+        'hour_start',
+        'hour_end',
+        'is_active',
+        'vacation_days',
+        'school_id',
+        'is_closed',
+        'closed_at'
+    ];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+        'is_active' => 'boolean',
+        'is_closed' => 'boolean',
+        'closed_at' => 'datetime',
+    ];
+
+    public static array $rules = [
+        'name' => 'nullable|string|max:255',
+        'start_date' => 'required|date',
+        'end_date' => 'required|date',
+        'hour_start' => 'nullable',
+        'hour_end' => 'nullable',
+        'is_active' => 'boolean',
+        'vacation_days' => 'nullable|string',
+        'school_id' => 'required|integer',
+        'is_closed' => 'boolean',
+        'closed_at' => 'nullable|date',
+    ];
+
+    public function school(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\School::class, 'school_id');
+    }
+
+    public function snapshots(): HasMany
+    {
+        return $this->hasMany(SeasonSnapshot::class);
+    }
+}

--- a/app/V5/Models/SeasonSettings.php
+++ b/app/V5/Models/SeasonSettings.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\V5\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SeasonSettings extends Model
+{
+    use HasFactory;
+
+    protected $table = 'season_settings';
+
+    protected $fillable = [
+        'season_id',
+        'key',
+        'value',
+    ];
+
+    protected $casts = [
+        'value' => 'array',
+    ];
+
+    public static array $rules = [
+        'season_id' => 'required|integer',
+        'key' => 'required|string|max:255',
+        'value' => 'nullable',
+    ];
+
+    public function season(): BelongsTo
+    {
+        return $this->belongsTo(Season::class);
+    }
+}

--- a/app/V5/Models/SeasonSnapshot.php
+++ b/app/V5/Models/SeasonSnapshot.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\V5\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SeasonSnapshot extends Model
+{
+    use HasFactory;
+
+    protected $table = 'season_snapshots';
+
+    protected $fillable = [
+        'season_id',
+        'snapshot_type',
+        'snapshot_data',
+        'snapshot_date',
+        'is_immutable',
+        'created_by',
+        'description',
+        'checksum',
+    ];
+
+    protected $casts = [
+        'snapshot_data' => 'array',
+        'snapshot_date' => 'datetime',
+        'is_immutable' => 'boolean',
+    ];
+
+    public static array $rules = [
+        'season_id' => 'required|integer',
+        'snapshot_type' => 'required|string|max:255',
+        'snapshot_data' => 'nullable|array',
+        'snapshot_date' => 'nullable|date',
+        'is_immutable' => 'boolean',
+        'created_by' => 'nullable|integer',
+        'description' => 'nullable|string',
+        'checksum' => 'nullable|string',
+    ];
+
+    public function season(): BelongsTo
+    {
+        return $this->belongsTo(Season::class);
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            $model->checksum = hash('sha256', json_encode($model->snapshot_data));
+        });
+
+        static::updating(function ($model) {
+            if ($model->is_immutable && $model->isDirty()) {
+                throw new \Exception('Immutable snapshots cannot be modified');
+            }
+        });
+    }
+}

--- a/app/V5/Modules/Season/Controllers/SeasonController.php
+++ b/app/V5/Modules/Season/Controllers/SeasonController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\V5\Modules\Season\Controllers;
+
+use App\V5\BaseV5Controller;
+use App\V5\Modules\Season\Services\SeasonService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SeasonController extends BaseV5Controller
+{
+    public function __construct(SeasonService $service)
+    {
+        parent::__construct($service);
+    }
+
+    public function index(): JsonResponse
+    {
+        $data = $this->service->all();
+        return $this->respond($data->toArray());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $season = $this->service->createSeason($request->all());
+        return $this->respond($season->toArray(), 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $season = $this->service->find($id);
+        if (!$season) {
+            return $this->respond(['message' => 'Season not found'], 404);
+        }
+        return $this->respond($season->toArray());
+    }
+
+    public function update(int $id, Request $request): JsonResponse
+    {
+        $season = $this->service->updateSeason($id, $request->all());
+        if (!$season) {
+            return $this->respond(['message' => 'Season not found'], 404);
+        }
+        return $this->respond($season->toArray());
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $deleted = $this->service->deleteSeason($id);
+        if (!$deleted) {
+            return $this->respond(['message' => 'Season not found'], 404);
+        }
+        return $this->respond(['deleted' => true]);
+    }
+
+    public function current(Request $request): JsonResponse
+    {
+        $season = $this->service->getCurrentSeason($request->get('school_id'));
+        return $this->respond($season?->toArray() ?? []);
+    }
+
+    public function close(int $id): JsonResponse
+    {
+        $season = $this->service->closeSeason($id);
+        if (!$season) {
+            return $this->respond(['message' => 'Season not found'], 404);
+        }
+        return $this->respond($season->toArray());
+    }
+
+    public function clone(int $id): JsonResponse
+    {
+        $season = $this->service->cloneSeason($id);
+        if (!$season) {
+            return $this->respond(['message' => 'Season not found'], 404);
+        }
+        return $this->respond($season->toArray(), 201);
+    }
+}

--- a/app/V5/Modules/Season/Repositories/SeasonRepository.php
+++ b/app/V5/Modules/Season/Repositories/SeasonRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\V5\Modules\Season\Repositories;
+
+use App\V5\Models\Season;
+use App\V5\Repositories\BaseRepository;
+use Illuminate\Database\Eloquent\Collection;
+
+class SeasonRepository extends BaseRepository
+{
+    public function __construct(Season $model = null)
+    {
+        parent::__construct($model ?? new Season());
+    }
+
+    public function all(): Collection
+    {
+        return $this->model->newQuery()->get();
+    }
+
+    public function find(int $id): ?Season
+    {
+        return $this->model->newQuery()->find($id);
+    }
+
+    public function create(array $data): Season
+    {
+        return $this->model->newQuery()->create($data);
+    }
+
+    public function update(Season $season, array $data): Season
+    {
+        $season->fill($data);
+        $season->save();
+        return $season;
+    }
+
+    public function delete(Season $season): bool
+    {
+        return (bool) $season->delete();
+    }
+
+    public function findBySeason(int $id): ?Season
+    {
+        return $this->find($id);
+    }
+
+    public function getCurrentSeason(int $schoolId): ?Season
+    {
+        return $this->model->newQuery()
+            ->where('school_id', $schoolId)
+            ->where('is_active', true)
+            ->orderByDesc('start_date')
+            ->first();
+    }
+}

--- a/app/V5/Modules/Season/Repositories/SeasonSnapshotRepository.php
+++ b/app/V5/Modules/Season/Repositories/SeasonSnapshotRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\V5\Modules\Season\Repositories;
+
+use App\V5\Models\Season;
+use App\V5\Models\SeasonSnapshot;
+use App\V5\Repositories\BaseRepository;
+use Illuminate\Database\Eloquent\Collection;
+
+class SeasonSnapshotRepository extends BaseRepository
+{
+    public function __construct(SeasonSnapshot $model = null)
+    {
+        parent::__construct($model ?? new SeasonSnapshot());
+    }
+
+    public function find(int $id): ?SeasonSnapshot
+    {
+        return $this->model->newQuery()->find($id);
+    }
+
+    public function create(array $data): SeasonSnapshot
+    {
+        return $this->model->newQuery()->create($data);
+    }
+
+    public function findBySeason(int $seasonId): Collection
+    {
+        return $this->model->newQuery()
+            ->where('season_id', $seasonId)
+            ->orderByDesc('snapshot_date')
+            ->get();
+    }
+
+    public function createSeasonSnapshot(Season $season, string $type, array $data, array $extra = []): SeasonSnapshot
+    {
+        $payload = array_merge([
+            'season_id' => $season->id,
+            'snapshot_type' => $type,
+            'snapshot_data' => $data,
+            'snapshot_date' => now(),
+        ], $extra);
+
+        return $this->create($payload);
+    }
+}

--- a/app/V5/Modules/Season/Services/SeasonService.php
+++ b/app/V5/Modules/Season/Services/SeasonService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\V5\Modules\Season\Services;
+
+use App\V5\Modules\Season\Repositories\SeasonRepository;
+use App\V5\Services\BaseService;
+use App\V5\Models\Season;
+use Illuminate\Support\Collection;
+
+class SeasonService extends BaseService
+{
+    public function __construct(SeasonRepository $repository)
+    {
+        parent::__construct($repository);
+    }
+
+    /**
+     * @return Collection<int,Season>
+     */
+    public function all(): Collection
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        return $repo->all();
+    }
+
+    public function find(int $id): ?Season
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        return $repo->find($id);
+    }
+
+    public function createSeason(array $data): Season
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        return $repo->create($data);
+    }
+
+    public function updateSeason(int $id, array $data): ?Season
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        $season = $repo->find($id);
+        if (!$season) {
+            return null;
+        }
+        return $repo->update($season, $data);
+    }
+
+    public function deleteSeason(int $id): bool
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        $season = $repo->find($id);
+        return $season ? $repo->delete($season) : false;
+    }
+
+    public function cloneSeason(int $id): ?Season
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        $season = $repo->find($id);
+        if (!$season) {
+            return null;
+        }
+        $data = $season->replicate()->toArray();
+        unset($data['id']);
+        $data['is_active'] = false;
+        return $repo->create($data);
+    }
+
+    public function closeSeason(int $id): ?Season
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        $season = $repo->find($id);
+        if (!$season) {
+            return null;
+        }
+        $repo->update($season, [
+            'is_active' => false,
+            'is_closed' => true,
+            'closed_at' => now(),
+        ]);
+        return $season->fresh();
+    }
+
+    public function activateSeason(int $id): ?Season
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        $season = $repo->find($id);
+        if (!$season) {
+            return null;
+        }
+        $repo->update($season, ['is_active' => true]);
+        return $season->fresh();
+    }
+
+    public function getCurrentSeason(int $schoolId): ?Season
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        return $repo->getCurrentSeason($schoolId);
+    }
+}

--- a/app/V5/Modules/Season/Services/SeasonSnapshotService.php
+++ b/app/V5/Modules/Season/Services/SeasonSnapshotService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\V5\Modules\Season\Services;
+
+use App\V5\Modules\Season\Repositories\SeasonSnapshotRepository;
+use App\V5\Services\BaseService;
+use App\V5\Models\Season;
+use App\V5\Models\SeasonSnapshot;
+
+class SeasonSnapshotService extends BaseService
+{
+    public function __construct(SeasonSnapshotRepository $repository)
+    {
+        parent::__construct($repository);
+    }
+
+    public function createImmutableSnapshot(Season $season, string $type, array $data, array $extra = []): SeasonSnapshot
+    {
+        /** @var SeasonSnapshotRepository $repo */
+        $repo = $this->repository;
+        $extra['is_immutable'] = true;
+        return $repo->createSeasonSnapshot($season, $type, $data, $extra);
+    }
+
+    public function validateSnapshot(SeasonSnapshot $snapshot): bool
+    {
+        return $snapshot->verifyIntegrity();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1592,5 +1592,13 @@ Route::prefix('system')
 /* BOUKII V5 */
 Route::prefix('v5')->group(function () {
     Route::get('health-check', [\App\V5\Modules\HealthCheck\Controllers\HealthCheckController::class, 'index']);
+    Route::get('seasons', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'index']);
+    Route::post('seasons', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'store']);
+    Route::get('seasons/current', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'current']);
+    Route::get('seasons/{id}', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'show']);
+    Route::put('seasons/{id}', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'update']);
+    Route::delete('seasons/{id}', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'destroy']);
+    Route::post('seasons/{id}/close', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'close']);
+    Route::post('seasons/{id}/clone', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'clone']);
 });
 /* BOUKII V5 */


### PR DESCRIPTION
## Summary
- add new Eloquent models under `app/V5/Models`
- create repositories, services and controller for seasons under V5
- register V5 season routes

## Testing
- `vendor/bin/phpunit --dont-report-useless-tests --testsuite Unit --stop-on-error`

------
https://chatgpt.com/codex/tasks/task_e_6887d47b9ee0832081e8c724ea431e9e