### PR TITLE
Refactor context management in ContextController

### DIFF
--- a/app/Http/Requests/V5/Context/SwitchSchoolRequest.php
+++ b/app/Http/Requests/V5/Context/SwitchSchoolRequest.php
@@ -2,39 +2,23 @@
 
 namespace App\Http\Requests\V5\Context;
 
-use App\Models\School;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Contracts\Validation\Validator;
 use Symfony\Component\HttpFoundation\Response;
 
 class SwitchSchoolRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        $schoolId = $this->input('school_id');
-        if (! $schoolId) {
-            return false;
-        }
-
-        $school = School::find($schoolId);
-        if (! $school) {
-            return false;
-        }
-
-        return $this->user()->can('switch', $school);
+        return true;
     }
 
     public function rules(): array
     {
         return [
-            'school_id' => ['required', 'integer', 'exists:schools,id'],
+            'school_id' => ['required', 'integer'],
         ];
-    }
-
-    protected function failedAuthorization()
-    {
-        throw new HttpResponseException($this->problem('Access denied', Response::HTTP_FORBIDDEN));
     }
 
     protected function failedValidation(Validator $validator)

--- a/app/Services/V5/ContextService.php
+++ b/app/Services/V5/ContextService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services\V5;
+
+use App\Models\User;
+
+class ContextService
+{
+    /**
+     * Get context information for the given user.
+     */
+    public function getContext(User $user): array
+    {
+        $token = $user->currentAccessToken();
+
+        $context = [
+            'school_id' => null,
+            'season_id' => null,
+        ];
+
+        if ($token && $token->context_data) {
+            $data = $token->context_data;
+            $context['school_id'] = $data['school_id'] ?? null;
+            $context['season_id'] = $data['season_id'] ?? null;
+        }
+
+        return $context;
+    }
+
+    /**
+     * Switch the current school for the authenticated user.
+     *
+     * @return array|null Returns updated context or null if no active token.
+     */
+    public function switchSchool(User $user, int $schoolId): ?array
+    {
+        $token = $user->currentAccessToken();
+
+        if (! $token) {
+            return null;
+        }
+
+        $contextData = $token->context_data ?? [];
+        $contextData['school_id'] = $schoolId;
+        $contextData['season_id'] = null;
+
+        $token->context_data = $contextData;
+        $token->save();
+
+        return [
+            'school_id' => $schoolId,
+            'season_id' => null,
+        ];
+    }
+}

--- a/tests/Feature/V5/Context/SchoolSelectorTest.php
+++ b/tests/Feature/V5/Context/SchoolSelectorTest.php
@@ -63,6 +63,19 @@ class SchoolSelectorTest extends TestCase
     }
 
     /** @test */
+    public function retorna_404_si_school_no_existe()
+    {
+        $response = $this->postJson('/api/v5/context/school', [
+            'school_id' => 999999,
+        ], [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson(['status' => 404]);
+    }
+
+    /** @test */
     public function cambio_valido_actualiza_el_contexto()
     {
         $response = $this->postJson('/api/v5/context/school', [


### PR DESCRIPTION
## Summary
- add `ContextService` to encapsulate token context operations
- inject and use `ContextService` in V5 `ContextController`
- authorize school switching and handle missing school with 404
- simplify `SwitchSchoolRequest` and add test for missing school

## Testing
- `vendor/bin/phpunit tests/Feature/V5/Context/SchoolSelectorTest.php` *(fails: SQLSTATE[HY000]: General error: 1 no such table: permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d5aec9c083208a95c4b6a0eecc0f