### PR TITLE
Clarify current season relation

### DIFF
--- a/docs/v5/school.md
+++ b/docs/v5/school.md
@@ -23,9 +23,14 @@ Response:
   {
     "id": 1,
     "name": "Test School",
+    "current_season_id": 3,
     "season_settings": [
       { "key": "currency", "value": "CHF" }
     ]
   }
 ]
 ```
+
+Each school record includes `current_season_id` which references the
+active `Season` for that school. Use the `currentSeason` relationship on
+the `School` model to retrieve the full season object.


### PR DESCRIPTION
## Summary
- document `current_season_id` in school module documentation

## Testing
- `composer install --no-interaction`
- `php artisan test` *(fails: table `personal_access_tokens` already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6888e600f2f083208d77cbfbc9554696