### PR TITLE
refactor: streamline app shell stories

### DIFF
--- a/front/src/app/ui/app-shell/app-shell.stories.ts
+++ b/front/src/app/ui/app-shell/app-shell.stories.ts
@@ -13,96 +13,28 @@ import { AuthV5Service } from '@core/services/auth-v5.service';
 import { TranslationService, SupportedLanguage } from '@core/services/translation.service';
 import { EnvironmentService } from '@core/services/environment.service';
 
-// Enhanced Mock Services for Stories
 class MockTranslationService {
-  private lang: SupportedLanguage = 'es';
-  currentLanguage(): SupportedLanguage { return this.lang; }
-  setLanguage(lang: SupportedLanguage): void { this.lang = lang; }
-  get(key: string): string { return key; }
-  instant(key: string): string { return key; }
   private langSignal = signal<SupportedLanguage>('es');
-  
   currentLanguage = computed(() => this.langSignal());
-
-  setLanguage(lang: SupportedLanguage): void {
-    this.langSignal.set(lang);
-  }
-
-  get(key: string): string {
-    const translations: Record<string, string> = {
-      'nav.search': 'Buscar...',
-      'nav.notifications': 'Notificaciones',
-      'nav.user': 'Usuario',
-      'nav.logout': 'Cerrar sesión',
-      'nav.dashboard': 'Dashboard',
-      'nav.reservations': 'Reservas',
-      'nav.clients': 'Clientes',
-      'nav.resources': 'Recursos',
-      'nav.support': 'Soporte',
-      'nav.support.subtitle': 'Centro de ayuda',
-      'notifications.empty': 'No hay notificaciones',
-    };
-    return translations[key] || key;
-  }
-
-  instant(key: string): string {
-    return this.get(key);
-  }
+  setLanguage(lang: SupportedLanguage) { this.langSignal.set(lang); }
+  get(key: string) { return key; }
+  instant(key: string) { return key; }
 }
 
 class MockAuthV5Service {
-  private userSignal = signal({ 
-    id: 1, 
-    name: 'Usuario Demo', 
-    email: 'demo@boukii.com', 
-    role: 'Administrador' 
-  });
-  
-  user = computed(() => this.userSignal());
-  
-  isAuthenticated(): boolean {
-    return true;
-  }
-  
-  currentSchool() {
-    return { id: 1, name: 'Escuela Demo' };
-  }
-  
-  currentSchoolIdSignal() {
-    return signal(1);
-  }
+  user = computed(() => ({ name: 'Usuario Demo' }));
+  isAuthenticated() { return true; }
+  currentSchool() { return { id: 1, name: 'Escuela Demo' }; }
+  currentSchoolIdSignal() { return signal(1); }
 }
 
 class MockUiStore {
   private themeSignal = signal<'light' | 'dark'>('light');
-  private sidebarCollapsedSignal = signal(false);
-  private notificationsSignal = signal([
-    { id: 1, type: 'info', title: 'Nueva reserva', message: 'Cliente ha hecho una reserva', unread: true },
-    { id: 2, type: 'warning', title: 'Recurso ocupado', message: 'Pista 1 ocupada hasta las 18h', unread: true },
-    { id: 3, type: 'success', title: 'Pago confirmado', message: 'Reserva #123 pagada', unread: false }
-  ]);
-  
+  private collapsedSignal = signal(false);
   theme = computed(() => this.themeSignal());
   isDark = computed(() => this.themeSignal() === 'dark');
-  sidebarCollapsed = computed(() => this.sidebarCollapsedSignal());
-  notifications = computed(() => this.notificationsSignal());
-  unreadNotificationsCount = computed(() => 
-    this.notificationsSignal().filter(n => n.unread).length
-  );
-  
-  toggleTheme(): void {
-    const current = this.themeSignal();
-    this.themeSignal.set(current === 'light' ? 'dark' : 'light');
-    document.body.dataset.theme = this.themeSignal();
-  }
-  
-  toggleSidebar(): void {
-    this.sidebarCollapsedSignal.update(collapsed => !collapsed);
-  }
-  
-  initializeTheme(): void {
-    document.body.dataset.theme = this.themeSignal();
-  }
+  sidebarCollapsed = computed(() => this.collapsedSignal());
+  initializeTheme() { document.body.dataset.theme = this.themeSignal(); }
 }
 
 const meta: Meta<AppShellComponent> = {
@@ -117,25 +49,16 @@ const meta: Meta<AppShellComponent> = {
         { provide: UiStore, useClass: MockUiStore },
         { provide: AuthStore, useValue: { loadMe: () => {} } },
         { provide: LoadingStore, useValue: { isLoading: () => false, longestRunningRequest: () => null } },
-        { provide: AuthV5Service, useValue: { isAuthenticated: () => true, currentSchool: () => ({}), currentSchoolIdSignal: () => 1, user: () => ({ name: 'Test User' }), permissions: () => [] } },
         { provide: AuthV5Service, useClass: MockAuthV5Service },
         { provide: TranslationService, useClass: MockTranslationService },
-        { provide: EnvironmentService, useValue: { isProduction: () => true, envName: () => 'production' } },
+        { provide: EnvironmentService, useValue: { envName: () => 'production', isProduction: () => true } },
       ],
     }),
   ],
-  parameters: {
-    layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'AppShell principal de Boukii V5 con navbar 56px y sidebar 264px/72px. Chevron siempre visible con rotación 180°.',
-      },
-    },
-  },
-  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
 };
-
 export default meta;
+
 type Story = StoryObj<AppShellComponent>;
 
 function setup(theme: 'light' | 'dark', collapsed: boolean) {
@@ -144,19 +67,15 @@ function setup(theme: 'light' | 'dark', collapsed: boolean) {
   return { template: `<app-shell></app-shell>` };
 }
 
-export const DefaultLight: Story = {
+export const LightExpanded: Story = {
   render: () => setup('light', false),
 };
 
-export const DefaultDark: Story = {
-  render: () => setup('dark', false),
-};
-
-export const CollapsedLight: Story = {
+export const LightCollapsed: Story = {
   render: () => setup('light', true),
 };
 
-export const CollapsedDark: Story = {
+export const DarkCollapsed: Story = {
   render: () => setup('dark', true),
 };
 
@@ -174,267 +93,14 @@ export const MenusOpen: Story = {
   },
 };
 
-// === Estados base ===
-export const Default: Story = {
-  name: '🏠 Estado Base',
-  parameters: {
-    docs: {
-      description: {
-        story: 'AppShell en estado expandido por defecto con navbar 56px y sidebar 264px.',
-      },
-    },
-  },
-  render: () => {
-    localStorage.clear();
-    localStorage.setItem('sidebar-collapsed', 'false');
-    localStorage.setItem('theme', 'light');
-    return { template: `<app-shell></app-shell>` };
-  },
-};
-
-export const SidebarCollapsed: Story = {
-  name: '📐 Sidebar Colapsado',
-  parameters: {
-    docs: {
-      description: {
-        story: 'AppShell con sidebar colapsado (72px). El chevron debe estar visible y rotado 180°.',
-      },
-    },
-  },
-  render: () => {
-    localStorage.setItem('sidebar-collapsed', 'true');
-    localStorage.setItem('theme', 'light');
-    return { template: `<app-shell></app-shell>` };
-  },
-};
-
-// === Temas ===
-export const DarkTheme: Story = {
-  name: '🌙 Tema Oscuro',
-  parameters: {
-    docs: {
-      description: {
-        story: 'AppShell con tema oscuro activado. Solo cambian colores, manteniendo dimensiones exactas.',
-      },
-    },
-  },
-  render: () => {
-    localStorage.setItem('theme', 'dark');
-    localStorage.setItem('sidebar-collapsed', 'false');
-    document.body.setAttribute('data-theme', 'dark');
-    return { template: `<app-shell></app-shell>` };
-  },
-};
-
-export const DarkCollapsed: Story = {
-  name: '🌙📐 Oscuro + Colapsado',
-  parameters: {
-    docs: {
-      description: {
-        story: 'Combinación de tema oscuro con sidebar colapsado.',
-      },
-    },
-  },
-  render: () => {
-    localStorage.setItem('theme', 'dark');
-    localStorage.setItem('sidebar-collapsed', 'true');
-    document.body.setAttribute('data-theme', 'dark');
-    return { template: `<app-shell></app-shell>` };
-  },
-};
-
-// === Idiomas ===
-export const EnglishLanguage: Story = {
-  name: '🇬🇧 Idioma Inglés',
+export const StagingBadge: Story = {
   decorators: [
     applicationConfig({
       providers: [
-        { provide: TranslationService, useValue: { 
-          currentLanguage: () => 'en', 
-          setLanguage: () => {}, 
-          get: (key: string) => key.replace('.', ' ').toUpperCase(),
-          instant: (key: string) => key.replace('.', ' ').toUpperCase()
-        }},
+        { provide: EnvironmentService, useValue: { envName: () => 'staging', isProduction: () => false } },
       ],
     }),
   ],
-  render: () => {
-    localStorage.setItem('language', 'en');
-    return { template: `<app-shell></app-shell>` };
-  },
+  render: () => setup('light', false),
 };
 
-export const GermanLanguage: Story = {
-  name: '🇩🇪 Idioma Alemán',
-  decorators: [
-    applicationConfig({
-      providers: [
-        { provide: TranslationService, useValue: { 
-          currentLanguage: () => 'de', 
-          setLanguage: () => {}, 
-          get: (key: string) => key.replace('.', ' ').toUpperCase() + ' (DE)',
-          instant: (key: string) => key.replace('.', ' ').toUpperCase() + ' (DE)'
-        }},
-      ],
-    }),
-  ],
-  render: () => {
-    localStorage.setItem('language', 'de');
-    return { template: `<app-shell></app-shell>` };
-  },
-};
-
-// === Estados de entorno ===
-export const StagingEnvironment: Story = {
-  name: '🚧 Entorno Staging',
-  parameters: {
-    docs: {
-      description: {
-        story: 'AppShell con badge de entorno visible (no production). Badge fijo abajo-derecha.',
-      },
-    },
-  },
-  decorators: [
-    applicationConfig({
-      providers: [
-        { provide: EnvironmentService, useValue: { isProduction: () => false, envName: () => 'staging' } },
-      ],
-    }),
-  ],
-  render: () => ({ template: `<app-shell></app-shell>` }),
-};
-
-export const DevelopmentEnvironment: Story = {
-  name: '🔧 Entorno Desarrollo',
-  decorators: [
-    applicationConfig({
-      providers: [
-        { provide: EnvironmentService, useValue: { isProduction: () => false, envName: () => 'development' } },
-      ],
-    }),
-  ],
-  render: () => ({ template: `<app-shell></app-shell>` }),
-};
-
-// === Estados interactivos ===
-export const WithNotifications: Story = {
-  name: '🔔 Con Notificaciones',
-  parameters: {
-    docs: {
-      description: {
-        story: 'AppShell con notificaciones activas. Badge dinámico en campana.',
-      },
-    },
-  },
-  decorators: [
-    applicationConfig({
-      providers: [
-        { 
-          provide: UiStore, 
-          useValue: {
-            ...new MockUiStore(),
-            unreadNotificationsCount: () => 3,
-            initializeTheme: () => {}
-          }
-        },
-      ],
-    }),
-  ],
-  render: () => ({ template: `<app-shell></app-shell>` }),
-};
-
-export const NoNotifications: Story = {
-  name: '🔕 Sin Notificaciones',
-  parameters: {
-    docs: {
-      description: {
-        story: 'AppShell sin notificaciones pendientes. No badge visible.',
-      },
-    },
-  },
-  decorators: [
-    applicationConfig({
-      providers: [
-        { 
-          provide: UiStore, 
-          useValue: {
-            ...new MockUiStore(),
-            unreadNotificationsCount: () => 0,
-            initializeTheme: () => {}
-          }
-        },
-      ],
-    }),
-  ],
-  render: () => ({ template: `<app-shell></app-shell>` }),
-};
-
-// === Usuario y datos ===
-export const DifferentUser: Story = {
-  name: '👤 Usuario Diferente',
-  decorators: [
-    applicationConfig({
-      providers: [
-        { 
-          provide: AuthV5Service, 
-          useValue: { 
-            isAuthenticated: () => true, 
-            currentSchool: () => ({ name: 'Escuela Premium' }),
-            currentSchoolIdSignal: () => signal(2),
-            user: () => ({ name: 'María García', role: 'Gerente', email: 'maria@premium.com' })
-          }
-        },
-      ],
-    }),
-  ],
-  render: () => ({ template: `<app-shell></app-shell>` }),
-};
-
-// === Estados responsive (simulado) ===
-export const MobileView: Story = {
-  name: '📱 Vista Mobile',
-  parameters: {
-    viewport: { defaultViewport: 'mobile1' },
-    docs: {
-      description: {
-        story: 'AppShell en resolución móvil. Sidebar oculto por defecto, navbar adaptado.',
-      },
-    },
-  },
-  render: () => ({ template: `<app-shell></app-shell>` }),
-};
-
-// === Combinaciones complejas ===
-export const AllInteractionsOpen: Story = {
-  name: '🎭 Todas las Interacciones',
-  parameters: {
-    docs: {
-      description: {
-        story: 'Story para testing manual: tema oscuro, colapsado, notificaciones, entorno staging.',
-      },
-    },
-  },
-  decorators: [
-    applicationConfig({
-      providers: [
-        { provide: EnvironmentService, useValue: { isProduction: () => false, envName: () => 'staging' } },
-        { 
-          provide: UiStore, 
-          useValue: {
-            ...new MockUiStore(),
-            theme: () => 'dark',
-            sidebarCollapsed: () => true,
-            unreadNotificationsCount: () => 5,
-            initializeTheme: () => {}
-          }
-        },
-      ],
-    }),
-  ],
-  render: () => {
-    localStorage.setItem('theme', 'dark');
-    localStorage.setItem('sidebar-collapsed', 'true');
-    document.body.setAttribute('data-theme', 'dark');
-    return { template: `<app-shell></app-shell>` };
-  },
-};


### PR DESCRIPTION
## Summary
- reduce AppShell stories to core examples
- open menus via play function
- show staging badge when environment is "staging"

## Testing
- `npm test` *(fails: ReferenceError: jasmine is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a625e70330832093131870e5f625ee