### PR TITLE
Add season role helpers

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,8 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Traits\HasRoles;
+use App\V5\Models\UserSeasonRole;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @OA\Schema(
@@ -191,6 +193,26 @@ use Spatie\Permission\Traits\HasRoles;
             'id', // Clave local en el modelo inicial
             'school_id' // Clave local en el modelo intermedio
         );
+    }
+
+    public function userSeasonRoles(): HasMany
+    {
+        return $this->hasMany(UserSeasonRole::class);
+    }
+
+    public function getSeasonRole(int $seasonId): ?string
+    {
+        return $this->userSeasonRoles()
+            ->where('season_id', $seasonId)
+            ->value('role');
+    }
+
+    public function hasSeasonRole(int $seasonId, string $role): bool
+    {
+        return $this->userSeasonRoles()
+            ->where('season_id', $seasonId)
+            ->where('role', $role)
+            ->exists();
     }
 
     public function getActivitylogOptions(): LogOptions

--- a/database/factories/UserSeasonRoleFactory.php
+++ b/database/factories/UserSeasonRoleFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\V5\Models\UserSeasonRole;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserSeasonRoleFactory extends Factory
+{
+    protected $model = UserSeasonRole::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => \App\Models\User::factory(),
+            'season_id' => \App\V5\Models\Season::factory(),
+            'role' => $this->faker->randomElement(['admin', 'manager', 'viewer']),
+        ];
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose `userSeasonRoles` relationship on User model
- add helpers to fetch season roles
- provide factory for creating `UserSeasonRole` instances

## Testing
- `vendor/bin/phpunit --stop-on-failure --display-deprecations=0 --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6888c4c767f08320a4f4a844bb6287f9