### PR TITLE
refactor: rename language storage key

### DIFF
--- a/front/src/app/core/config/languages.config.ts
+++ b/front/src/app/core/config/languages.config.ts
@@ -84,7 +84,7 @@ export const FALLBACK_LANGUAGE: SupportedLanguage = 'en';
 /**
  * Storage key for selected language
  */
-export const LANGUAGE_STORAGE_KEY = 'boukii_language';
+export const LANGUAGE_STORAGE_KEY = 'language';
 
 /**
  * Get all available languages as array

--- a/front/src/app/core/services/translation.service.ts
+++ b/front/src/app/core/services/translation.service.ts
@@ -716,6 +716,13 @@ export class TranslationService {
    */
   private getStoredLanguage(): SupportedLanguage | null {
     if (typeof localStorage === 'undefined') return null;
+    const legacyKey = 'boukii_language';
+
+    const legacy = localStorage.getItem(legacyKey);
+    if (legacy && !localStorage.getItem(LANGUAGE_STORAGE_KEY)) {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, legacy);
+      localStorage.removeItem(legacyKey);
+    }
 
     const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
     if (stored && stored in LANGUAGE_CONFIGS) {
@@ -731,6 +738,7 @@ export class TranslationService {
   private storeLanguage(language: SupportedLanguage): void {
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+      localStorage.removeItem('boukii_language');
     }
   }
 


### PR DESCRIPTION
## Summary
- store language preference using the `language` key
- migrate legacy `boukii_language` localStorage entries to the new key

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a61250ba60832097b228f652c23b00