### PR TITLE
Add season migrations and model relations

### DIFF
--- a/app/V5/Models/Season.php
+++ b/app/V5/Models/Season.php
@@ -74,4 +74,9 @@ class Season extends Model
     {
         return $this->hasMany(SeasonSnapshot::class);
     }
+
+    public function settings(): HasMany
+    {
+        return $this->hasMany(SeasonSettings::class);
+    }
 }

--- a/app/V5/Models/SeasonSnapshot.php
+++ b/app/V5/Models/SeasonSnapshot.php
@@ -61,6 +61,11 @@ class SeasonSnapshot extends Model
         return $this->belongsTo(Season::class);
     }
 
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class, 'created_by');
+    }
+
     protected static function boot()
     {
         parent::boot();

--- a/database/migrations/2025_07_28_212935_create_seasons_table.php
+++ b/database/migrations/2025_07_28_212935_create_seasons_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('seasons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->time('hour_start')->nullable();
+            $table->time('hour_end')->nullable();
+            $table->boolean('is_active')->default(false);
+            $table->string('vacation_days')->nullable();
+            $table->unsignedBigInteger('school_id');
+            $table->boolean('is_closed')->default(false);
+            $table->timestamp('closed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['school_id', 'start_date', 'end_date'], 'idx_seasons_school_dates');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('seasons');
+    }
+};

--- a/database/migrations/2025_07_28_212937_create_season_snapshots_table.php
+++ b/database/migrations/2025_07_28_212937_create_season_snapshots_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('season_snapshots', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('season_id')->constrained();
+            $table->string('snapshot_type');
+            $table->longText('snapshot_data')->nullable();
+            $table->timestamp('snapshot_date')->nullable();
+            $table->boolean('is_immutable')->default(false);
+            $table->foreignId('created_by')->nullable()->constrained('users');
+            $table->text('description')->nullable();
+            $table->string('checksum', 64);
+            $table->timestamps();
+
+            $table->index(['season_id', 'snapshot_type']);
+            $table->index(['is_immutable', 'snapshot_date']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('season_snapshots');
+    }
+};

--- a/database/migrations/2025_07_28_212939_create_season_settings_table.php
+++ b/database/migrations/2025_07_28_212939_create_season_settings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('season_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('season_id')->constrained();
+            $table->string('key');
+            $table->json('value')->nullable();
+            $table->timestamps();
+
+            $table->unique(['season_id', 'key']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('season_settings');
+    }
+};


### PR DESCRIPTION
## Summary
- create migrations for seasons, season snapshots, and season settings
- extend Season model with settings relation
- extend SeasonSnapshot model with user relation
- verify migrations by running them with sqlite

## Testing
- `vendor/bin/pint --test` *(fails: 652 style issues)*
- `DB_DATABASE=':memory:' vendor/bin/phpunit --stop-on-failure --testsuite Feature --filter SeasonWorkflowTest --do-not-cache-result`

------
https://chatgpt.com/codex/tasks/task_e_6887eb543ddc8320a3289e1e0014d579