### PR TITLE
Implement second-week task scaffolding

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -70,5 +70,7 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'admin.rate.limit' => \App\Http\Middleware\AdminRateLimit::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'season.context' => \App\V5\Middleware\SeasonContextMiddleware::class,
+        'season.permission' => \App\V5\Guards\SeasonPermissionGuard::class,
     ];
 }

--- a/app/Models/School.php
+++ b/app/Models/School.php
@@ -335,7 +335,8 @@ class School extends Model
         'inscription',
         'type',
         'active',
-        'settings'
+        'settings',
+        'current_season_id'
     ];
 
     protected $casts = [
@@ -374,7 +375,8 @@ class School extends Model
         'inscription' => 'boolean',
         'type' => 'string',
         'active' => 'boolean',
-        'settings' => 'string'
+        'settings' => 'string',
+        'current_season_id' => 'integer'
     ];
 
     public static array $rules = [
@@ -414,6 +416,7 @@ class School extends Model
         'type' => 'nullable',
         'active' => 'nullable',
         'settings' => 'nullable',
+        'current_season_id' => 'nullable|integer',
         'created_at' => 'nullable',
         'updated_at' => 'nullable',
         'deleted_at' => 'nullable'
@@ -511,6 +514,16 @@ class School extends Model
     public function vouchers(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\App\Models\Voucher::class, 'school_id');
+    }
+
+    public function seasonSettings(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(\App\V5\Models\SchoolSeasonSettings::class, 'school_id');
+    }
+
+    public function currentSeason(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(\App\V5\Models\Season::class, 'current_season_id');
     }
 
     public function getActivitylogOptions(): LogOptions

--- a/app/V5/Guards/SeasonPermissionGuard.php
+++ b/app/V5/Guards/SeasonPermissionGuard.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\V5\Guards;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use App\V5\Modules\Auth\Services\AuthV5Service;
+
+class SeasonPermissionGuard
+{
+    protected AuthV5Service $auth;
+
+    public function __construct(AuthV5Service $auth)
+    {
+        $this->auth = $auth;
+    }
+
+    public function handle(Request $request, \Closure $next): Response
+    {
+        $userId = $request->user()->id ?? 0;
+        $seasonId = (int) $request->get('season_id');
+        $permissions = $this->auth->checkSeasonPermissions($userId, $seasonId);
+        // TODO: check actual permission list
+        return $next($request);
+    }
+}

--- a/app/V5/Middleware/SeasonContextMiddleware.php
+++ b/app/V5/Middleware/SeasonContextMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\V5\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use App\V5\Modules\Season\Services\SeasonService;
+
+class SeasonContextMiddleware
+{
+    protected SeasonService $seasons;
+
+    public function __construct(SeasonService $seasons)
+    {
+        $this->seasons = $seasons;
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        if (!$request->has('season_id') && $request->has('school_id')) {
+            $season = $this->seasons->getCurrentSeason($request->get('school_id'));
+            if ($season) {
+                $request->merge(['season_id' => $season->id]);
+            }
+        }
+        return $next($request);
+    }
+}

--- a/app/V5/Models/SchoolSeasonSettings.php
+++ b/app/V5/Models/SchoolSeasonSettings.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\V5\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @OA\Schema(
+ *     schema="V5SchoolSeasonSettings",
+ *     required={"school_id","season_id","key"},
+ *     @OA\Property(property="id", type="integer", readOnly=true),
+ *     @OA\Property(property="school_id", type="integer"),
+ *     @OA\Property(property="season_id", type="integer"),
+ *     @OA\Property(property="key", type="string"),
+ *     @OA\Property(property="value", type="object", nullable=true)
+ * )
+ */
+class SchoolSeasonSettings extends Model
+{
+    use HasFactory;
+
+    protected $table = 'school_season_settings';
+
+    protected $fillable = [
+        'school_id',
+        'season_id',
+        'key',
+        'value',
+    ];
+
+    protected $casts = [
+        'value' => 'array',
+    ];
+
+    public static array $rules = [
+        'school_id' => 'required|integer',
+        'season_id' => 'required|integer',
+        'key' => 'required|string|max:255',
+        'value' => 'nullable',
+    ];
+
+    public function school(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\School::class);
+    }
+
+    public function season(): BelongsTo
+    {
+        return $this->belongsTo(Season::class);
+    }
+}

--- a/app/V5/Models/UserSeasonRole.php
+++ b/app/V5/Models/UserSeasonRole.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\V5\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @OA\Schema(
+ *     schema="V5UserSeasonRole",
+ *     required={"user_id","season_id","role"},
+ *     @OA\Property(property="id", type="integer", readOnly=true),
+ *     @OA\Property(property="user_id", type="integer"),
+ *     @OA\Property(property="season_id", type="integer"),
+ *     @OA\Property(property="role", type="string")
+ * )
+ */
+class UserSeasonRole extends Model
+{
+    use HasFactory;
+
+    protected $table = 'user_season_roles';
+
+    protected $fillable = [
+        'user_id',
+        'season_id',
+        'role',
+    ];
+
+    public static array $rules = [
+        'user_id' => 'required|integer',
+        'season_id' => 'required|integer',
+        'role' => 'required|string|max:255',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class);
+    }
+
+    public function season(): BelongsTo
+    {
+        return $this->belongsTo(Season::class);
+    }
+}

--- a/app/V5/Modules/Auth/Controllers/AuthV5Controller.php
+++ b/app/V5/Modules/Auth/Controllers/AuthV5Controller.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\V5\Modules\Auth\Controllers;
+
+use App\V5\BaseV5Controller;
+use App\V5\Modules\Auth\Services\AuthV5Service;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AuthV5Controller extends BaseV5Controller
+{
+    public function __construct(AuthV5Service $service)
+    {
+        parent::__construct($service);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $data = $this->service->loginWithSeasonContext($request->all());
+        return $this->respond($data);
+    }
+
+    public function permissions(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id ?? 0;
+        $seasonId = (int) $request->get('season_id');
+        $data = $this->service->checkSeasonPermissions($userId, $seasonId);
+        return $this->respond($data);
+    }
+
+    public function switch(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id ?? 0;
+        $seasonId = (int) $request->get('season_id');
+        $this->service->assignSeasonRole($userId, $seasonId, 'active');
+        return $this->respond(['switched' => true]);
+    }
+}

--- a/app/V5/Modules/Auth/Services/AuthV5Service.php
+++ b/app/V5/Modules/Auth/Services/AuthV5Service.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\V5\Modules\Auth\Services;
+
+use App\V5\Services\BaseService;
+
+class AuthV5Service extends BaseService
+{
+    public function loginWithSeasonContext(array $credentials): array
+    {
+        // TODO: implement login logic using season context
+        return [];
+    }
+
+    public function checkSeasonPermissions(int $userId, int $seasonId): array
+    {
+        // TODO: return permission list for user in given season
+        return [];
+    }
+
+    public function assignSeasonRole(int $userId, int $seasonId, string $role): void
+    {
+        // TODO: persist role assignment
+    }
+}

--- a/app/V5/Modules/School/Controllers/SchoolV5Controller.php
+++ b/app/V5/Modules/School/Controllers/SchoolV5Controller.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\V5\Modules\School\Controllers;
+
+use App\V5\BaseV5Controller;
+use App\V5\Modules\School\Services\SchoolV5Service;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SchoolV5Controller extends BaseV5Controller
+{
+    public function __construct(SchoolV5Service $service)
+    {
+        parent::__construct($service);
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $seasonId = (int) $request->get('season_id');
+        $data = $this->service->listBySeason($seasonId);
+        return $this->respond($data);
+    }
+}

--- a/app/V5/Modules/School/Services/SchoolV5Service.php
+++ b/app/V5/Modules/School/Services/SchoolV5Service.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\V5\Modules\School\Services;
+
+use App\V5\Services\BaseService;
+
+class SchoolV5Service extends BaseService
+{
+    public function listBySeason(int $seasonId)
+    {
+        // TODO: fetch schools filtered by season
+        return [];
+    }
+}

--- a/database/migrations/2025_07_28_214715_add_current_season_id_to_schools.php
+++ b/database/migrations/2025_07_28_214715_add_current_season_id_to_schools.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('schools', function (Blueprint $table) {
+            $table->foreignId('current_season_id')->nullable()->constrained('seasons');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('schools', function (Blueprint $table) {
+            $table->dropForeign(['current_season_id']);
+            $table->dropColumn('current_season_id');
+        });
+    }
+};

--- a/database/migrations/2025_07_28_214721_create_school_season_settings_table.php
+++ b/database/migrations/2025_07_28_214721_create_school_season_settings_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('school_season_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('school_id')->constrained();
+            $table->foreignId('season_id')->constrained();
+            $table->string('key');
+            $table->json('value')->nullable();
+            $table->timestamps();
+            $table->unique(['school_id', 'season_id', 'key'], 'uniq_school_season_key');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('school_season_settings');
+    }
+};

--- a/database/migrations/2025_07_28_214759_create_user_season_roles_table.php
+++ b/database/migrations/2025_07_28_214759_create_user_season_roles_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_season_roles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained();
+            $table->foreignId('season_id')->constrained();
+            $table->string('role');
+            $table->timestamps();
+            $table->unique(['user_id', 'season_id'], 'uniq_user_season');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_season_roles');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1599,5 +1599,12 @@ Route::prefix('v5')->group(function () {
     Route::get('seasons/current', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'current']);
     Route::post('seasons/{id}/close', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'close']);
     Route::post('seasons/{id}/clone', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'clone']);
+
+    Route::middleware(['season.context', 'season.permission'])->group(function () {
+        Route::get('schools', [\App\V5\Modules\School\Controllers\SchoolV5Controller::class, 'index']);
+        Route::post('auth/login', [\App\V5\Modules\Auth\Controllers\AuthV5Controller::class, 'login']);
+        Route::get('auth/permissions', [\App\V5\Modules\Auth\Controllers\AuthV5Controller::class, 'permissions']);
+        Route::post('auth/season/switch', [\App\V5\Modules\Auth\Controllers\AuthV5Controller::class, 'switch']);
+    });
 });
 /* BOUKII V5 */


### PR DESCRIPTION
## Summary
- add migrations for season context and settings
- create models for SchoolSeasonSettings and UserSeasonRole
- add middleware and guard for season context
- scaffold School and Auth V5 controllers and services
- wire up new routes and kernel aliases
- extend School model for season relations

## Testing
- `vendor/bin/phpunit --testsuite none`
- `vendor/bin/pint --test` *(fails: style issues across repo)*

------
https://chatgpt.com/codex/tasks/task_e_6887ee6cf3a08320946cfa1eb2d80f73