### PR TITLE
feat: show notification dot in collapsed sidebar

### DIFF
--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -129,7 +129,11 @@ interface Notification {
                 <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
               </svg>
               @if (unreadNotificationsCount() > 0) {
-                <span class="notification-badge">{{ unreadNotificationsCount() }}</span>
+                @if (ui.sidebarCollapsed()) {
+                  <span class="notification-dot"></span>
+                } @else {
+                  <span class="notification-badge">{{ unreadNotificationsCount() }}</span>
+                }
               }
             </button>
 

--- a/front/src/app/ui/app-shell/app-shell.styles.scss
+++ b/front/src/app/ui/app-shell/app-shell.styles.scss
@@ -105,6 +105,11 @@
   background: var(--red); color: #fff; font: 700 10px/1 Inter;
   display: grid; place-items: center;
 }
+.notification-dot {
+  position: absolute; top: -2px; right: -2px;
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--red);
+}
 
 /* User menu */
 .user-menu { position: relative; }


### PR DESCRIPTION
## Summary
- show notification dot when sidebar collapsed
- add notification-dot style for small circular indicator

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError: jasmine is not defined in app-shell.component.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a61fb00b648320bb23c847ca834975