### PR TITLE
Add permission check and tests

### DIFF
--- a/app/V5/Guards/SeasonPermissionGuard.php
+++ b/app/V5/Guards/SeasonPermissionGuard.php
@@ -20,7 +20,11 @@ class SeasonPermissionGuard
         $userId = $request->user()->id ?? 0;
         $seasonId = (int) $request->get('season_id');
         $permissions = $this->auth->checkSeasonPermissions($userId, $seasonId);
-        // TODO: check actual permission list
+
+        if (empty($permissions)) {
+            abort(403, 'Forbidden');
+        }
+
         return $next($request);
     }
 }

--- a/tests/Unit/SeasonPermissionGuardTest.php
+++ b/tests/Unit/SeasonPermissionGuardTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\V5\Guards\SeasonPermissionGuard;
+use App\V5\Modules\Auth\Services\AuthV5Service;
+use Illuminate\Http\Request;
+use Mockery;
+use Tests\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class SeasonPermissionGuardTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_request_is_allowed_when_permissions_exist(): void
+    {
+        $service = Mockery::mock(AuthV5Service::class);
+        $service->shouldReceive('checkSeasonPermissions')
+            ->once()
+            ->with(1, 5)
+            ->andReturn(['view schools']);
+
+        $guard = new SeasonPermissionGuard($service);
+
+        $request = Request::create('/test', 'GET', ['season_id' => 5]);
+        $user = new \stdClass();
+        $user->id = 1;
+        $request->setUserResolver(fn () => $user);
+
+        $response = $guard->handle($request, function () {
+            return response('ok', 200);
+        });
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_request_is_denied_when_no_permissions(): void
+    {
+        $service = Mockery::mock(AuthV5Service::class);
+        $service->shouldReceive('checkSeasonPermissions')
+            ->once()
+            ->with(1, 5)
+            ->andReturn([]);
+
+        $guard = new SeasonPermissionGuard($service);
+
+        $request = Request::create('/test', 'GET', ['season_id' => 5]);
+        $user = new \stdClass();
+        $user->id = 1;
+        $request->setUserResolver(fn () => $user);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Forbidden');
+        $guard->handle($request, function () {
+            return response('ok', 200);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- enforce permission list in `SeasonPermissionGuard`
- add unit tests to verify allowed and denied behavior

## Testing
- `./vendor/bin/phpunit --filter SeasonPermissionGuardTest`
- `./vendor/bin/phpunit --testsuite Unit`


------
https://chatgpt.com/codex/tasks/task_e_68888e191da08320917415845260ee43