### PR TITLE
Refactor theme handling to use UiStore and dataset.theme

### DIFF
--- a/front/src/app/core/stores/ui.store.spec.ts
+++ b/front/src/app/core/stores/ui.store.spec.ts
@@ -1,0 +1,30 @@
+import { UiStore } from './ui.store';
+
+describe('UiStore theme persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (document.documentElement.dataset as any).theme;
+  });
+
+  it('setTheme persists to localStorage and dataset.theme', () => {
+    const store = new UiStore();
+    store.setTheme('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect((document.documentElement.dataset as any).theme).toBe('dark');
+  });
+
+  it('toggleTheme persists changes', () => {
+    const store = new UiStore();
+    store.setTheme('light');
+    store.toggleTheme();
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect((document.documentElement.dataset as any).theme).toBe('dark');
+  });
+
+  it('initializeTheme applies stored theme', () => {
+    localStorage.setItem('theme', 'dark');
+    const store = new UiStore();
+    store.initializeTheme();
+    expect((document.documentElement.dataset as any).theme).toBe('dark');
+  });
+});

--- a/front/src/app/core/stores/ui.store.ts
+++ b/front/src/app/core/stores/ui.store.ts
@@ -70,7 +70,7 @@ export class UiStore {
     // Apply theme to document
     if (typeof document !== 'undefined') {
       const effectiveTheme = getEffectiveTheme(theme);
-      document.documentElement.dataset['theme'] = effectiveTheme;
+      (document.documentElement.dataset as any).theme = effectiveTheme;
     }
   }
 
@@ -86,14 +86,14 @@ export class UiStore {
     const theme = this._theme();
     if (typeof document !== 'undefined') {
       const effectiveTheme = getEffectiveTheme(theme);
-      document.documentElement.dataset['theme'] = effectiveTheme;
+      (document.documentElement.dataset as any).theme = effectiveTheme;
 
       // Listen for system theme changes if using system preference
       if (theme === 'system') {
         const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
         const updateSystemTheme = () => {
           if (this._theme() === 'system') {
-            document.documentElement.dataset['theme'] = mediaQuery.matches ? 'dark' : 'light';
+            (document.documentElement.dataset as any).theme = mediaQuery.matches ? 'dark' : 'light';
           }
         };
 

--- a/front/src/app/ui/app-shell/app-shell.component.spec.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.spec.ts
@@ -4,7 +4,7 @@ import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { ThemeService } from '@core/services/theme.service';
-import { signal } from '@angular/core';
+import { signal, computed } from '@angular/core';
 
 import { AppShellComponent } from './app-shell.component';
 import { UiStore } from '@core/stores/ui.store';
@@ -36,11 +36,18 @@ class MockTranslationService {
 
 class MockUiStore {
   sidebarCollapsed = signal(false);
+  private theme = signal<'light' | 'dark' | 'system'>('light');
+  isDark = computed(() => this.theme() === 'dark');
   initializeTheme(): void {}
   toggleSidebar(): void {
     const newState = !this.sidebarCollapsed();
     this.sidebarCollapsed.set(newState);
     localStorage.setItem('sidebarCollapsed', String(newState));
+  }
+  toggleTheme(): void {
+    const current = this.theme();
+    const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
+    this.theme.set(next);
   }
 }
 

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -117,13 +117,13 @@ interface Notification {
           </div>
 
           <!-- Theme Toggle -->
-          <button 
+          <button
             class="icon-btn"
-            (click)="toggleTheme()"
-            [attr.aria-label]="isDarkMode() ? 'Switch to light mode' : 'Switch to dark mode'"
+            (click)="ui.toggleTheme()"
+            [attr.aria-label]="ui.isDark() ? 'Switch to light mode' : 'Switch to dark mode'"
             title="Toggle theme"
           >
-            @if (isDarkMode()) {
+            @if (ui.isDark()) {
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>
@@ -538,7 +538,6 @@ export class AppShellComponent implements OnInit {
   // Component state signals
   private readonly _languageDropdownOpen = signal(false);
   private readonly _userDropdownOpen = signal(false);
-  private readonly _isDarkMode = signal(false);
   private readonly _notificationDropdownOpen = signal(false);
   private readonly _loggingOut = signal(false);
   private readonly _notifications = signal<Notification[]>([
@@ -571,7 +570,6 @@ export class AppShellComponent implements OnInit {
   // Public computed properties
   readonly languageDropdownOpen = this._languageDropdownOpen.asReadonly();
   readonly userDropdownOpen = this._userDropdownOpen.asReadonly();
-  readonly isDarkMode = this._isDarkMode.asReadonly();
   readonly notificationDropdownOpen = this._notificationDropdownOpen.asReadonly();
   readonly notifications = this._notifications.asReadonly();
   readonly loggingOut = this._loggingOut.asReadonly();
@@ -600,27 +598,8 @@ export class AppShellComponent implements OnInit {
     // Initialize theme system
     this.ui.initializeTheme();
 
-    // Load theme state
-    this.loadThemeState();
-
     // Try to load user session if token exists
     this.auth.loadMe();
-  }
-
-  // Theme management
-  private loadThemeState(): void {
-    const theme = localStorage.getItem('theme') || 'light';
-    this._isDarkMode.set(theme === 'dark');
-    document.documentElement.setAttribute('data-theme', theme);
-  }
-
-  toggleTheme(): void {
-    const currentTheme = this._isDarkMode();
-    const newTheme = currentTheme ? 'light' : 'dark';
-    
-    this._isDarkMode.set(!currentTheme);
-    document.documentElement.setAttribute('data-theme', newTheme);
-    localStorage.setItem('theme', newTheme);
   }
 
   // Sidebar management

--- a/front/src/app/ui/app-shell/app-shell.stories.ts
+++ b/front/src/app/ui/app-shell/app-shell.stories.ts
@@ -83,6 +83,7 @@ class MockUiStore {
   ]);
   
   theme = computed(() => this.themeSignal());
+  isDark = computed(() => this.themeSignal() === 'dark');
   sidebarCollapsed = computed(() => this.sidebarCollapsedSignal());
   notifications = computed(() => this.notificationsSignal());
   unreadNotificationsCount = computed(() => 
@@ -92,7 +93,7 @@ class MockUiStore {
   toggleTheme(): void {
     const current = this.themeSignal();
     this.themeSignal.set(current === 'light' ? 'dark' : 'light');
-    document.body.setAttribute('data-theme', this.themeSignal());
+    document.body.dataset.theme = this.themeSignal();
   }
   
   toggleSidebar(): void {
@@ -100,7 +101,7 @@ class MockUiStore {
   }
   
   initializeTheme(): void {
-    document.body.setAttribute('data-theme', this.themeSignal());
+    document.body.dataset.theme = this.themeSignal();
   }
 }
 


### PR DESCRIPTION
## Summary
- remove component-level dark mode state and use UiStore signals
- apply theme through `document.documentElement.dataset.theme`
- add tests verifying theme persistence and dataset updates

## Testing
- `cd front && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6088b1a00832084ec2fc7397ab891