### PR TITLE
fix(db): SQLite CI compat for schools schema (slug/active)

### DIFF
--- a/database/migrations/2000_01_01_000050_ci_compat_add_slug_active_to_schools.php
+++ b/database/migrations/2000_01_01_000050_ci_compat_add_slug_active_to_schools.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('schools')) {
+            Schema::table('schools', function (Blueprint $table) {
+                // slug (unique) si falta
+                if (! Schema::hasColumn('schools', 'slug')) {
+                    $table->string('slug')->nullable()->unique()->after('name');
+                }
+                // active (bool) si falta
+                if (! Schema::hasColumn('schools', 'active')) {
+                    $table->boolean('active')->default(true)->after('slug');
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('schools')) {
+            Schema::table('schools', function (Blueprint $table) {
+                if (Schema::hasColumn('schools', 'active')) {
+                    $table->dropColumn('active');
+                }
+                if (Schema::hasColumn('schools', 'slug')) {
+                    // Algunos SQLite no soportan dropUnique por nombre; el dropColumn es suficiente en CI
+                    $table->dropColumn('slug');
+                }
+            });
+        }
+    }
+};

--- a/database/seeders/CiSmokeSeeder.php
+++ b/database/seeders/CiSmokeSeeder.php
@@ -24,6 +24,8 @@ class CiSmokeSeeder extends Seeder
         // Escuela
         $schoolId = DB::table('schools')->insertGetId([
             'name' => 'CI School',
+            'slug' => 'ci-school',
+            'active' => true,
             'created_at' => now(),
             'updated_at' => now(),
         ]);


### PR DESCRIPTION
## Summary
- ensure `schools` table has `slug` and `active` columns in CI using guarded migration
- seed `slug` and `active` fields for CI smoke tests

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=$(pwd)/database/database.sqlite php artisan migrate:fresh --force`
- `DB_CONNECTION=sqlite DB_DATABASE=$(pwd)/database/database.sqlite php artisan db:seed --force --class=CiSmokeSeeder`
- `DB_CONNECTION=sqlite DB_DATABASE=$(pwd)/database/database.sqlite php artisan tinker --execute="echo Schema::hasColumn('schools','slug') ? 'ok' : 'missing';"`
- `DB_CONNECTION=sqlite DB_DATABASE=$(pwd)/database/database.sqlite php artisan tinker --execute="echo Schema::hasColumn('schools','active') ? 'ok' : 'missing';"`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=$(pwd)/database/database.sqlite php artisan test --testsuite=Ci --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a5b39f774483209a21a56bd02b8ec5