### PR TITLE
ci: quarantine phpunit-full (run only with run-full-suite label)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -99,8 +99,9 @@ jobs:
         run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 
   phpunit-full:
-    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run-full-suite')
     needs: backend
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run `phpunit-full` job only when PR is labeled `run-full-suite`

## Testing
- `composer validate --quiet`
- `yamllint .github/workflows/backend-ci.yml` *(fails: line-length, commas, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a5c998215c8320830639cd1e4a2f11