### PR TITLE
fix(shell): restore design & make collapse usable in all states (light/dark)

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -36,6 +36,7 @@
         "@storybook/angular": "^8.6.14",
         "@storybook/builder-vite": "^8.6.14",
         "@storybook/manager-api": "^8.6.14",
+        "@storybook/testing-library": "^0.2.1",
         "@storybook/theming": "^8.6.14",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.2",
@@ -7595,6 +7596,97 @@
         "storybook": "^8.6.14"
       }
     },
+    "node_modules/@storybook/testing-library": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.2.1.tgz",
+      "integrity": "sha512-AdbfLCm1C2nEFrhA3ScdicfW6Fjcorehr6RlGwECMiWwaXisnP971Wd4psqtWxlAqQo4tYBZ0f6rJ3J78JLtsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "^9.0.0",
+        "@testing-library/user-event": "~14.4.0",
+        "ts-dedent": "^2.2.0"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@storybook/theming": {
       "version": "8.6.14",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.14.tgz",
@@ -9854,6 +9946,23 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-flatten": {
@@ -12130,6 +12239,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -12212,6 +12361,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -12754,6 +12921,34 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -14341,6 +14536,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -14674,6 +14879,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-flag": {
@@ -15353,6 +15571,21 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
@@ -15387,11 +15620,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -15403,6 +15670,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-callable": {
@@ -15424,6 +15708,23 @@
       "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15553,6 +15854,19 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-network-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
@@ -15572,6 +15886,23 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -15637,6 +15968,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -15647,6 +16007,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-text-path": {
@@ -15692,6 +16087,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-what": {
@@ -19979,6 +20404,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -21247,6 +21720,27 @@
       "integrity": "sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==",
       "dev": true
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexpu-core": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
@@ -22033,6 +22527,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -22658,6 +23168,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/storybook": {
@@ -25114,6 +25638,45 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-typed-array": {

--- a/front/package.json
+++ b/front/package.json
@@ -129,13 +129,10 @@
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/angular": "^8.6.14",
-    "@storybook/builder-vite": "^8.6.14",
     "@storybook/manager-api": "^8.6.14",
-    "@storybook/testing-library": "^0.2.1",
     "@storybook/theming": "^8.6.14",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/user-event": "^14.5.2",
+    "@storybook/builder-vite": "^8.6.14",
+    "@storybook/testing-library": "^0.2.1",
     "@types/jasmine": "~5.1.0",
     "@types/jest": "^29.5.12",
     "angular-eslint": "20.1.1",
@@ -161,8 +158,11 @@
     "storybook": "^8.6.14",
     "ts-jest": "^29.1.1",
     "typescript": "^5.4.0",
-    "typescript-eslint": "8.34.1",
     "vite": "^5.0.0",
-    "vite-tsconfig-paths": "^4.2.0"
+    "vite-tsconfig-paths": "^4.2.0",
+    "typescript-eslint": "8.34.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/user-event": "^14.5.2"
   }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -129,9 +129,13 @@
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/angular": "^8.6.14",
-    "@storybook/manager-api": "^8.6.14",
-    "@storybook/theming": "^8.6.14",
     "@storybook/builder-vite": "^8.6.14",
+    "@storybook/manager-api": "^8.6.14",
+    "@storybook/testing-library": "^0.2.1",
+    "@storybook/theming": "^8.6.14",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jasmine": "~5.1.0",
     "@types/jest": "^29.5.12",
     "angular-eslint": "20.1.1",
@@ -157,11 +161,8 @@
     "storybook": "^8.6.14",
     "ts-jest": "^29.1.1",
     "typescript": "^5.4.0",
-    "vite": "^5.0.0",
-    "vite-tsconfig-paths": "^4.2.0",
     "typescript-eslint": "8.34.1",
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/user-event": "^14.5.2"
+    "vite": "^5.0.0",
+    "vite-tsconfig-paths": "^4.2.0"
   }
 }

--- a/front/src/app/core/services/theme.service.ts
+++ b/front/src/app/core/services/theme.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, signal, computed, effect } from '@angular/core';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 export type Theme = 'light' | 'dark' | 'system';
 
@@ -24,7 +25,7 @@ export class ThemeService {
     return theme;
   });
 
-  constructor() {
+  constructor(private overlay: OverlayContainer) {
     // Effect para aplicar el tema al DOM cuando cambie
     effect(() => {
       const theme = this.effectiveTheme();
@@ -146,6 +147,10 @@ export class ThemeService {
       detail: { theme, previous: theme === 'light' ? 'dark' : 'light' },
     });
     document.dispatchEvent(event);
+
+    // Propagar data-theme al contenedor de overlays para que herede las variables
+    const el = this.overlay.getContainerElement();
+    el.setAttribute('data-theme', theme);
   }
 
   /**

--- a/front/src/app/core/stores/ui.store.ts
+++ b/front/src/app/core/stores/ui.store.ts
@@ -17,7 +17,7 @@ function getStoredTheme(): Theme {
 // Helper to get stored sidebar state with fallback
 function getStoredSidebarState(): boolean {
   if (typeof localStorage === 'undefined') return false;
-  const stored = localStorage.getItem('sidebar-collapsed');
+  const stored = localStorage.getItem('sidebarCollapsed');
   return stored === 'true';
 }
 
@@ -47,7 +47,7 @@ export class UiStore {
     this._sidebarCollapsed.set(newState);
     // Persist sidebar state
     if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('sidebar-collapsed', String(newState));
+      localStorage.setItem('sidebarCollapsed', String(newState));
     }
   }
 
@@ -55,7 +55,7 @@ export class UiStore {
     this._sidebarCollapsed.set(collapsed);
     // Persist sidebar state
     if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('sidebar-collapsed', String(collapsed));
+      localStorage.setItem('sidebarCollapsed', String(collapsed));
     }
   }
 

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -37,7 +37,7 @@ interface Notification {
     <!-- Show full layout only when authenticated and has school selected -->
     @if (shouldShowFullLayout()) {
       {{ logFullLayoutRender() }}
-      <div class="app-shell" [class.sidebar-collapsed]="sidebarCollapsed()">
+      <div class="app-shell" [class.app-sidebar--collapsed]="sidebarCollapsed()">
         
         <!-- NAVBAR -->
         <header class="app-navbar" role="banner">
@@ -312,155 +312,151 @@ interface Notification {
         </header>
 
         <!-- SIDEBAR -->
-        <aside class="app-sidebar" [class.collapsed]="sidebarCollapsed()" role="navigation" [attr.aria-label]="'nav.mainNavigation' | translate">
+        <aside class="app-sidebar" [class.app-sidebar--collapsed]="sidebarCollapsed()" role="navigation" [attr.aria-label]="'nav.mainNavigation' | translate">
           <!-- Sidebar Header -->
           <div class="sidebar-header">
-            <div class="sidebar-logo">
-              <span class="logo-text">bouk<span class="logo-accent">ii</span></span>
-            </div>
-            <button 
-              class="sidebar-toggle"
+            <img class="logo" src="assets/logo.svg" alt="boukii" />
+            <button
+              class="collapse"
+              type="button"
               (click)="toggleSidebar()"
-              [attr.aria-label]="sidebarCollapsed() ? 'Expand sidebar' : 'Collapse sidebar'"
-              [title]="sidebarCollapsed() ? 'Expand sidebar' : 'Collapse sidebar'"
+              aria-label="Colapsar/Expandir"
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" [class.rotated]="sidebarCollapsed()">
-                <polyline points="15,18 9,12 15,6"></polyline>
-              </svg>
+              <i class="chev" [class.rot]="sidebarCollapsed()"></i>
             </button>
           </div>
 
           <!-- Navigation Menu -->
           <nav class="sidebar-nav">              
             <!-- Dashboard -->
-            <a href="#" class="nav-item active" role="menuitem" aria-current="page" [title]="sidebarCollapsed() ? 'Dashboard' : null">
+            <a href="#" class="nav-item item active" role="menuitem" aria-current="page" [title]="sidebarCollapsed() ? 'Dashboard' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>
                 </svg>
               </div>
-              <span class="nav-text">Dashboard</span>
-              <span class="badge badge--yellow">3</span>
+              <span class="nav-text label">Dashboard</span>
+              <span class="badge counter counter--yellow">3</span>
             </a>
 
             <!-- Reservas -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Reservas' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Reservas' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
                 </svg>
               </div>
-              <span class="nav-text">Reservas</span>
-              <span class="badge badge--blue">12</span>
+              <span class="nav-text label">Reservas</span>
+              <span class="badge counter counter--blue">12</span>
             </a>
 
             <!-- Clientes -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Clientes' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Clientes' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
                 </svg>
               </div>
-              <span class="nav-text">Clientes</span>
-              <span class="badge badge--green">8</span>
+              <span class="nav-text label">Clientes</span>
+              <span class="badge counter counter--green">8</span>
             </a>
 
             <!-- Planificador -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Planificador' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Planificador' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
                 </svg>
               </div>
-              <span class="nav-text">Planificador</span>
-              <span class="badge badge--red">2</span>
+              <span class="nav-text label">Planificador</span>
+              <span class="badge counter counter--red">2</span>
             </a>
 
             <!-- Instructores -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Instructores' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Instructores' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                 </svg>
               </div>
-              <span class="nav-text">Instructores</span>
-              <span class="badge badge--green">5</span>
+              <span class="nav-text label">Instructores</span>
+              <span class="badge counter counter--green">5</span>
             </a>
 
             <!-- Cursos -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Cursos y Actividades' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Cursos y Actividades' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"/>
                 </svg>
               </div>
-              <span class="nav-text">Cursos y Actividades</span>
-              <span class="badge badge--blue">15</span>
+              <span class="nav-text label">Cursos y Actividades</span>
+              <span class="badge counter counter--blue">15</span>
             </a>
 
             <!-- Material -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Alquiler de Material' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Alquiler de Material' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
                 </svg>
               </div>
-              <span class="nav-text">Alquiler de Material</span>
-              <span class="badge badge--yellow">4</span>
+              <span class="nav-text label">Alquiler de Material</span>
+              <span class="badge counter counter--yellow">4</span>
             </a>
 
             <!-- Bonos -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Bonos y códigos' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Bonos y códigos' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M4 4h16v2H4zm0 5h16v6H4zm0 11h16v-2H4z"/>
                 </svg>
               </div>
-              <span class="nav-text">Bonos y códigos</span>
-              <span class="badge badge--green">7</span>
+              <span class="nav-text label">Bonos y códigos</span>
+              <span class="badge counter counter--green">7</span>
             </a>
 
             <!-- Comunicación -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Comunicación' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Comunicación' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h4v6l4-3 4 3v-6h4c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
                 </svg>
               </div>
-              <span class="nav-text">Comunicación</span>
-              <span class="badge badge--red">3</span>
+              <span class="nav-text label">Comunicación</span>
+              <span class="badge counter counter--red">3</span>
             </a>
 
             <!-- Pagos -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Pagos' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Pagos' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"/>
                 </svg>
               </div>
-              <span class="nav-text">Pagos</span>
-              <span class="badge badge--blue">11</span>
+              <span class="nav-text label">Pagos</span>
+              <span class="badge counter counter--blue">11</span>
             </a>
 
             <!-- Reportes -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Reportes' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Reportes' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"/>
                 </svg>
               </div>
-              <span class="nav-text">Reportes</span>
-              <span class="badge badge--green">2</span>
+              <span class="nav-text label">Reportes</span>
+              <span class="badge counter counter--green">2</span>
             </a>
 
             <!-- Configuración -->
-            <a href="#" class="nav-item" role="menuitem" [title]="sidebarCollapsed() ? 'Configuración' : null">
+            <a href="#" class="nav-item item" role="menuitem" [title]="sidebarCollapsed() ? 'Configuración' : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5 3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97 0-.33-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1 0 .33.03.65.07.97L2.46 14.6c-.19.15-.24.42-.12.64l2 3.46c.12.22.39.31.61.22l2.49-1c.52.39 1.06.73 1.69.98l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.25 1.17-.59 1.69-.98l2.49 1c.22.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.66Z"/>
                 </svg>
               </div>
-              <span class="nav-text">Configuración</span>
+              <span class="nav-text label">Configuración</span>
             </a>
           </nav>
 
@@ -607,7 +603,7 @@ export class AppShellComponent implements OnInit {
     this.ui.initializeTheme();
 
     // Load sidebar collapsed state from localStorage
-    const sidebarState = localStorage.getItem('sidebar-collapsed');
+    const sidebarState = localStorage.getItem('sidebarCollapsed');
     if (sidebarState) {
       this._sidebarCollapsed.set(JSON.parse(sidebarState));
     }
@@ -639,7 +635,7 @@ export class AppShellComponent implements OnInit {
   toggleSidebar(): void {
     const newState = !this._sidebarCollapsed();
     this._sidebarCollapsed.set(newState);
-    localStorage.setItem('sidebar-collapsed', JSON.stringify(newState));
+    localStorage.setItem('sidebarCollapsed', JSON.stringify(newState));
   }
 
   // Language management

--- a/front/src/app/ui/app-shell/app-shell.stories.ts
+++ b/front/src/app/ui/app-shell/app-shell.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata, applicationConfig } from '@storybook/angular';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
+import { within, userEvent } from '@storybook/testing-library';
 
 import { AppShellComponent } from './app-shell.component';
 import { UiStore } from '@core/stores/ui.store';
@@ -13,31 +14,17 @@ import { EnvironmentService } from '@core/services/environment.service';
 
 class MockTranslationService {
   private lang: SupportedLanguage = 'es';
-
-  currentLanguage(): SupportedLanguage {
-    return this.lang;
-  }
-
-  setLanguage(lang: SupportedLanguage): void {
-    this.lang = lang;
-  }
-
-  get(key: string): string {
-    return key;
-  }
-
-  instant(key: string): string {
-    return key;
-  }
+  currentLanguage(): SupportedLanguage { return this.lang; }
+  setLanguage(lang: SupportedLanguage): void { this.lang = lang; }
+  get(key: string): string { return key; }
+  instant(key: string): string { return key; }
 }
 
 const meta: Meta<AppShellComponent> = {
   title: 'App/AppShell',
   component: AppShellComponent,
   decorators: [
-    moduleMetadata({
-      imports: [AppShellComponent],
-    }),
+    moduleMetadata({ imports: [AppShellComponent] }),
     applicationConfig({
       providers: [
         provideAnimations(),
@@ -45,7 +32,7 @@ const meta: Meta<AppShellComponent> = {
         { provide: UiStore, useValue: { initializeTheme: () => {} } },
         { provide: AuthStore, useValue: { loadMe: () => {} } },
         { provide: LoadingStore, useValue: { isLoading: () => false, longestRunningRequest: () => null } },
-        { provide: AuthV5Service, useValue: { isAuthenticated: () => true, currentSchool: () => ({}), currentSchoolIdSignal: () => 1, user: () => ({ name: 'Test User' }) } },
+        { provide: AuthV5Service, useValue: { isAuthenticated: () => true, currentSchool: () => ({}), currentSchoolIdSignal: () => 1, user: () => ({ name: 'Test User' }), permissions: () => [] } },
         { provide: TranslationService, useClass: MockTranslationService },
         { provide: EnvironmentService, useValue: { isProduction: () => true, envName: () => 'production' } },
       ],
@@ -60,34 +47,39 @@ const meta: Meta<AppShellComponent> = {
 export default meta;
 type Story = StoryObj<AppShellComponent>;
 
-export const Default: Story = {
-  render: () => {
-    localStorage.clear();
-    return { template: `<app-shell></app-shell>` };
+function setup(theme: 'light' | 'dark', collapsed: boolean) {
+  localStorage.setItem('theme', theme);
+  localStorage.setItem('sidebarCollapsed', JSON.stringify(collapsed));
+  return { template: `<app-shell></app-shell>` };
+}
+
+export const DefaultLight: Story = {
+  render: () => setup('light', false),
+};
+
+export const DefaultDark: Story = {
+  render: () => setup('dark', false),
+};
+
+export const CollapsedLight: Story = {
+  render: () => setup('light', true),
+};
+
+export const CollapsedDark: Story = {
+  render: () => setup('dark', true),
+};
+
+export const MenusOpen: Story = {
+  render: () => setup('light', false),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+    await user.click(canvas.getByTitle('Language'));
+    await user.click(canvas.getByTitle('Notifications'));
+    const userBtn = canvasElement.querySelector('.user-trigger') as HTMLElement;
+    if (userBtn) {
+      await user.click(userBtn);
+    }
   },
 };
 
-export const Collapsed: Story = {
-  render: () => {
-    localStorage.setItem('sidebar-collapsed', 'true');
-    return { template: `<app-shell></app-shell>` };
-  },
-};
-
-export const Dark: Story = {
-  render: () => {
-    localStorage.setItem('theme', 'dark');
-    return { template: `<app-shell></app-shell>` };
-  },
-};
-
-export const NonProdBadge: Story = {
-  decorators: [
-    applicationConfig({
-      providers: [
-        { provide: EnvironmentService, useValue: { isProduction: () => false, envName: () => 'staging' } },
-      ],
-    }),
-  ],
-  render: () => ({ template: `<app-shell></app-shell>` }),
-};

--- a/front/src/app/ui/app-shell/app-shell.styles.scss
+++ b/front/src/app/ui/app-shell/app-shell.styles.scss
@@ -14,7 +14,7 @@
   height: 100vh;
   background: var(--color-background);
 
-  &.sidebar-collapsed {
+  &.app-sidebar--collapsed {
     grid-template-columns: var(--sidebar-collapsed-width) 1fr;
   }
 }
@@ -457,7 +457,7 @@
   flex-direction: column;
   transition: width 180ms ease;
   
-  &.collapsed {
+  &.app-sidebar--collapsed {
     width: var(--sidebar-collapsed-width);
     
     .logo-text {
@@ -474,7 +474,7 @@
       justify-content: center;
     }
     
-    .sidebar-toggle {
+    .collapse {
       position: absolute;
       right: -12px;
       background: var(--color-surface);
@@ -486,216 +486,6 @@
   }
 }
 
-/* Sidebar Header */
-.sidebar-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--color-border);
-  min-height: var(--navbar-height);
-  box-sizing: border-box;
-}
-
-.sidebar-logo {
-  display: flex;
-  align-items: center;
-}
-
-.logo-text {
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--color-text-primary);
-  transition: opacity 180ms ease;
-}
-
-.logo-accent {
-  color: var(--color-primary);
-}
-
-.sidebar-toggle {
-  width: 32px;
-  height: 32px;
-  border: none;
-  background: transparent;
-  border-radius: 6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 150ms;
-  
-  &:hover {
-    background: var(--color-surface-elevated);
-  }
-  
-  svg {
-    transition: transform 180ms ease;
-    
-    &.rotated {
-      transform: rotate(180deg);
-    }
-  }
-}
-
-/* Sidebar Navigation */
-.sidebar-nav {
-  flex: 1;
-  padding: 12px 8px;
-  overflow-y: auto;
-}
-
-.nav-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  height: 44px;
-  padding: 0 12px;
-  margin-bottom: 2px;
-  border-radius: 12px;
-  color: var(--color-text-primary);
-  text-decoration: none;
-  font-size: 14px;
-  font-weight: 600;
-  transition: all 150ms ease;
-  position: relative;
-  
-  &:hover:not(.active) {
-    background: var(--color-surface-elevated);
-  }
-  
-  &.active {
-    background: var(--color-primary);
-    color: var(--color-text-on-primary);
-    
-    .nav-icon svg {
-      color: var(--color-text-on-primary);
-    }
-  }
-}
-
-.nav-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-  
-  svg {
-    color: var(--color-text-primary);
-    transition: color 150ms ease;
-  }
-}
-
-.nav-text {
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  transition: opacity 180ms ease;
-}
-
-/* Badges positioned exactly */
-.app-sidebar .badge {
-  transition: opacity 180ms ease;
-}
-
-.app-sidebar.collapsed .badge {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  font-size: 0;
-}
-
-/* Support Section */
-.sidebar-support {
-  margin-top: auto;
-  padding: 12px 8px;
-  border-top: 1px solid var(--color-border);
-}
-
-.support-content {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--color-primary) 8%, transparent);
-  position: relative;
-}
-
-.support-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-  
-  svg {
-    color: var(--color-primary);
-  }
-}
-
-.support-text {
-  flex: 1;
-  transition: opacity 180ms ease;
-}
-
-.support-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  line-height: 1.2;
-}
-
-.support-subtitle {
-  font-size: 11px;
-  color: var(--color-primary);
-  margin-top: 1px;
-}
-
-.support-btn {
-  width: 24px;
-  height: 24px;
-  border: none;
-  background: transparent;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 150ms;
-  flex-shrink: 0;
-  
-  &:hover {
-    background: color-mix(in srgb, var(--color-primary) 15%, transparent);
-  }
-  
-  svg {
-    color: var(--color-primary);
-  }
-}
-
-/* Support section in collapsed state */
-.app-sidebar.collapsed {
-  .support-content {
-    display: none;
-  }
-
-  .support-btn {
-    opacity: 1;
-    pointer-events: auto;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    margin: 8px auto;
-  }
-}
 
 /* ============================================= 
    MAIN CONTENT AREA
@@ -796,4 +586,103 @@
   .language-text {
     display: none;
   }
+}
+
+/* Sidebar header and collapsed navigation refinements */
+.sidebar-header {
+  height: 56px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .logo {
+    height: 22px;
+  }
+
+  .collapse {
+    min-width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    cursor: pointer;
+
+    .chev {
+      inline-size: 12px;
+      block-size: 12px;
+      mask: url('/assets/icons/chevron-left.svg') no-repeat center/contain;
+      background: var(--text-1);
+      transition: transform 0.18s;
+    }
+
+    .chev.rot {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+.app-sidebar--collapsed .sidebar-header .logo {
+  display: none;
+}
+
+.sidebar-nav .item {
+  height: 44px;
+  padding: 0 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 12px;
+  position: relative;
+}
+
+.sidebar-nav .item .label {
+  white-space: nowrap;
+}
+
+.app-sidebar--collapsed .sidebar-nav .item .label {
+  display: none;
+}
+
+.sidebar-nav .item .counter {
+  margin-left: auto;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  font: 700 10px/1 Inter;
+  color: #fff;
+}
+
+.app-sidebar--collapsed .sidebar-nav .item .counter {
+  margin-left: 0;
+  min-width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  padding: 0;
+  font-size: 0;
+}
+
+.counter--blue {
+  background: var(--blue);
+}
+
+.counter--yellow {
+  background: var(--yellow);
+}
+
+.counter--red {
+  background: var(--red);
+}
+
+.counter--green {
+  background: var(--green);
+}
+
+.sidebar-nav .item--active {
+  background: var(--active);
+  color: var(--active-contrast);
 }

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -68,6 +68,7 @@
   /* Elevation */
   --elev-1: 0 1px 2px var(--shadow);
   --elev-2: 0 4px 10px var(--shadow);
+  --elev-3: 0 8px 24px var(--shadow);
 
   /* Typography */
   --fs-12: 12px;
@@ -76,6 +77,21 @@
   --fs-18: 18px;
   --fs-24: 24px;
   --fs-28: 28px;
+
+  /* Legacy color tokens (for merged styles) */
+  --color-background: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-elevated: var(--surface-2);
+  --color-border: var(--border);
+  --color-border-subtle: var(--border);
+  --color-primary: var(--blue);
+  --color-info: var(--blue);
+  --color-success: var(--green);
+  --color-warning: var(--yellow);
+  --color-error: var(--red);
+  --color-text-primary: var(--text-1);
+  --color-text-secondary: var(--text-2);
+  --color-text-tertiary: var(--muted);
 }
 
 :root[data-theme="dark"] {
@@ -92,6 +108,26 @@
   --text-1: #f1f5f9;
   --text-2: #cbd5e1;
   --muted: #94a3b8;
+
+  /* Elevation */
+  --elev-1: 0 1px 2px var(--shadow);
+  --elev-2: 0 4px 10px var(--shadow);
+  --elev-3: 0 8px 24px var(--shadow);
+
+  /* Legacy color tokens (for merged styles) */
+  --color-background: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-elevated: var(--surface-2);
+  --color-border: var(--border);
+  --color-border-subtle: var(--border);
+  --color-primary: var(--blue);
+  --color-info: var(--blue);
+  --color-success: var(--green);
+  --color-warning: var(--yellow);
+  --color-error: var(--red);
+  --color-text-primary: var(--text-1);
+  --color-text-secondary: var(--text-2);
+  --color-text-tertiary: var(--muted);
   
   /* Improved contrast for yellow chips in dark mode */
   .chip--yellow { 
@@ -112,9 +148,9 @@ a {
   text-decoration: none; 
 }
 
-*:focus-visible { 
-  outline: 2px solid var(--brand-500); 
-  outline-offset: 2px; 
+*:focus-visible {
+  outline: 2px solid var(--brand-500);
+  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) { 
@@ -192,9 +228,9 @@ a {
   color: #915e00; 
 }
 
-.chip--red    { 
-  background: color-mix(in srgb, var(--red) 16%, transparent); 
-  color: var(--red); 
+.chip--red    {
+  background: color-mix(in srgb, var(--red) 16%, transparent);
+  color: var(--red);
 }
 
 /* KPI */
@@ -389,4 +425,37 @@ html {
 .icon-btn:focus-visible {
   outline: 2px solid var(--brand-500);
   outline-offset: 2px;
+}
+
+/* Overlay menus */
+.cdk-overlay-container, .cdk-overlay-pane {
+  z-index: 1000;
+}
+
+[data-theme] .mat-mdc-menu-panel,
+[data-theme] .cdk-overlay-pane .menu-panel {
+  background: var(--surface);
+  color: var(--text-1);
+  border: 1px solid var(--border);
+  box-shadow: var(--elev-3);
+  border-radius: 12px;
+  min-width: 220px;
+}
+
+.menu-item {
+  height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+}
+
+.menu-item:hover {
+  background: var(--surface-2);
+}
+
+.menu-section {
+  padding: 6px 12px;
+  color: var(--muted);
+  font-size: 12px;
 }


### PR DESCRIPTION
## Summary
- keep sidebar chevron visible and persist collapsed state
- compact sidebar counters and hide labels when collapsed
- propagate theme to overlays and add menu stories/tests
- define legacy color tokens to fix merged styles

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`
- `npm run build:storybook`


------
https://chatgpt.com/codex/tasks/task_e_68a5d3f8f1dc832095e6976f37780454