### PR TITLE
Create school_user pivot table and relations

### DIFF
--- a/app/Models/School.php
+++ b/app/Models/School.php
@@ -496,6 +496,11 @@ class School extends Model
         return $this->hasMany(\App\Models\SchoolUser::class, 'school_id');
     }
 
+    public function users(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'school_user', 'school_id', 'user_id');
+    }
+
     public function seasons(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\App\Models\Season::class, 'school_id');

--- a/app/Models/SchoolUser.php
+++ b/app/Models/SchoolUser.php
@@ -50,9 +50,11 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *          format="date-time"
  *      )
  * )
- */class SchoolUser extends Model
+*/class SchoolUser extends Model
 {
-      use LogsActivity, SoftDeletes, HasFactory;     public $table = 'school_users';
+      use LogsActivity, SoftDeletes, HasFactory;     public $table = 'school_user';
+    public $primaryKey = null;
+    public $incrementing = false;
 
     public $fillable = [
         'school_id',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -187,7 +187,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
     {
         return $this->belongsToMany(
             \App\Models\School::class,
-            'school_users', // Tabla pivote
+            'school_user', // Tabla pivote
             'user_id', // Clave foránea del modelo actual
             'school_id' // Clave foránea del modelo relacionado
         )->where('schools.active', 1)

--- a/database/migrations/2024_06_15_000000_create_school_user_table.php
+++ b/database/migrations/2024_06_15_000000_create_school_user_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('school_users') && ! Schema::hasTable('school_user')) {
+            Schema::rename('school_users', 'school_user');
+        }
+
+        if (! Schema::hasTable('school_user')) {
+            Schema::create('school_user', function (Blueprint $table) {
+                $table->unsignedBigInteger('user_id');
+                $table->unsignedBigInteger('school_id');
+                $table->timestamps();
+                $table->primary(['user_id', 'school_id']);
+            });
+
+            return;
+        }
+
+        // Drop legacy id column if present
+        if (Schema::hasColumn('school_user', 'id')) {
+            Schema::table('school_user', function (Blueprint $table) {
+                $table->dropColumn('id');
+            });
+        }
+
+        Schema::table('school_user', function (Blueprint $table) {
+            if (! Schema::hasColumn('school_user', 'user_id')) {
+                $table->unsignedBigInteger('user_id');
+            }
+            if (! Schema::hasColumn('school_user', 'school_id')) {
+                $table->unsignedBigInteger('school_id');
+            }
+            if (! Schema::hasColumn('school_user', 'created_at') && ! Schema::hasColumn('school_user', 'updated_at')) {
+                $table->timestamps();
+            }
+        });
+
+        $sm = Schema::getConnection()->getDoctrineSchemaManager();
+        $details = $sm->listTableDetails('school_user');
+        if (! $details->hasPrimaryKey()) {
+            Schema::table('school_user', function (Blueprint $table) {
+                $table->primary(['user_id', 'school_id']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('school_user')) {
+            Schema::drop('school_user');
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add migration to rename legacy `school_users` table, create `school_user` with composite primary key
- expose many-to-many `users`/`schools` relations through `school_user` pivot
- adapt `SchoolUser` model to new pivot table structure

## Testing
- `php artisan migrate:fresh --force` (sqlite)
- `php artisan migrate:fresh --force` (mysql)


------
https://chatgpt.com/codex/tasks/task_e_68a6ccb3826c8320a88dbd3a879ff7c6