### PR TITLE
chore(backend): track composer.lock for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /storage/logs
 /vendor
 .phpunit.result.cache
-composer.lock
 
 # Environment files
 .env

--- a/composer.lock
+++ b/composer.lock
@@ -3631,12 +3631,12 @@
             "version": "2.72.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/briannesbitt/Carbon.git",
+                "url": "https://github.com/CarbonPHP/carbon.git",
                 "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
                 "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
                 "shasum": ""
             },
@@ -10692,12 +10692,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary
- ensure composer.lock is committed for reproducible builds
- remove composer.lock from .gitignore

## Testing
- `php artisan test` *(fails: Data Provider method ... is not static; many unit/feature tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ab8b6bf483208f3b414276e0cbad