### PR TITLE
test(front): verify runtime config override precedence

### DIFF
--- a/front/src/app/core/services/config.service.spec.ts
+++ b/front/src/app/core/services/config.service.spec.ts
@@ -1,0 +1,20 @@
+import { ConfigService } from './config.service';
+
+describe('ConfigService runtime override', () => {
+  it('uses runtime config over environment defaults', () => {
+    const service = new ConfigService();
+
+    // Baseline from environment configuration
+    expect(service.getApiBaseUrl()).toBe('http://api-boukii.test/api/v5');
+
+    // Mock runtime-config.json with a different API URL
+    service.setRuntimeConfig(
+      {
+        api: { baseUrl: 'http://runtime.example', version: 'v9' },
+      } as any
+    );
+
+    // The runtime configuration should take precedence
+    expect(service.getApiBaseUrl()).toBe('http://runtime.example/api/v9');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test ensuring ConfigService prefers runtime config over environment defaults

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb1cf3008320a7840f3b92f75097