### PR TITLE
Add backend and front CI workflows

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,39 @@
+name: Backend CI
+
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!front/**'
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, pdo, sqlite, bcmath, intl
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist
+      - name: PHP lint
+        run: |
+          find app bootstrap config database routes tests -name "*.php" -print0 | xargs -0 -n1 php -l
+      - name: Static analysis
+        run: vendor/bin/phpstan analyse
+      - name: Run tests
+        run: |
+          mkdir -p test-reports
+          vendor/bin/phpunit --log-junit test-reports/phpunit.xml
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-reports
+          path: test-reports/phpunit.xml

--- a/.github/workflows/front-ci.yml
+++ b/.github/workflows/front-ci.yml
@@ -1,0 +1,45 @@
+name: Front CI
+
+on:
+  pull_request:
+    paths:
+      - 'front/**'
+
+jobs:
+  front:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: front/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm run test:ci
+      - name: Build
+        run: npm run build
+      - name: Build Storybook
+        run: npm run build:storybook
+      - name: Upload test coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: front-coverage
+          path: front/coverage
+      - name: Upload Storybook
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static
+          path: front/storybook-static


### PR DESCRIPTION
## Summary
- run PHP lint, static analysis and tests for backend PRs
- run npm lint, typecheck, tests, build and storybook for front PRs
- keep front and backend CI isolated via path filters

## Testing
- `composer install`
- `find app bootstrap config database routes tests -name "*.php" | head -n 50 | xargs -n1 php -l | tail -n 20`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/phpunit --log-junit test-reports/phpunit.xml` *(fails: errors)*
- `npm ci` *(terminated: partial output)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48d32d89c83208945eeb914865096