### PR TITLE
Add MySQL schema dump script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
-        ]
+        ],
+        "db:schema:dump": "bash scripts/db/dump-mysql-schema.sh"
     },
     "extra": {
         "laravel": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "db:schema:dump": "bash scripts/db/dump-mysql-schema.sh"
     },
     "devDependencies": {
         "axios": "^1.1.2",

--- a/scripts/db/dump-mysql-schema.sh
+++ b/scripts/db/dump-mysql-schema.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="database/schema/mysql"
+mkdir -p "$OUTPUT_DIR"
+
+MYSQL_PWD="${DB_PASSWORD:-}" mysqldump --no-data \
+  -h "${DB_HOST:-127.0.0.1}" \
+  -P "${DB_PORT:-3306}" \
+  -u "${DB_USERNAME:-root}" \
+  "${DB_DATABASE:-}" > "$OUTPUT_DIR/schema.sql"


### PR DESCRIPTION
## Summary
- add bash script to export MySQL schema to database/schema/mysql/schema.sql
- expose schema dump command via NPM and Composer scripts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `composer test` *(fails: Command "test" is not defined)*
- `DB_DATABASE=information_schema bash scripts/db/dump-mysql-schema.sh` *(fails: mysqldump: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a61269924883209182040f419f0560