### PR TITLE
Use context-specific rate limiter for context and me routes

### DIFF
--- a/routes/api_v5/context.php
+++ b/routes/api_v5/context.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V5\ContextController;
 
-Route::middleware(['auth:sanctum', 'throttle:api'])
+Route::middleware(['auth:sanctum', 'throttle:context'])
     ->prefix('context')
     ->name('v5.context.')
     ->group(function () {

--- a/routes/api_v5/me.php
+++ b/routes/api_v5/me.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V5\MeSchoolController;
 
-Route::middleware(['auth:sanctum', 'throttle:api'])
+Route::middleware(['auth:sanctum', 'throttle:context'])
     ->prefix('me')
     ->name('v5.me.')
     ->group(function () {


### PR DESCRIPTION
## Summary
- Replace `throttle:api` middleware with `throttle:context` for `context` and `me` API routes

## Testing
- `./vendor/bin/phpunit` *(fails: no tests run / process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d3b8d2248320af6a6d366b285fb6