### PR TITLE
docs: add audit status and testing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ Documentación → `docs/shared/` y `docs/backend/`.
 - [API Docs](docs/api/API_DOCUMENTATION.md)
 - [Guía Frontend](docs/shared/FRONTEND_ANGULAR.md)
 - [Operaciones](docs/backend/OPERATIONS.md)
+
+## How to run tests
+
+### SQLite smoke
+```bash
+cp .env.example .env
+cat .env.ci.sqlite >> .env
+touch database/database.sqlite
+php artisan migrate:fresh
+php artisan test --testsuite=Ci
+```
+
+### MySQL full
+```bash
+cp .env.example .env
+cat .env.ci.mysql >> .env
+mysql -h 127.0.0.1 -P 3306 -u root -proot boukii_v5 < database/schema/mysql/schema.sql
+php artisan migrate
+php artisan test --testsuite=Full
+```

--- a/docs/audit/BACKEND_STATUS.md
+++ b/docs/audit/BACKEND_STATUS.md
@@ -1,0 +1,14 @@
+# Backend Status
+
+## Test Coverage
+- SQLite smoke suite runs on every pull request.
+- Full MySQL suite is gated behind the `run-full-suite` label.
+
+## Migration Debt
+- Historical migrations were pruned; the repository boots from a schema dump.
+- Incremental migrations after the dump still need reconstruction.
+
+## Convergence Plan
+1. Rebuild missing migrations from the schema dump.
+2. Gradually re-enable tests and factories.
+3. Promote the MySQL full suite once migrations and factories stabilize.

--- a/docs/audit/CI_PIPELINE.md
+++ b/docs/audit/CI_PIPELINE.md
@@ -1,0 +1,22 @@
+# CI Pipeline
+
+The backend uses two GitHub Actions jobs.
+
+## Smoke job (`backend`)
+- Runs on every push and pull request.
+- Uses SQLite and executes the `Ci` PHPUnit testsuite.
+- Performs a database smoke query and PHPStan analysis.
+
+## Full job (`phpunit-full`)
+- Triggered when a pull request has the `run-full-suite` label.
+- Starts a MySQL service and loads `database/schema/mysql/schema.sql`.
+- Runs remaining migrations and the full PHPUnit testsuite.
+
+## Schema dump regeneration
+After schema changes, update the MySQL dump consumed by CI:
+
+```bash
+composer db:schema:dump
+```
+
+This regenerates `database/schema/mysql/schema.sql` used by the full job.

--- a/docs/audit/MIGRATION_PLAN.md
+++ b/docs/audit/MIGRATION_PLAN.md
@@ -1,0 +1,18 @@
+# Migration Plan
+
+The current database is bootstrapped from a MySQL schema dump located at `database/schema/mysql/schema.sql`. Historical Laravel migrations have been removed.
+
+## Goals
+- Reconstruct full Laravel migration history.
+- Ensure repeatable schema evolution and compatibility with existing data.
+
+## Strategy
+1. Extract tables and foreign keys from the schema dump.
+2. Regenerate baseline migrations using `laravel-migration-generator`.
+3. Commit migrations in batches per bounded context.
+4. Validate each batch with the MySQL full test suite.
+5. Remove dependency on the schema dump once history is rebuilt.
+
+## Open Questions
+- Ordering and idempotency of data backfills.
+- Handling of seed data required for CI and smoke tests.

--- a/docs/audit/OPENAPI_STATUS.md
+++ b/docs/audit/OPENAPI_STATUS.md
@@ -1,0 +1,16 @@
+# OpenAPI Status
+
+| Endpoint | Status |
+| --- | --- |
+| `POST /api/v5/auth/login` | Implemented |
+| `POST /api/v5/auth/logout` | Implemented |
+| `GET /api/v5/auth/me` | Implemented |
+| `GET /api/v5/schools` | Implemented |
+| `POST /api/v5/schools/{id}/select` | Stubbed |
+| `GET /api/v5/seasons` | Implemented |
+| `POST /api/v5/seasons` | Pending |
+| `GET /api/v5/dashboard/stats` | Pending |
+| `GET /api/v5/clients` | Implemented |
+| `GET /api/v5/courses` | Implemented |
+| `GET /api/v5/bookings` | Partial |
+| `GET /api/v5/monitors` | Stubbed |


### PR DESCRIPTION
## Summary
- add backend, OpenAPI, migration and CI audit reports
- document SQLite smoke and MySQL full test workflows in README

## Testing
- `php -d memory_limit=1024M -d zend.assertions=-1 vendor/bin/phpunit -c phpunit.ci.xml --testsuite=Ci`

------
https://chatgpt.com/codex/tasks/task_e_68a6c403eae08320a4a7f4a6f307303e