### PR TITLE
chore: refine docs sync workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -6,6 +6,7 @@ on:
     branches: [ v5 ]
     paths:
       - 'docs/shared/**'
+      - 'docs/backend/**'
 
 jobs:
   sync:
@@ -19,41 +20,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Necesario para obtener historial completo
-          
-      - name: 🔍 Debug - Info del commit
-        run: |
-          echo "🏷️  Commit SHA: ${{ github.sha }}"
-          echo "💬 Commit message: ${{ github.event.head_commit.message }}"
-          echo "👤 Author: ${{ github.event.head_commit.author.name }}"
-          echo "📂 Changed files:"
-          git diff --name-only HEAD~1 HEAD
-          
-      - name: 📋 List docs/shared contents
-        run: |
-          echo "📁 Contents of docs/shared/:"
-          ls -la docs/shared/ || echo "⚠️  docs/shared/ directory not found"
-          
-      - name: 🚀 Push docs to frontend repo
+
+      - name: 🚀 Push shared docs to frontend repo
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.PAT_SYNC }}
         with:
           source-directory: 'docs/shared'
-          destination-github-username: 'sysantonio'
+          destination-github-username: '<OWNER>'
           destination-repository-name: 'boukii-admin-panel'
           target-branch: 'v5'
           destination-directory: 'docs/shared'
-          commit-message: |
-            docs-sync: mirror shared docs from backend → frontend
-            
-            Source commit: ${{ github.sha }}
-            Author: ${{ github.event.head_commit.author.name }}
-            Original message: ${{ github.event.head_commit.message }}
+          commit-message: 'docs-sync: mirror shared docs from backend → frontend'
           user-name: 'boukii-docs-sync-bot'
           user-email: 'noreply@boukii.com'
-          
-      - name: ✅ Sync completed
-        run: |
-          echo "🎉 Documentation sync completed successfully!"
-          echo "📝 Synced from: api-boukii/docs/shared/"
-          echo "📝 Synced to:   boukii-admin-panel/docs/shared/"
+
+      - name: 🚀 Push backend docs to frontend repo
+        if: ${{ false }}
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.PAT_SYNC }}
+        with:
+          source-directory: 'docs/backend'
+          destination-github-username: '<OWNER>'
+          destination-repository-name: 'boukii-admin-panel'
+          target-branch: 'v5'
+          destination-directory: 'docs/backend'
+          commit-message: 'docs-sync: mirror backend docs from backend → frontend'
+          user-name: 'boukii-docs-sync-bot'
+          user-email: 'noreply@boukii.com'


### PR DESCRIPTION
## Summary
- extend docs sync trigger to include backend docs
- drop debug/echo steps
- add optional backend docs sync step

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d9d0458888320a8a99ead4aa6897e