### PR TITLE
Add V5 auth/school docs

### DIFF
--- a/docs/v5/auth.md
+++ b/docs/v5/auth.md
@@ -1,0 +1,60 @@
+# Auth Module
+
+The Auth module handles authentication using season context and role permissions.
+
+## Endpoints
+
+### Login
+
+```http
+POST /api/v5/auth/login
+```
+
+Parameters:
+- `email` (string, required)
+- `password` (string, required)
+- `season_id` (integer, required if `school_id` not provided)
+
+`season.context` middleware will fill `season_id` when only `school_id` is sent.
+
+Response:
+```json
+{
+  "token": "<access-token>",
+  "user": { /* User fields */ },
+  "role": "manager",
+  "season_id": 1,
+  "permissions": ["view schools"]
+}
+```
+
+### Permissions
+
+```http
+GET /api/v5/auth/permissions?season_id={id}
+```
+
+Returns an array of permission strings for the authenticated user. Requires the
+`season.context` **and** `season.permission` middleware.
+
+### Switch Season Role
+
+```http
+POST /api/v5/auth/season/switch
+```
+
+Body:
+```json
+{
+  "season_id": 1
+}
+```
+
+Sets the user's role for the season to `active`. Protected by `season.context`
+and `season.permission` middleware.
+
+## Season Context
+
+All endpoints depend on the season context. The middleware determines the
+current season when only `school_id` is provided and ensures the user has the
+necessary permissions via `SeasonPermissionGuard`.

--- a/docs/v5/school.md
+++ b/docs/v5/school.md
@@ -1,0 +1,31 @@
+# School Module
+
+Lists schools for a season along with their season-specific settings.
+
+## Endpoints
+
+### List Schools
+
+```http
+GET /api/v5/schools?season_id={id}
+```
+
+Parameters:
+- `season_id` (integer) required unless `school_id` is provided
+
+The `season.context` middleware can derive the current `season_id` from
+`school_id`. Access requires both `season.context` and `season.permission`
+middleware along with a valid authentication token.
+
+Response:
+```json
+[
+  {
+    "id": 1,
+    "name": "Test School",
+    "season_settings": [
+      { "key": "currency", "value": "CHF" }
+    ]
+  }
+]
+```

--- a/docs/v5/v5-overview.md
+++ b/docs/v5/v5-overview.md
@@ -36,6 +36,7 @@ It returns:
 Use this route to confirm that the V5 API is reachable.
 
 The Season module manages school terms and is exposed under `/api/v5/seasons`. See `docs/v5/season.md` for all Season endpoints.
+Authentication routes live under `/api/v5/auth` and are detailed in `docs/v5/auth.md`. The `/api/v5/schools` endpoint which lists schools for a season is covered in `docs/v5/school.md`.
 ## Running V5 Tests
 
 Feature tests for V5 reside under `tests/Feature`, currently starting with `V5HealthCheckTest.php`. Run all tests with:


### PR DESCRIPTION
## Summary
- document `/v5/auth/*` routes
- document `/v5/schools` route
- link new docs from the V5 overview

## Testing
- `composer install --no-interaction`
- `php artisan test` *(fails: 2 failed, 2 warnings, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6888d25eaae88320900c401193991f90