### PR TITLE
Add context rate limiter

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -30,7 +30,7 @@ class RouteServiceProvider extends ServiceProvider
             Route::middleware('api')
                 ->prefix('api')
                 ->group(base_path('routes/api.php'));
-                
+
             Route::middleware('api')
                 ->prefix('api/v3/admin')
                 ->group(base_path('routes/api/admin_v3.php'));
@@ -70,5 +70,7 @@ class RouteServiceProvider extends ServiceProvider
 
             return Limit::perMinutes($decayMinutes, $maxAttempts)->by($request->ip());
         });
+
+        RateLimiter::for('context', fn (Request $r) => Limit::perMinute(60)->by(optional($r->user())->id ?: $r->ip()));
     }
 }


### PR DESCRIPTION
## Summary
- register `context` rate limiter that throttles requests by user ID or IP up to 60 per minute

## Testing
- `php -l app/Providers/RouteServiceProvider.php`
- `./vendor/bin/pint app/Providers/RouteServiceProvider.php`
- `./vendor/bin/phpunit tests/Repositories/ClientRepositoryTest.php` (fails: Carbon\Exceptions\InvalidFormatException)


------
https://chatgpt.com/codex/tasks/task_e_68a6d2957cb88320b3ff5bf03c5bcce0