### PR TITLE
Add Season service and API tests

### DIFF
--- a/tests/Feature/SeasonApiTest.php
+++ b/tests/Feature/SeasonApiTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\V5\Models\Season;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class SeasonApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('seasons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->boolean('is_active')->default(false);
+            $table->unsignedBigInteger('school_id');
+            $table->timestamps();
+            $table->timestamp('deleted_at')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('seasons');
+        parent::tearDown();
+    }
+
+    public function test_can_create_and_show_season(): void
+    {
+        $payload = [
+            'name' => 'Season A',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-02-01',
+            'is_active' => false,
+            'school_id' => 1,
+        ];
+
+        $create = $this->postJson('/api/v5/seasons', $payload);
+        $create->assertStatus(201)
+            ->assertJsonPath('name', 'Season A');
+
+        $id = $create->json('id');
+
+        $this->getJson('/api/v5/seasons/'.$id)
+            ->assertStatus(200)
+            ->assertJsonPath('id', $id);
+    }
+
+    public function test_can_list_seasons(): void
+    {
+        Season::create([
+            'name' => 'S1',
+            'start_date' => '2024-03-01',
+            'end_date' => '2024-04-01',
+            'is_active' => false,
+            'school_id' => 1,
+        ]);
+        Season::create([
+            'name' => 'S2',
+            'start_date' => '2024-05-01',
+            'end_date' => '2024-06-01',
+            'is_active' => false,
+            'school_id' => 1,
+        ]);
+
+        $this->getJson('/api/v5/seasons')
+            ->assertStatus(200)
+            ->assertJsonCount(2);
+    }
+
+    public function test_can_update_and_delete_season(): void
+    {
+        $season = Season::create([
+            'name' => 'ToUpdate',
+            'start_date' => '2024-07-01',
+            'end_date' => '2024-08-01',
+            'is_active' => false,
+            'school_id' => 1,
+        ]);
+
+        $this->putJson('/api/v5/seasons/'.$season->id, ['name' => 'Updated'])
+            ->assertStatus(200)
+            ->assertJsonPath('name', 'Updated');
+
+        $this->deleteJson('/api/v5/seasons/'.$season->id)
+            ->assertStatus(200)
+            ->assertJson(['deleted' => true]);
+
+        $this->getJson('/api/v5/seasons/'.$season->id)->assertStatus(404);
+    }
+}

--- a/tests/Feature/SeasonWorkflowTest.php
+++ b/tests/Feature/SeasonWorkflowTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\V5\Models\Season;
+use App\V5\Modules\Season\Services\SeasonSnapshotService;
+use App\V5\Modules\Season\Repositories\SeasonSnapshotRepository;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class SeasonWorkflowTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('seasons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->boolean('is_active')->default(false);
+            $table->boolean('is_closed')->default(false);
+            $table->timestamp('closed_at')->nullable();
+            $table->unsignedBigInteger('school_id');
+            $table->timestamps();
+            $table->timestamp('deleted_at')->nullable();
+        });
+
+        Schema::create('season_snapshots', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('season_id');
+            $table->string('snapshot_type');
+            $table->text('snapshot_data')->nullable();
+            $table->timestamp('snapshot_date')->nullable();
+            $table->boolean('is_immutable')->default(false);
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->text('description')->nullable();
+            $table->string('checksum', 64);
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('season_snapshots');
+        Schema::dropIfExists('seasons');
+        parent::tearDown();
+    }
+
+    public function test_season_lifecycle_operations(): void
+    {
+        $create = $this->postJson('/api/v5/seasons', [
+            'name' => 'Workflow',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-12-31',
+            'is_active' => false,
+            'school_id' => 1,
+        ]);
+        $create->assertStatus(201);
+        $id = $create->json('id');
+
+        $this->putJson('/api/v5/seasons/'.$id, ['is_active' => true])
+            ->assertStatus(200)
+            ->assertJsonPath('is_active', true);
+
+        $season = Season::find($id);
+        $snapshotService = new SeasonSnapshotService(new SeasonSnapshotRepository());
+        $snapshot = $snapshotService->createImmutableSnapshot($season, 'manual', $season->toArray());
+        $this->assertTrue($snapshot->is_immutable);
+        $this->assertEquals($id, $snapshot->season_id);
+
+        $this->postJson('/api/v5/seasons/'.$id.'/close')
+            ->assertStatus(200)
+            ->assertJsonPath('is_closed', true);
+
+        $season->refresh();
+        $this->assertTrue($season->is_closed);
+        $this->assertFalse($season->is_active);
+    }
+}

--- a/tests/Unit/SeasonServiceTest.php
+++ b/tests/Unit/SeasonServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\V5\Modules\Season\Services\SeasonService;
+use App\V5\Modules\Season\Repositories\SeasonRepository;
+use App\V5\Models\Season;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class SeasonServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('seasons');
+        Schema::create('seasons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->time('hour_start')->nullable();
+            $table->time('hour_end')->nullable();
+            $table->boolean('is_active')->default(false);
+            $table->string('vacation_days')->nullable();
+            $table->unsignedBigInteger('school_id');
+            $table->boolean('is_closed')->default(false);
+            $table->timestamp('closed_at')->nullable();
+            $table->timestamps();
+            $table->timestamp('deleted_at')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('seasons');
+        parent::tearDown();
+    }
+
+    private function getService(): SeasonService
+    {
+        return new SeasonService(new SeasonRepository());
+    }
+
+    public function test_create_and_find_season(): void
+    {
+        $service = $this->getService();
+
+        $season = $service->createSeason([
+            'name' => 'Winter',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-02-01',
+            'is_active' => false,
+            'school_id' => 1,
+        ]);
+
+        $found = $service->find($season->id);
+
+        $this->assertEquals('Winter', $found->name);
+    }
+
+    public function test_activate_season_sets_active_flag(): void
+    {
+        $service = $this->getService();
+        $season = Season::create([
+            'name' => 'Spring',
+            'start_date' => '2024-03-01',
+            'end_date' => '2024-04-01',
+            'is_active' => false,
+            'school_id' => 1,
+        ]);
+
+        $updated = $service->activateSeason($season->id);
+
+        $this->assertTrue($updated->is_active);
+    }
+
+    public function test_clone_season_creates_inactive_copy(): void
+    {
+        $service = $this->getService();
+        $season = Season::create([
+            'name' => 'Summer',
+            'start_date' => '2024-06-01',
+            'end_date' => '2024-07-01',
+            'is_active' => true,
+            'school_id' => 1,
+        ]);
+
+        $clone = $service->cloneSeason($season->id);
+
+        $this->assertNotNull($clone);
+        $this->assertNotEquals($season->id, $clone->id);
+        $this->assertFalse($clone->is_active);
+        $this->assertEquals($season->name, $clone->name);
+    }
+
+    public function test_close_season_marks_closed(): void
+    {
+        $service = $this->getService();
+        $season = Season::create([
+            'name' => 'Autumn',
+            'start_date' => '2024-09-01',
+            'end_date' => '2024-10-01',
+            'is_active' => true,
+            'is_closed' => false,
+            'school_id' => 1,
+        ]);
+
+        $closed = $service->closeSeason($season->id);
+
+        $this->assertTrue($closed->is_closed);
+        $this->assertFalse($closed->is_active);
+        $this->assertNotNull($closed->closed_at);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for SeasonService logic
- create feature tests for Season API endpoints
- validate workflow: create, activate, snapshot and close

## Testing
- `vendor/bin/phpunit --filter=SeasonServiceTest --stop-on-failure`
- `vendor/bin/phpunit --filter=SeasonApiTest --stop-on-failure`
- `vendor/bin/phpunit --filter=SeasonWorkflowTest --stop-on-failure`
- `vendor/bin/phpunit --filter=V5HealthCheckTest --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6887dc9c4f7c83209dc72748ccbb431d