### PR TITLE
feat: implement school selector with user context

### DIFF
--- a/app/Http/Controllers/Api/V5/ContextController.php
+++ b/app/Http/Controllers/Api/V5/ContextController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api\V5;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V5\Context\SwitchSchoolRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContextController extends Controller
+{
+    /**
+     * Get current context (school_id, season_id).
+     */
+    public function show(Request $request): JsonResponse
+    {
+        $token = $request->user()->currentAccessToken();
+        $context = [
+            'school_id' => null,
+            'season_id' => null,
+        ];
+
+        if ($token && $token->context_data) {
+            $data = is_array($token->context_data)
+                ? $token->context_data
+                : json_decode($token->context_data, true);
+            $context['school_id'] = $data['school_id'] ?? null;
+            $context['season_id'] = $data['season_id'] ?? null;
+        }
+
+        return response()->json($context);
+    }
+
+    /**
+     * Switch current school for the authenticated user.
+     */
+    public function switchSchool(SwitchSchoolRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $schoolId = (int) $request->validated()['school_id'];
+
+        $token = $user->currentAccessToken();
+        if (! $token) {
+            return $this->problem('No active access token', Response::HTTP_UNAUTHORIZED);
+        }
+
+        $contextData = $token->context_data ?? [];
+        if (! is_array($contextData)) {
+            $contextData = json_decode($contextData, true) ?? [];
+        }
+
+        $contextData['school_id'] = $schoolId;
+        $contextData['season_id'] = null;
+
+        $token->context_data = $contextData;
+        $token->save();
+
+        return response()->json([
+            'school_id' => $schoolId,
+            'season_id' => null,
+        ]);
+    }
+
+    private function problem(string $detail, int $status): JsonResponse
+    {
+        return response()->json([
+            'type' => 'about:blank',
+            'title' => Response::$statusTexts[$status] ?? 'Error',
+            'status' => $status,
+            'detail' => $detail,
+        ], $status, ['Content-Type' => 'application/problem+json']);
+    }
+}

--- a/app/Http/Controllers/Api/V5/MeSchoolController.php
+++ b/app/Http/Controllers/Api/V5/MeSchoolController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Api\V5;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\API\SchoolResource;
+use App\Models\School;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MeSchoolController extends Controller
+{
+    /**
+     * List schools visible to the authenticated user.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $this->authorize('viewAny', School::class);
+
+        $schools = $request->user()->schools()->paginate();
+
+        return SchoolResource::collection($schools)->response();
+    }
+}

--- a/app/Http/Requests/V5/Context/SwitchSchoolRequest.php
+++ b/app/Http/Requests/V5/Context/SwitchSchoolRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests\V5\Context;
+
+use App\Models\School;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Contracts\Validation\Validator;
+use Symfony\Component\HttpFoundation\Response;
+
+class SwitchSchoolRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $schoolId = $this->input('school_id');
+        if (! $schoolId) {
+            return false;
+        }
+
+        $school = School::find($schoolId);
+        if (! $school) {
+            return false;
+        }
+
+        return $this->user()->can('switch', $school);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'school_id' => ['required', 'integer', 'exists:schools,id'],
+        ];
+    }
+
+    protected function failedAuthorization()
+    {
+        throw new HttpResponseException($this->problem('Access denied', Response::HTTP_FORBIDDEN));
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        $errors = $validator->errors()->toArray();
+        throw new HttpResponseException($this->problem('Validation failed', Response::HTTP_UNPROCESSABLE_ENTITY, $errors));
+    }
+
+    private function problem(string $detail, int $status, array $errors = null)
+    {
+        $problem = [
+            'type' => 'about:blank',
+            'title' => Response::$statusTexts[$status] ?? 'Error',
+            'status' => $status,
+            'detail' => $detail,
+        ];
+
+        if ($errors) {
+            $problem['errors'] = $errors;
+        }
+
+        return response()->json($problem, $status, ['Content-Type' => 'application/problem+json']);
+    }
+}

--- a/app/Policies/SchoolPolicy.php
+++ b/app/Policies/SchoolPolicy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\School;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class SchoolPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any schools.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasRole('admin') || $user->can('schools.view');
+    }
+
+    /**
+     * Determine whether the user can switch to the given school.
+     */
+    public function switch(User $user, School $school): bool
+    {
+        if (! $user->can('schools.switch')) {
+            return false;
+        }
+
+        return $user->schools()->where('schools.id', $school->id)->exists();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,8 @@ namespace App\Providers;
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
+use App\Models\School;
+use App\Policies\SchoolPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -14,7 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        School::class => SchoolPolicy::class,
     ];
 
     /**

--- a/docs/api/openapi-v5.yaml
+++ b/docs/api/openapi-v5.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.3
+info:
+  title: Boukii API V5
+  version: '1.0'
+paths:
+  /api/v5/me/schools:
+    get:
+      summary: List schools visible to the authenticated user
+      tags: [Schools]
+      responses:
+        '200':
+          description: Paginated list of schools
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/School'
+  /api/v5/context:
+    get:
+      summary: Get current user context
+      tags: [Context]
+      responses:
+        '200':
+          description: Current context
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserContext'
+  /api/v5/context/school:
+    post:
+      summary: Switch current school
+      tags: [Context]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                school_id:
+                  type: integer
+      responses:
+        '200':
+          description: Updated context
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserContext'
+components:
+  schemas:
+    School:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    UserContext:
+      type: object
+      properties:
+        school_id:
+          type: integer
+          nullable: true
+        season_id:
+          type: integer
+          nullable: true

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,6 +46,8 @@ Route::prefix('v5')
         require base_path('routes/api_v5/schools.php');
         require base_path('routes/api_v5/seasons.php');
         require base_path('routes/api_v5/logs.php');
+        require base_path('routes/api_v5/me.php');
+        require base_path('routes/api_v5/context.php');
     });
 
 /*

--- a/routes/api_v5/context.php
+++ b/routes/api_v5/context.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V5\ContextController;
+
+Route::middleware(['auth:sanctum', 'throttle:api'])
+    ->prefix('context')
+    ->name('v5.context.')
+    ->group(function () {
+        Route::get('/', [ContextController::class, 'show'])->name('show');
+        Route::post('/school', [ContextController::class, 'switchSchool'])->name('school');
+    });

--- a/routes/api_v5/me.php
+++ b/routes/api_v5/me.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V5\MeSchoolController;
+
+Route::middleware(['auth:sanctum', 'throttle:api'])
+    ->prefix('me')
+    ->name('v5.me.')
+    ->group(function () {
+        Route::get('/schools', [MeSchoolController::class, 'index'])->name('schools.index');
+    });

--- a/tests/Feature/V5/Context/SchoolSelectorTest.php
+++ b/tests/Feature/V5/Context/SchoolSelectorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\V5\Context;
+
+use App\Models\PersonalAccessToken;
+use App\Models\School;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class SchoolSelectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $token;
+    private User $user;
+    private School $schoolOwned;
+    private School $otherSchool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Permission::create(['name' => 'schools.view']);
+        Permission::create(['name' => 'schools.switch']);
+
+        $this->user = User::factory()->create();
+        $this->user->givePermissionTo(['schools.view', 'schools.switch']);
+
+        $this->schoolOwned = School::factory()->create(['active' => true]);
+        $this->otherSchool = School::factory()->create(['active' => true]);
+
+        $this->user->schools()->attach($this->schoolOwned->id);
+
+        $this->token = $this->user->createToken('test-token')->plainTextToken;
+    }
+
+    /** @test */
+    public function lista_solo_schools_del_usuario()
+    {
+        $response = $this->getJson('/api/v5/me/schools', [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertCount(1, $data);
+        $this->assertEquals($this->schoolOwned->id, $data[0]['id']);
+    }
+
+    /** @test */
+    public function retorna_403_si_intenta_cambiar_a_una_school_sin_pertenencia()
+    {
+        $response = $this->postJson('/api/v5/context/school', [
+            'school_id' => $this->otherSchool->id,
+        ], [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response->assertStatus(403);
+        $response->assertJson(['status' => 403]);
+    }
+
+    /** @test */
+    public function cambio_valido_actualiza_el_contexto()
+    {
+        $response = $this->postJson('/api/v5/context/school', [
+            'school_id' => $this->schoolOwned->id,
+        ], [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'school_id' => $this->schoolOwned->id,
+            'season_id' => null,
+        ]);
+
+        $tokenId = explode('|', $this->token)[0];
+        $tokenModel = PersonalAccessToken::find($tokenId);
+        $this->assertEquals($this->schoolOwned->id, $tokenModel->context_data['school_id']);
+        $this->assertNull($tokenModel->context_data['season_id']);
+    }
+
+    /** @test */
+    public function get_context_devuelve_estado_actual()
+    {
+        // Set context first
+        $this->postJson('/api/v5/context/school', [
+            'school_id' => $this->schoolOwned->id,
+        ], [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response = $this->getJson('/api/v5/context', [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'school_id' => $this->schoolOwned->id,
+            'season_id' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add SchoolPolicy for viewing and switching schools
- implement context endpoints for selecting school and reading current context
- expose `/me/schools` endpoint for user-available schools
- document new endpoints in OpenAPI spec
- add feature tests for school selector behavior

## Testing
- `php artisan route:list | grep v5 | head -n 20`
- `vendor/bin/phpunit tests/Feature/V5/Context/SchoolSelectorTest.php --testdox` *(fails: process did not complete within the environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c6ab0adc83208d4fc007cde3d2e9