### PR TITLE
Improve season module

### DIFF
--- a/app/V5/Models/Season.php
+++ b/app/V5/Models/Season.php
@@ -4,6 +4,7 @@ namespace App\V5\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -28,6 +29,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Season extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $table = 'seasons';
 

--- a/app/V5/Models/SeasonSettings.php
+++ b/app/V5/Models/SeasonSettings.php
@@ -4,6 +4,7 @@ namespace App\V5\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -20,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class SeasonSettings extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $table = 'season_settings';
 

--- a/app/V5/Models/SeasonSnapshot.php
+++ b/app/V5/Models/SeasonSnapshot.php
@@ -4,6 +4,7 @@ namespace App\V5\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -25,6 +26,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class SeasonSnapshot extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $table = 'season_snapshots';
 
@@ -79,5 +81,11 @@ class SeasonSnapshot extends Model
                 throw new \Exception('Immutable snapshots cannot be modified');
             }
         });
+    }
+
+    public function verifyIntegrity(): bool
+    {
+        $expected = hash('sha256', json_encode($this->snapshot_data));
+        return $this->checksum === $expected;
     }
 }

--- a/app/V5/Modules/Season/Repositories/SeasonRepository.php
+++ b/app/V5/Modules/Season/Repositories/SeasonRepository.php
@@ -53,4 +53,13 @@ class SeasonRepository extends BaseRepository
             ->orderByDesc('start_date')
             ->first();
     }
+
+    public function getActiveSeasons(int $schoolId): Collection
+    {
+        return $this->model->newQuery()
+            ->where('school_id', $schoolId)
+            ->where('is_active', true)
+            ->orderByDesc('start_date')
+            ->get();
+    }
 }

--- a/app/V5/Modules/Season/Services/SeasonService.php
+++ b/app/V5/Modules/Season/Services/SeasonService.php
@@ -105,4 +105,14 @@ class SeasonService extends BaseService
         $repo = $this->repository;
         return $repo->getCurrentSeason($schoolId);
     }
+
+    /**
+     * @return Collection<int,Season>
+     */
+    public function getActiveSeasons(int $schoolId): Collection
+    {
+        /** @var SeasonRepository $repo */
+        $repo = $this->repository;
+        return $repo->getActiveSeasons($schoolId);
+    }
 }

--- a/database/migrations/2025_07_28_212935_create_seasons_table.php
+++ b/database/migrations/2025_07_28_212935_create_seasons_table.php
@@ -24,6 +24,7 @@ return new class extends Migration
             $table->boolean('is_closed')->default(false);
             $table->timestamp('closed_at')->nullable();
             $table->timestamps();
+            $table->softDeletes();
 
             $table->index(['school_id', 'start_date', 'end_date'], 'idx_seasons_school_dates');
         });

--- a/database/migrations/2025_07_28_212937_create_season_snapshots_table.php
+++ b/database/migrations/2025_07_28_212937_create_season_snapshots_table.php
@@ -22,6 +22,7 @@ return new class extends Migration
             $table->text('description')->nullable();
             $table->string('checksum', 64);
             $table->timestamps();
+            $table->softDeletes();
 
             $table->index(['season_id', 'snapshot_type']);
             $table->index(['is_immutable', 'snapshot_date']);

--- a/database/migrations/2025_07_28_212939_create_season_settings_table.php
+++ b/database/migrations/2025_07_28_212939_create_season_settings_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('key');
             $table->json('value')->nullable();
             $table->timestamps();
+            $table->softDeletes();
 
             $table->unique(['season_id', 'key']);
         });

--- a/tests/Unit/SeasonServiceTest.php
+++ b/tests/Unit/SeasonServiceTest.php
@@ -114,4 +114,28 @@ class SeasonServiceTest extends TestCase
         $this->assertFalse($closed->is_active);
         $this->assertNotNull($closed->closed_at);
     }
+
+    public function test_get_active_seasons_returns_only_active(): void
+    {
+        $service = $this->getService();
+        Season::create([
+            'name' => 'Active 1',
+            'start_date' => '2024-11-01',
+            'end_date' => '2024-12-01',
+            'is_active' => true,
+            'school_id' => 1,
+        ]);
+        Season::create([
+            'name' => 'Inactive',
+            'start_date' => '2025-01-01',
+            'end_date' => '2025-02-01',
+            'is_active' => false,
+            'school_id' => 1,
+        ]);
+
+        $active = $service->getActiveSeasons(1);
+
+        $this->assertCount(1, $active);
+        $this->assertEquals('Active 1', $active->first()->name);
+    }
 }

--- a/tests/Unit/SeasonSnapshotServiceTest.php
+++ b/tests/Unit/SeasonSnapshotServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\V5\Modules\Season\Services\SeasonSnapshotService;
+use App\V5\Modules\Season\Repositories\SeasonSnapshotRepository;
+use App\V5\Modules\Season\Repositories\SeasonRepository;
+use App\V5\Models\Season;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class SeasonSnapshotServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('seasons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->boolean('is_active')->default(false);
+            $table->unsignedBigInteger('school_id');
+            $table->timestamps();
+            $table->timestamp('deleted_at')->nullable();
+        });
+
+        Schema::create('season_snapshots', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('season_id');
+            $table->string('snapshot_type');
+            $table->text('snapshot_data')->nullable();
+            $table->timestamp('snapshot_date')->nullable();
+            $table->boolean('is_immutable')->default(false);
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->text('description')->nullable();
+            $table->string('checksum', 64);
+            $table->timestamps();
+            $table->timestamp('deleted_at')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('season_snapshots');
+        Schema::dropIfExists('seasons');
+        parent::tearDown();
+    }
+
+    private function getService(): SeasonSnapshotService
+    {
+        return new SeasonSnapshotService(new SeasonSnapshotRepository());
+    }
+
+    public function test_create_immutable_snapshot_and_validate(): void
+    {
+        $season = Season::create([
+            'name' => 'Test',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-02-01',
+            'is_active' => true,
+            'school_id' => 1,
+        ]);
+
+        $service = $this->getService();
+        $snapshot = $service->createImmutableSnapshot($season, 'manual', $season->toArray());
+
+        $this->assertTrue($snapshot->is_immutable);
+        $this->assertTrue($service->validateSnapshot($snapshot));
+    }
+}


### PR DESCRIPTION
## Summary
- add soft-deletes to season tables
- support active seasons in repository & service
- add snapshot integrity check
- cover services with new tests

## Testing
- `./vendor/bin/phpunit tests/Unit/SeasonServiceTest.php tests/Unit/SeasonSnapshotServiceTest.php tests/Feature/SeasonApiTest.php tests/Feature/SeasonWorkflowTest.php --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68880bbb93f48320871484160b0f3095