### PR TITLE
Implement per-user API rate limiting and document limits

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -42,7 +42,8 @@ class Kernel extends HttpKernel
 
         'api' => [
             \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
-            'throttle:5000,1',
+            'throttle:60,1',
+            'user.rate.limit',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];
@@ -69,6 +70,7 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'admin.rate.limit' => \App\Http\Middleware\AdminRateLimit::class,
+        'user.rate.limit' => \App\Http\Middleware\UserRateLimit::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         // V5 Middleware Aliases (cleaned up duplicates)
         'role.permission.middleware' => \App\Http\Middleware\V5\ContextPermissionMiddleware::class,

--- a/app/Http/Middleware/UserRateLimit.php
+++ b/app/Http/Middleware/UserRateLimit.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class UserRateLimit
+{
+    protected RateLimiter $limiter;
+
+    public function __construct(RateLimiter $limiter)
+    {
+        $this->limiter = $limiter;
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+        $key = 'user_rate_limit:'.($user?->id ?? $request->ip());
+
+        $maxAttempts = 60;
+        $decayMinutes = 1;
+
+        if ($this->limiter->tooManyAttempts($key, $maxAttempts)) {
+            $retryAfter = $this->limiter->availableIn($key);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Too many requests. Rate limit exceeded.',
+                'retry_after' => $retryAfter,
+            ], Response::HTTP_TOO_MANY_REQUESTS);
+        }
+
+        $this->limiter->hit($key, $decayMinutes * 60);
+
+        $response = $next($request);
+
+        $response->headers->add([
+            'X-RateLimit-Limit' => $maxAttempts,
+            'X-RateLimit-Remaining' => $this->limiter->remaining($key, $maxAttempts),
+            'X-RateLimit-Reset' => $this->limiter->availableIn($key) + time(),
+        ]);
+
+        return $response;
+    }
+}

--- a/docs/api/API_DOCUMENTATION.md
+++ b/docs/api/API_DOCUMENTATION.md
@@ -24,6 +24,12 @@ Authorization: Bearer {token}  # Para endpoints autenticados
 X-School-Slug: {school-slug}  # Para endpoints de booking
 ```
 
+## Limitación de Peticiones
+
+La API restringe a cada usuario autenticado a **60 solicitudes por minuto**.
+Las respuestas incluyen los encabezados `X-RateLimit-Limit`, `X-RateLimit-Remaining` y
+`X-RateLimit-Reset` para ayudar a monitorizar el consumo.
+
 ## Formato de Respuesta Estándar
 
 ### Respuesta Exitosa


### PR DESCRIPTION
## Summary
- reduce default API throttle to 60 requests per minute
- add user-specific rate limiting middleware
- document request limits in API docs

## Testing
- `./vendor/bin/pint app/Http/Kernel.php app/Http/Middleware/UserRateLimit.php`
- `./vendor/bin/phpunit` *(fails: EEEEE)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b4e2faec8320b19c8658daddbc8d