### PR TITLE
Fix login route protection and update tests

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -33,7 +33,7 @@ class UserFactory extends Factory
             'recover_token' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'created_at' => $this->faker->date('Y-m-d H:i:s'),
             'updated_at' => $this->faker->date('Y-m-d H:i:s'),
-            'deleted_at' => $this->faker->word,
+            'deleted_at' => null,
             'logout' => $this->faker->boolean
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1600,9 +1600,11 @@ Route::prefix('v5')->group(function () {
     Route::post('seasons/{id}/close', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'close']);
     Route::post('seasons/{id}/clone', [\App\V5\Modules\Season\Controllers\SeasonController::class, 'clone']);
 
+    Route::post('auth/login', [\App\V5\Modules\Auth\Controllers\AuthV5Controller::class, 'login'])
+        ->middleware('season.context');
+
     Route::middleware(['season.context', 'season.permission'])->group(function () {
         Route::get('schools', [\App\V5\Modules\School\Controllers\SchoolV5Controller::class, 'index']);
-        Route::post('auth/login', [\App\V5\Modules\Auth\Controllers\AuthV5Controller::class, 'login']);
         Route::get('auth/permissions', [\App\V5\Modules\Auth\Controllers\AuthV5Controller::class, 'permissions']);
         Route::post('auth/season/switch', [\App\V5\Modules\Auth\Controllers\AuthV5Controller::class, 'switch']);
     });

--- a/tests/Feature/V5AuthRoutesTest.php
+++ b/tests/Feature/V5AuthRoutesTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class V5AuthRoutesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('role_has_permissions');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('roles');
+        Schema::dropIfExists('user_season_roles');
+        Schema::dropIfExists('seasons');
+        Schema::dropIfExists('users');
+        Schema::dropIfExists('personal_access_tokens');
+
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->bigInteger('id')->primary();
+            $table->string('email')->nullable();
+            $table->string('password');
+            $table->string('type', 100);
+            $table->boolean('active')->default(1);
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('seasons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->boolean('is_active')->default(false);
+            $table->unsignedBigInteger('school_id');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('user_season_roles', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('season_id');
+            $table->string('role');
+            $table->timestamps();
+            $table->unique(['user_id', 'season_id']);
+        });
+
+        Schema::create('roles', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('permission_id');
+            $table->unsignedBigInteger('role_id');
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('role_has_permissions');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('roles');
+        Schema::dropIfExists('user_season_roles');
+        Schema::dropIfExists('seasons');
+        Schema::dropIfExists('users');
+        Schema::dropIfExists('personal_access_tokens');
+        parent::tearDown();
+    }
+
+    public function test_login_route_is_accessible_without_permission_middleware(): void
+    {
+        $seasonId = DB::table('seasons')->insertGetId([
+            'name' => 'S1',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-12-31',
+            'is_active' => true,
+            'school_id' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $user = User::create([
+            'id' => 1,
+            'email' => 'user@test.com',
+            'password' => Hash::make('pass'),
+            'type' => 'admin',
+            'active' => 1,
+        ]);
+
+        DB::table('user_season_roles')->insert([
+            'user_id' => $user->id,
+            'season_id' => $seasonId,
+            'role' => 'admin',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('roles')->insert([
+            'id' => 1,
+            'name' => 'admin',
+            'guard_name' => 'web',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/v5/auth/login', [
+            'email' => 'user@test.com',
+            'password' => 'pass',
+            'season_id' => $seasonId,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertNotEmpty($response->json('token'));
+    }
+
+    public function test_other_routes_still_require_permissions(): void
+    {
+        $seasonId = DB::table('seasons')->insertGetId([
+            'name' => 'S1',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-12-31',
+            'is_active' => true,
+            'school_id' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->getJson('/api/v5/schools?season_id=' . $seasonId);
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- move `/api/v5/auth/login` outside of the `season.permission` middleware
- keep `season.context` middleware on the login route
- ensure factories don't set invalid dates
- add feature tests for V5 auth routes

## Testing
- `vendor/bin/phpunit --filter V5AuthRoutesTest --testdox`

------
https://chatgpt.com/codex/tasks/task_e_688896bfe5788320ab9ea6fd791e62d1