### PR TITLE
Add Season docs and annotate models

### DIFF
--- a/app/V5/Models/Season.php
+++ b/app/V5/Models/Season.php
@@ -7,6 +7,24 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @OA\Schema(
+ *     schema="V5Season",
+ *     required={"start_date","end_date","school_id"},
+ *     @OA\Property(property="id", type="integer", readOnly=true),
+ *     @OA\Property(property="name", type="string", nullable=true),
+ *     @OA\Property(property="start_date", type="string", format="date"),
+ *     @OA\Property(property="end_date", type="string", format="date"),
+ *     @OA\Property(property="hour_start", type="string", format="time", nullable=true),
+ *     @OA\Property(property="hour_end", type="string", format="time", nullable=true),
+ *     @OA\Property(property="is_active", type="boolean"),
+ *     @OA\Property(property="vacation_days", type="string", nullable=true),
+ *     @OA\Property(property="school_id", type="integer"),
+ *     @OA\Property(property="is_closed", type="boolean"),
+ *     @OA\Property(property="closed_at", type="string", format="date-time", nullable=true),
+ * )
+ */
+
 class Season extends Model
 {
     use HasFactory;

--- a/app/V5/Models/SeasonSettings.php
+++ b/app/V5/Models/SeasonSettings.php
@@ -6,6 +6,17 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @OA\Schema(
+ *     schema="V5SeasonSettings",
+ *     required={"season_id","key"},
+ *     @OA\Property(property="id", type="integer", readOnly=true),
+ *     @OA\Property(property="season_id", type="integer"),
+ *     @OA\Property(property="key", type="string"),
+ *     @OA\Property(property="value", type="object", nullable=true),
+ * )
+ */
+
 class SeasonSettings extends Model
 {
     use HasFactory;

--- a/app/V5/Models/SeasonSnapshot.php
+++ b/app/V5/Models/SeasonSnapshot.php
@@ -6,6 +6,22 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @OA\Schema(
+ *     schema="V5SeasonSnapshot",
+ *     required={"season_id","snapshot_type"},
+ *     @OA\Property(property="id", type="integer", readOnly=true),
+ *     @OA\Property(property="season_id", type="integer"),
+ *     @OA\Property(property="snapshot_type", type="string"),
+ *     @OA\Property(property="snapshot_data", type="object", nullable=true),
+ *     @OA\Property(property="snapshot_date", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="is_immutable", type="boolean"),
+ *     @OA\Property(property="created_by", type="integer", nullable=true),
+ *     @OA\Property(property="description", type="string", nullable=true),
+ *     @OA\Property(property="checksum", type="string", nullable=true),
+ * )
+ */
+
 class SeasonSnapshot extends Model
 {
     use HasFactory;

--- a/app/V5/Modules/Season/Controllers/SeasonController.php
+++ b/app/V5/Modules/Season/Controllers/SeasonController.php
@@ -14,18 +14,45 @@ class SeasonController extends BaseV5Controller
         parent::__construct($service);
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/v5/seasons",
+     *     tags={"Season"},
+     *     summary="List seasons",
+     *     @OA\Response(response=200, description="List of seasons")
+     * )
+     */
     public function index(): JsonResponse
     {
         $data = $this->service->all();
         return $this->respond($data->toArray());
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/v5/seasons",
+     *     tags={"Season"},
+     *     summary="Create season",
+     *     @OA\RequestBody(@OA\JsonContent(ref="#/components/schemas/V5Season")),
+     *     @OA\Response(response=201, description="Created")
+     * )
+     */
     public function store(Request $request): JsonResponse
     {
         $season = $this->service->createSeason($request->all());
         return $this->respond($season->toArray(), 201);
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/v5/seasons/{id}",
+     *     tags={"Season"},
+     *     summary="Show season",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Season data"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     public function show(int $id): JsonResponse
     {
         $season = $this->service->find($id);
@@ -35,6 +62,17 @@ class SeasonController extends BaseV5Controller
         return $this->respond($season->toArray());
     }
 
+    /**
+     * @OA\Put(
+     *     path="/api/v5/seasons/{id}",
+     *     tags={"Season"},
+     *     summary="Update season",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(@OA\JsonContent(ref="#/components/schemas/V5Season")),
+     *     @OA\Response(response=200, description="Updated"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     public function update(int $id, Request $request): JsonResponse
     {
         $season = $this->service->updateSeason($id, $request->all());
@@ -44,6 +82,16 @@ class SeasonController extends BaseV5Controller
         return $this->respond($season->toArray());
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/api/v5/seasons/{id}",
+     *     tags={"Season"},
+     *     summary="Delete season",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Deleted"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     public function destroy(int $id): JsonResponse
     {
         $deleted = $this->service->deleteSeason($id);
@@ -53,12 +101,31 @@ class SeasonController extends BaseV5Controller
         return $this->respond(['deleted' => true]);
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/v5/seasons/current",
+     *     tags={"Season"},
+     *     summary="Current season",
+     *     @OA\Parameter(name="school_id", in="query", required=false, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Season data")
+     * )
+     */
     public function current(Request $request): JsonResponse
     {
         $season = $this->service->getCurrentSeason($request->get('school_id'));
         return $this->respond($season?->toArray() ?? []);
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/v5/seasons/{id}/close",
+     *     tags={"Season"},
+     *     summary="Close season",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Closed"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     public function close(int $id): JsonResponse
     {
         $season = $this->service->closeSeason($id);
@@ -68,6 +135,16 @@ class SeasonController extends BaseV5Controller
         return $this->respond($season->toArray());
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/v5/seasons/{id}/clone",
+     *     tags={"Season"},
+     *     summary="Clone season",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=201, description="Cloned"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
     public function clone(int $id): JsonResponse
     {
         $season = $this->service->cloneSeason($id);

--- a/docs/v5/season.md
+++ b/docs/v5/season.md
@@ -1,0 +1,73 @@
+# Season Module
+
+The Season module manages academic seasons for a school. Each season has a start and end date along with optional hours and vacation days.
+
+## Endpoints
+
+### List Seasons
+
+```http
+GET /api/v5/seasons
+```
+
+Returns all seasons.
+
+### Create Season
+
+```http
+POST /api/v5/seasons
+```
+
+Parameters: see `Season` schema. Returns the created season.
+
+### Show Season
+
+```http
+GET /api/v5/seasons/{id}
+```
+
+Retrieve a single season by ID.
+
+### Update Season
+
+```http
+PUT /api/v5/seasons/{id}
+```
+
+Accepts the same fields as creation. Returns the updated season.
+
+### Delete Season
+
+```http
+DELETE /api/v5/seasons/{id}
+```
+
+Removes a season.
+
+### Current Season
+
+```http
+GET /api/v5/seasons/current?school_id={id}
+```
+
+Fetch the active season for a school.
+
+### Close Season
+
+```http
+POST /api/v5/seasons/{id}/close
+```
+
+Marks a season as closed.
+
+### Clone Season
+
+```http
+POST /api/v5/seasons/{id}/clone
+```
+
+Creates a new season based on an existing one.
+
+## Workflow Notes
+
+Most operations rely on `SeasonService` which interacts with the repository and models. Closing or cloning a season updates additional fields like `is_closed` and `closed_at`.

--- a/docs/v5/v5-overview.md
+++ b/docs/v5/v5-overview.md
@@ -35,6 +35,7 @@ It returns:
 
 Use this route to confirm that the V5 API is reachable.
 
+The Season module manages school terms and is exposed under `/api/v5/seasons`. See `docs/v5/season.md` for all Season endpoints.
 ## Running V5 Tests
 
 Feature tests for V5 reside under `tests/Feature`, currently starting with `V5HealthCheckTest.php`. Run all tests with:


### PR DESCRIPTION
## Summary
- document Season API endpoints
- reference Season module in v5 overview
- annotate Season models and controller with OpenAPI metadata

## Testing
- `vendor/bin/phpunit --filter=V5`

------
https://chatgpt.com/codex/tasks/task_e_6887d7cc96b48320a21870009823f24c