### PR TITLE
Add Season routes to /api/v5 group

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1592,12 +1592,11 @@ Route::prefix('system')
 /* BOUKII V5 */
 Route::prefix('v5')->group(function () {
     Route::get('health-check', [\App\V5\Modules\HealthCheck\Controllers\HealthCheckController::class, 'index']);
-    Route::get('seasons', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'index']);
-    Route::post('seasons', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'store']);
+
+    Route::resource('seasons', \App\V5\Modules\Season\Controllers\SeasonController::class)
+        ->except(['create', 'edit']);
+
     Route::get('seasons/current', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'current']);
-    Route::get('seasons/{id}', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'show']);
-    Route::put('seasons/{id}', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'update']);
-    Route::delete('seasons/{id}', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'destroy']);
     Route::post('seasons/{id}/close', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'close']);
     Route::post('seasons/{id}/clone', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'clone']);
 });


### PR DESCRIPTION
## Summary
- refactor `/api/v5` routes to use `Route::resource` for Season module
- keep custom `current`, `close` and `clone` Season actions

## Testing
- `./vendor/bin/phpunit --testsuite Unit --stop-on-error --stop-on-failure`
- `./vendor/bin/phpunit --testsuite Feature --stop-on-error --stop-on-failure` *(fails: table already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6887d6318cb88320bef4c6defa839556