### PR TITLE
feat: replace config menu with notifications

### DIFF
--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -449,14 +449,15 @@ interface Notification {
               <span class="badge counter counter--green">2</span>
             </a>
 
-            <!-- Configuración -->
-            <a href="#" class="nav-item item" role="menuitem" [title]="ui.sidebarCollapsed() ? ('nav.config' | translate) : null">
+            <!-- Notificaciones -->
+            <a href="#" class="nav-item item" role="menuitem" [title]="ui.sidebarCollapsed() ? ('nav.notifications' | translate) : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5 3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97 0-.33-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1 0 .33.03.65.07.97L2.46 14.6c-.19.15-.24.42-.12.64l2 3.46c.12.22.39.31.61.22l2.49-1c.52.39 1.06.73 1.69.98l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.25 1.17-.59 1.69-.98l2.49 1c.22.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.66Z"/>
+                  <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+                  <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
                 </svg>
               </div>
-              <span class="nav-text label">{{ 'nav.config' | translate }}</span>
+              <span class="nav-text label">{{ 'nav.notifications' | translate }}</span>
             </a>
           </nav>
 
@@ -712,19 +713,10 @@ export class AppShellComponent implements OnInit {
   logout(): void {
     if (this._loggingOut()) return; // Prevent multiple clicks
 
-    // Show confirmation dialog
-    const confirmed = confirm(this.translationService.get('userMenu.logoutConfirm'));
-    
-    if (confirmed) {
-      this._loggingOut.set(true);
-      
-      // Add a small delay to show the loading state
-      setTimeout(() => {
-        this.authV5.logout();
-        this._userDropdownOpen.set(false);
-        this._loggingOut.set(false);
-      }, 500);
-    }
+    this._loggingOut.set(true);
+    this.authV5.logout();
+    this._userDropdownOpen.set(false);
+    this._loggingOut.set(false);
   }
 
   // Click outside handler


### PR DESCRIPTION
## Summary
- swap Configuracion menu for Notificaciones entry using translation key and menuitem role
- remove confirm dialog and call AuthV5Service.logout directly
- test logout button triggers AuthV5Service without confirmation

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6167d86748320b1e216e682553c02