### PR TITLE
Separate CI and full MySQL PHPUnit configs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -76,7 +76,7 @@ jobs:
           SESSION_DRIVER: array
         run: |
           mkdir -p test-reports
-          php -d memory_limit=1024M -d zend.assertions=-1 vendor/bin/phpunit --no-coverage --testsuite=Ci --log-junit test-reports/phpunit.xml
+          php -d memory_limit=1024M -d zend.assertions=-1 vendor/bin/phpunit -c phpunit.ci.xml --testsuite=Ci --log-junit test-reports/phpunit.xml
 
       - name: Upload test reports
         if: always()
@@ -158,6 +158,6 @@ jobs:
           QUEUE_CONNECTION: sync
           SESSION_DRIVER: array
         run: |
-          php -d memory_limit=2048M -d zend.assertions=-1 vendor/bin/phpunit -c phpunit.ci.xml --no-coverage
+          php -d memory_limit=2048M -d zend.assertions=-1 vendor/bin/phpunit -c phpunit.mysql.xml --testsuite=Full
 
 

--- a/phpunit.mysql.xml
+++ b/phpunit.mysql.xml
@@ -3,17 +3,15 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         defaultTestSuite="Ci">
+         defaultTestSuite="Full">
     <testsuites>
-        <testsuite name="Ci">
-            <file>tests/Feature/CiSmokeTest.php</file>
+        <testsuite name="Full">
+            <directory>tests/Unit</directory>
+            <directory>tests/Feature</directory>
+            <directory>tests/V5/Feature</directory>
+            <directory>tests/V5/Integration</directory>
         </testsuite>
     </testsuites>
-    <groups>
-        <exclude>
-            <group>mysql</group>
-        </exclude>
-    </groups>
     <source>
         <include>
             <directory>app</directory>


### PR DESCRIPTION
## Summary
- add phpunit.ci.xml running Ci suite without MySQL tests
- add phpunit.mysql.xml for full test run
- update backend CI workflow to use new configs

## Testing
- `vendor/bin/phpunit -c phpunit.ci.xml --testsuite=Ci` *(fails: Database file at path [database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a61671ffbc8320ad289440afc086f6