### PR TITLE
fix(front): LoggingService productivo (env + headers + tests)

### DIFF
--- a/front/src/app/core/services/config.service.ts
+++ b/front/src/app/core/services/config.service.ts
@@ -14,6 +14,20 @@ export class ConfigService {
     this.runtime = cfg;
   }
 
+  /**
+   * Access the loaded runtime configuration if available
+   */
+  getRuntimeConfig(): RuntimeEnvironment | undefined {
+    return this.runtime;
+  }
+
+  /**
+   * Retrieve application version from runtime config or environment
+   */
+  getAppVersion(): string | undefined {
+    return this.runtime?.version || (environment as any)?.appVersion;
+  }
+
   /** Versioned API base URL (e.g. http://api-boukii.test/api/v5) */
   getApiBaseUrl(): string {
     const fromRuntime = this.runtime?.api?.baseUrl;

--- a/front/src/app/core/services/logging.service.spec.ts
+++ b/front/src/app/core/services/logging.service.spec.ts
@@ -1,0 +1,109 @@
+import { TestBed } from '@angular/core/testing';
+import { LoggingService, LogPayload } from './logging.service';
+import { ApiService } from './api.service';
+import { EnvironmentService } from './environment.service';
+import { ConfigService } from './config.service';
+
+describe('LoggingService', () => {
+  let service: LoggingService;
+  let api: { postWithHeaders: jest.Mock };
+  let env: { isProduction: jest.Mock; envName: jest.Mock };
+  let config: { getRuntimeConfig: jest.Mock; getAppVersion: jest.Mock };
+
+  beforeEach(() => {
+    api = { postWithHeaders: jest.fn().mockResolvedValue(undefined) };
+    env = { isProduction: jest.fn(), envName: jest.fn() };
+    config = { getRuntimeConfig: jest.fn(), getAppVersion: jest.fn() };
+
+    (global as any).location = { href: 'http://test.local' };
+    (global as any).navigator = { userAgent: 'jest' };
+
+    TestBed.configureTestingModule({
+      providers: [
+        LoggingService,
+        { provide: ApiService, useValue: api },
+        { provide: EnvironmentService, useValue: env },
+        { provide: ConfigService, useValue: config },
+      ],
+    });
+
+    service = TestBed.inject(LoggingService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs to console in dev without network', () => {
+    env.isProduction.mockReturnValue(false);
+    env.envName.mockReturnValue('development');
+    config.getRuntimeConfig.mockReturnValue({ logging: { enabled: true } });
+    config.getAppVersion.mockReturnValue('1.0.0');
+
+    const spy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    service.info('hello', { x: 1 });
+
+    expect(api.postWithHeaders).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'info',
+        message: 'hello',
+        env: 'development',
+        context: { x: 1 },
+      })
+    );
+  });
+
+  it('sends logs to API in production with headers', () => {
+    env.isProduction.mockReturnValue(true);
+    env.envName.mockReturnValue('production');
+    config.getRuntimeConfig.mockReturnValue({ logging: { enabled: true } });
+    config.getAppVersion.mockReturnValue('2.3.4');
+
+    service.error('boom');
+
+    expect(api.postWithHeaders).toHaveBeenCalledTimes(1);
+    const [url, payload, headers] = api.postWithHeaders.mock.calls[0];
+    expect(url).toBe('/logs');
+    expect((payload as LogPayload).level).toBe('error');
+    expect(headers['X-App-Version']).toBe('2.3.4');
+    expect(headers['X-Env']).toBe('production');
+    expect(new Date((payload as LogPayload).timestamp).toISOString()).toBe(
+      (payload as LogPayload).timestamp
+    );
+  });
+
+  it('can force network logging in dev', () => {
+    env.isProduction.mockReturnValue(false);
+    env.envName.mockReturnValue('development');
+    config.getRuntimeConfig.mockReturnValue({
+      logging: { enabled: true, forceNetworkInDev: true },
+    });
+
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    service.warn('check');
+
+    expect(spy).toHaveBeenCalled();
+    expect(api.postWithHeaders).toHaveBeenCalled();
+  });
+
+  it('respects logging.enabled === false', () => {
+    env.isProduction.mockReturnValue(true);
+    env.envName.mockReturnValue('production');
+    config.getRuntimeConfig.mockReturnValue({ logging: { enabled: false } });
+
+    service.error('ignored');
+
+    expect(api.postWithHeaders).not.toHaveBeenCalled();
+  });
+
+  it('swallows network errors', async () => {
+    env.isProduction.mockReturnValue(true);
+    env.envName.mockReturnValue('production');
+    config.getRuntimeConfig.mockReturnValue({ logging: { enabled: true } });
+    api.postWithHeaders.mockRejectedValueOnce(new Error('fail'));
+
+    expect(() => service.error('boom')).not.toThrow();
+  });
+});
+

--- a/front/src/app/core/services/logging.service.ts
+++ b/front/src/app/core/services/logging.service.ts
@@ -1,218 +1,137 @@
-import { Injectable, inject } from '@angular/core';
-import { AuthStore } from '../stores/auth.store';
-import { ErrorLogEntry, ErrorContext, ErrorSeverity, ErrorResponse } from '../models/error.models';
-import { LogLevel } from '../models/environment.models';
+import { Injectable, inject, PLATFORM_ID, Injector } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { ApiService } from './api.service';
+import { EnvironmentService } from './environment.service';
+import { ConfigService } from './config.service';
+import type { ErrorContext, ErrorResponse } from '../models/error.models';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
+
+export interface LogContext {
+  [key: string]: unknown;
+}
+
+export interface LogPayload {
+  level: LogLevel;
+  message: string;
+  context?: LogContext;
+  timestamp: string;
+  env: string;
+  appVersion?: string;
+  url?: string;
+  userId?: string | number;
+  schoolId?: string | number;
+  seasonId?: string | number;
+  ua?: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class LoggingService {
-  private readonly auth = inject(AuthStore);
-  private readonly logBuffer: ErrorLogEntry[] = [];
-  private readonly maxBufferSize = 100;
-  private currentLogLevel: LogLevel = 'info';
   private readonly api = inject(ApiService);
+  private readonly config = inject(ConfigService);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly injector = inject(Injector);
 
-  /**
-   * Log an error with full context
-   */
+  private get env(): EnvironmentService {
+    return this.injector.get(EnvironmentService);
+  }
+
+  private currentLogLevel: LogLevel = 'info';
+
+  log(level: LogLevel, message: string, context: LogContext = {}): void {
+    const envName = this.env.envName();
+    const appVersion = this.config.getAppVersion?.();
+
+    const payload: LogPayload = {
+      level,
+      message,
+      context: Object.keys(context).length ? context : undefined,
+      timestamp: new Date().toISOString(),
+      env: envName,
+      appVersion: appVersion || undefined,
+      url: isPlatformBrowser(this.platformId) ? window.location.href : undefined,
+      ua: isPlatformBrowser(this.platformId) ? navigator.userAgent : undefined,
+    };
+
+    const runtime = this.config.getRuntimeConfig?.();
+    const loggingCfg = (runtime as any)?.logging || {};
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Env': envName,
+    };
+    if (appVersion) {
+      headers['X-App-Version'] = appVersion;
+    }
+
+    const endpoint = loggingCfg.endpoint || '/logs';
+    const shouldSend =
+      (this.env.isProduction() && loggingCfg.enabled !== false) ||
+      (!this.env.isProduction() && loggingCfg.forceNetworkInDev === true);
+
+    if (shouldSend) {
+      void this.api
+        .postWithHeaders(endpoint, payload, headers)
+        .catch((err) => {
+          if (!this.env.isProduction()) {
+            console.error('Failed to send log', err);
+          }
+        });
+    }
+
+    if (!this.env.isProduction() || loggingCfg.enabled === false) {
+      const fn = (console as any)[level] || console.log;
+      fn(payload);
+    }
+  }
+
+  debug(message: string, context?: LogContext): void {
+    this.log('debug', message, context);
+  }
+
+  info(message: string, context?: LogContext): void {
+    this.log('info', message, context);
+  }
+
+  warn(message: string, context?: LogContext): void {
+    this.log('warn', message, context);
+  }
+
+  error(message: string, context?: LogContext): void {
+    this.log('error', message, context);
+  }
+
+  // Legacy wrapper methods
+  logInfo(message: string, context?: LogContext): void {
+    this.info(message, context);
+  }
+
+  logWarning(message: string, context?: LogContext): void {
+    this.warn(message, context);
+  }
+
   logError(
     message: string,
-    error: ErrorResponse,
-    context: Partial<ErrorContext>,
+    error?: ErrorResponse,
+    context?: Partial<ErrorContext>,
     userFriendlyMessage?: string
   ): void {
-    const logEntry: ErrorLogEntry = {
-      id: this.generateId(),
-      timestamp: new Date(),
-      level: 'error',
-      message,
-      context: this.buildErrorContext(context),
-      error,
-      handled: true,
-      userFriendlyMessage,
-    };
-
-    this.addToBuffer(logEntry);
-    this.writeToConsole(logEntry);
-
-    // In production, you would send this to your logging service
-    if (this.isProduction() && this.shouldSendToServer(logEntry)) {
-      this.sendToLoggingService(logEntry);
+    const ctx: LogContext = { ...(context || {}) };
+    if (error) {
+      (ctx as any).error = error;
     }
-  }
-
-  /**
-   * Log a warning
-   */
-  logWarning(message: string, context?: Partial<ErrorContext>): void {
-    const logEntry: ErrorLogEntry = {
-      id: this.generateId(),
-      timestamp: new Date(),
-      level: 'warn',
-      message,
-      context: this.buildErrorContext(context || {}),
-      error: { type: 'warning', title: 'Warning', detail: message, code: 'WARNING' },
-      handled: true,
-    };
-
-    this.addToBuffer(logEntry);
-    console.warn(`[${logEntry.timestamp.toISOString()}] ${message}`, logEntry.context);
-  }
-
-  /**
-   * Log info message
-   */
-  logInfo(message: string, context?: Partial<ErrorContext>): void {
-    const logEntry: ErrorLogEntry = {
-      id: this.generateId(),
-      timestamp: new Date(),
-      level: 'info',
-      message,
-      context: this.buildErrorContext(context || {}),
-      error: { type: 'info', title: 'Info', detail: message, code: 'INFO' },
-      handled: true,
-    };
-
-    this.addToBuffer(logEntry);
-    console.info(`[${logEntry.timestamp.toISOString()}] ${message}`, logEntry.context);
-  }
-
-  /**
-   * Get recent logs (for debugging or error reports)
-   */
-  getRecentLogs(count = 50): ErrorLogEntry[] {
-    return this.logBuffer.slice(-count);
-  }
-
-  /**
-   * Clear log buffer
-   */
-  clearLogs(): void {
-    this.logBuffer.length = 0;
-  }
-
-  /**
-   * Export logs for support/debugging
-   */
-  exportLogs(): string {
-    return JSON.stringify(this.logBuffer, null, 2);
-  }
-
-  private buildErrorContext(partialContext: Partial<ErrorContext>): ErrorContext {
-    const currentUser = this.auth.user();
-
-    return {
-      url: partialContext.url || window.location.href,
-      method: partialContext.method || 'UNKNOWN',
-      userId: currentUser?.id,
-      sessionId: this.getSessionId(),
-      userAgent: navigator.userAgent,
-      timestamp: new Date(),
-      requestId: partialContext.requestId || this.generateId(),
-      severity: partialContext.severity || ErrorSeverity.MEDIUM,
-    };
-  }
-
-  private addToBuffer(logEntry: ErrorLogEntry): void {
-    this.logBuffer.push(logEntry);
-
-    // Keep buffer size manageable
-    if (this.logBuffer.length > this.maxBufferSize) {
-      this.logBuffer.shift();
+    if (userFriendlyMessage) {
+      (ctx as any).userFriendlyMessage = userFriendlyMessage;
     }
+    this.error(message, ctx);
   }
 
-  private writeToConsole(logEntry: ErrorLogEntry): void {
-    const timestamp = logEntry.timestamp.toISOString();
-    const prefix = `[${timestamp}] [${logEntry.level.toUpperCase()}]`;
-
-    switch (logEntry.level) {
-      case 'error':
-        console.error(`${prefix} ${logEntry.message}`, {
-          error: logEntry.error,
-          context: logEntry.context,
-          userMessage: logEntry.userFriendlyMessage,
-        });
-        break;
-      case 'warn':
-        console.warn(`${prefix} ${logEntry.message}`, logEntry.context);
-        break;
-      case 'info':
-        console.info(`${prefix} ${logEntry.message}`, logEntry.context);
-        break;
-    }
-  }
-
-  private shouldSendToServer(logEntry: ErrorLogEntry): boolean {
-    // Only send errors and high-severity warnings to server
-    return (
-      logEntry.level === 'error' ||
-      (logEntry.level === 'warn' && logEntry.context.severity === ErrorSeverity.HIGH)
-    );
-  }
-
-  private async sendToLoggingService(logEntry: ErrorLogEntry): Promise<void> {
-    try {
-      // In a real app, send to your logging endpoint
-      await this.api.post('/logs', JSON.stringify(logEntry))
-
-    } catch (error) {
-      // Fallback: don't create infinite loops
-      console.error('Failed to send log to server:', error);
-    }
-  }
-
-  private generateId(): string {
-    return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-  }
-
-  private getSessionId(): string {
-    // In a real app, this might come from a session service
-    let sessionId = sessionStorage.getItem('session_id');
-    if (!sessionId) {
-      sessionId = this.generateId();
-      sessionStorage.setItem('session_id', sessionId);
-    }
-    return sessionId;
-  }
-
-  private isProduction(): boolean {
-    return false;
-/*
-    return !['development', 'local'].includes(window.location.hostname);
-*/
-  }
-
-  /**
-   * Set the current log level
-   */
   setLogLevel(level: LogLevel): void {
     this.currentLogLevel = level;
-    console.log(`Log level set to: ${level}`);
   }
 
-  /**
-   * Get the current log level
-   */
   getLogLevel(): LogLevel {
     return this.currentLogLevel;
   }
-
-  /**
-   * Check if a log level should be output
-   */
-  private shouldLog(level: 'debug' | 'info' | 'warn' | 'error'): boolean {
-    const levels: Record<LogLevel, number> = {
-      debug: 0,
-      info: 1,
-      warn: 2,
-      error: 3,
-      none: 4,
-    };
-
-    const currentLevelNumber = levels[this.currentLogLevel];
-    const logLevelNumber = levels[level];
-
-    return logLevelNumber >= currentLevelNumber;
-  }
 }
+

--- a/front/src/assets/config/runtime-config.develop.json
+++ b/front/src/assets/config/runtime-config.develop.json
@@ -47,7 +47,10 @@
   "logging": {
     "level": "info",
     "console": true,
-    "remote": true
+    "remote": true,
+    "endpoint": "/logs",
+    "forceNetworkInDev": false,
+    "enabled": true
   },
   "external": {
     "analytics": {

--- a/front/src/assets/config/runtime-config.development.json
+++ b/front/src/assets/config/runtime-config.development.json
@@ -126,6 +126,12 @@
     "currency": "EUR"
   },
 
+  "logging": {
+    "endpoint": "/logs",
+    "forceNetworkInDev": false,
+    "enabled": true
+  },
+
   "integrations": {
     "google": {
       "maps": "your-google-maps-api-key-dev"

--- a/front/src/assets/config/runtime-config.json
+++ b/front/src/assets/config/runtime-config.json
@@ -126,6 +126,12 @@
     "currency": "EUR"
   },
 
+  "logging": {
+    "endpoint": "/logs",
+    "forceNetworkInDev": false,
+    "enabled": true
+  },
+
   "integrations": {
     "google": {
       "maps": "your-google-maps-api-key-dev"

--- a/front/src/assets/config/runtime-config.local.json
+++ b/front/src/assets/config/runtime-config.local.json
@@ -47,7 +47,10 @@
   "logging": {
     "level": "debug",
     "console": true,
-    "remote": false
+    "remote": false,
+    "endpoint": "/logs",
+    "forceNetworkInDev": false,
+    "enabled": true
   },
   "external": {
     "analytics": {

--- a/front/src/assets/config/runtime-config.production.json
+++ b/front/src/assets/config/runtime-config.production.json
@@ -127,6 +127,12 @@
     "currency": "EUR"
   },
 
+  "logging": {
+    "endpoint": "/logs",
+    "forceNetworkInDev": false,
+    "enabled": true
+  },
+
   "integrations": {
     "firebase": {
       "apiKey": "AIzaSyBvOkBNaYUWN7YLNLdnKhYSThjEQrBOsXY",

--- a/front/src/assets/config/runtime-config.staging.json
+++ b/front/src/assets/config/runtime-config.staging.json
@@ -127,6 +127,12 @@
     "currency": "EUR"
   },
 
+  "logging": {
+    "endpoint": "/logs",
+    "forceNetworkInDev": false,
+    "enabled": true
+  },
+
   "integrations": {
     "firebase": {
       "apiKey": "AIzaSyBvOkBNaYUWN7YLNLdnKhYSThjEQrBOsXY",

--- a/front/src/assets/config/runtime-config.test.json
+++ b/front/src/assets/config/runtime-config.test.json
@@ -126,5 +126,11 @@
     "currency": "EUR"
   },
 
+  "logging": {
+    "endpoint": "/logs",
+    "forceNetworkInDev": false,
+    "enabled": true
+  },
+
   "integrations": {}
 }


### PR DESCRIPTION
## Resumen
- Implementa LoggingService con detección de entorno y envío de cabeceras `X-App-Version` y `X-Env`
- Expone getters en ConfigService para versión y runtime config
- Añade configuración de `logging` en los runtime-configs
- Crea tests unitarios para flujos de logging en prod/dev

## Ejemplos de payload
```json
{
  "level": "error",
  "message": "boom",
  "timestamp": "2025-08-20T00:00:00.000Z",
  "env": "production",
  "appVersion": "5.0.0",
  "url": "https://app.example.com/dashboard",
  "ua": "Mozilla/5.0 ..."
}
```

## Cómo forzar red en dev
En `src/assets/config/runtime-config.json`:
```json
"logging": {
  "forceNetworkInDev": true
}
```


------
https://chatgpt.com/codex/tasks/task_e_68a5b083d81883208926848e51428531