### PR TITLE
refactor(auth): use AuthShell for auth pages

### DIFF
--- a/front/src/app/features/auth/pages/forgot-password.page.ts
+++ b/front/src/app/features/auth/pages/forgot-password.page.ts
@@ -7,7 +7,7 @@ import { AuthV5Service } from '../../../core/services/auth-v5.service';
 import { TranslationService } from '../../../core/services/translation.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { TranslatePipe } from '../../../shared/pipes/translate.pipe';
-import { AuthLayoutComponent } from '../ui/auth-layout/auth-layout.component';
+import { AuthShellComponent } from '../ui/auth-shell/auth-shell.component';
 import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
 
 @Component({
@@ -18,30 +18,30 @@ import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
     ReactiveFormsModule,
     RouterLink,
     TranslatePipe,
-    AuthLayoutComponent,
+    AuthShellComponent,
     TextFieldComponent
   ],
   template: `
-    <auth-layout 
-      [title]="'auth.forgotPassword.welcome.title' | translate" 
-      [subtitle]="'auth.forgotPassword.subtitle' | translate">
-      
-      <div class="card" role="form" [attr.aria-labelledby]="'forgotPasswordTitle'">
-        <h2 id="forgotPasswordTitle" class="visually-hidden">{{ 'auth.forgotPassword.title' | translate }}</h2>
-        
-        @if (!emailSent()) {
-          <!-- Reset Password Form -->
-          <div class="card-header">
-            <h1 class="card-title">{{ 'auth.forgotPassword.title' | translate }}</h1>
-            <p class="card-subtitle">{{ 'auth.forgotPassword.subtitle' | translate }}</p>
-          </div>
+    <bk-auth-shell
+      [titleKey]="'auth.forgotPassword.welcome.title'"
+      [subtitleKey]="'auth.forgotPassword.subtitle'"
+      [features]="features">
 
-          <form [formGroup]="forgotPasswordForm" (ngSubmit)="onSubmit()" class="auth-form">
-            <!-- Email -->
-            <ui-text-field
-              [label]="'auth.common.email' | translate"
-              [placeholder]="'auth.common.email' | translate"
-              [errorMessage]="getFieldError('email')"
+      <h2 id="forgotPasswordTitle" class="visually-hidden">{{ 'auth.forgotPassword.title' | translate }}</h2>
+
+      @if (!emailSent()) {
+        <!-- Reset Password Form -->
+        <div class="card-header">
+          <h1 class="card-title">{{ 'auth.forgotPassword.title' | translate }}</h1>
+          <p class="card-subtitle">{{ 'auth.forgotPassword.subtitle' | translate }}</p>
+        </div>
+
+        <form [formGroup]="forgotPasswordForm" (ngSubmit)="onSubmit()" class="auth-form">
+          <!-- Email -->
+          <ui-text-field
+            [label]="'auth.common.email' | translate"
+            [placeholder]="'auth.common.email' | translate"
+            [errorMessage]="getFieldError('email')"
               type="email"
               autocomplete="email"
               (valueChange)="onFieldChange('email', $event)">
@@ -65,55 +65,54 @@ import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
             <div class="links">
               <a routerLink="/auth/login">{{ 'auth.forgotPassword.rememberedPassword' | translate }}</a>
             </div>
-          </form>
+        </form>
 
-        } @else {
-          <!-- Success State -->
-          <div class="success-state" role="status" aria-live="polite">
-            <div class="success-icon">
-              <i class="i-mail" aria-hidden="true"></i>
+      } @else {
+        <!-- Success State -->
+        <div class="success-state" role="status" aria-live="polite">
+          <div class="success-icon">
+            <i class="i-mail" aria-hidden="true"></i>
+          </div>
+
+          <div class="card-header">
+            <h1 class="card-title">{{ 'auth.forgotPassword.successTitle' | translate }}</h1>
+            <p class="card-subtitle">{{ 'auth.forgotPassword.emailSent' | translate }}</p>
+          </div>
+
+          @if (submittedEmail()) {
+            <div class="email-confirmation">
+              <p class="email-sent-message">
+                <strong>{{ submittedEmail() }}</strong>
+              </p>
+              <p class="help-text">{{ 'auth.forgotPassword.checkSpam' | translate }}</p>
             </div>
-            
-            <div class="card-header">
-              <h1 class="card-title">{{ 'auth.forgotPassword.successTitle' | translate }}</h1>
-              <p class="card-subtitle">{{ 'auth.forgotPassword.emailSent' | translate }}</p>
-            </div>
+          }
 
-            @if (submittedEmail()) {
-              <div class="email-confirmation">
-                <p class="email-sent-message">
-                  <strong>{{ submittedEmail() }}</strong>
-                </p>
-                <p class="help-text">{{ 'auth.forgotPassword.checkSpam' | translate }}</p>
-              </div>
-            }
+          <div class="success-actions">
+            <button
+              type="button"
+              class="btn btn--secondary w-100"
+              (click)="resetForm()"
+              [disabled]="isLoading()">
+              {{ 'auth.forgotPassword.sendAnother' | translate }}
+            </button>
 
-            <div class="success-actions">
-              <button 
-                type="button" 
-                class="btn btn--secondary w-100" 
-                (click)="resetForm()"
-                [disabled]="isLoading()">
-                {{ 'auth.forgotPassword.sendAnother' | translate }}
-              </button>
-              
-              <div class="links">
-                <a routerLink="/auth/login">{{ 'auth.forgotPassword.rememberedPassword' | translate }}</a>
-              </div>
+            <div class="links">
+              <a routerLink="/auth/login">{{ 'auth.forgotPassword.rememberedPassword' | translate }}</a>
             </div>
           </div>
-        }
-
-        <div 
-          id="status-message"
-          class="sr-only" 
-          role="status" 
-          aria-live="polite"
-          [attr.aria-hidden]="!statusMessage()">
-          {{ statusMessage() }}
         </div>
+      }
+
+      <div
+        id="status-message"
+        class="visually-hidden"
+        role="status"
+        aria-live="polite"
+        [attr.aria-hidden]="!statusMessage()">
+        {{ statusMessage() }}
       </div>
-    </auth-layout>
+    </bk-auth-shell>
   `,
   styleUrls: ['./forgot-password.page.scss']
 })
@@ -129,6 +128,12 @@ export class ForgotPasswordPage implements OnInit {
   readonly statusMessage = signal('');
   readonly emailSent = signal(false);
   readonly submittedEmail = signal('');
+
+  readonly features = [
+    { icon: 'i-grid', titleKey: 'auth.hero.feature1', descKey: 'auth.hero.feature1Desc' },
+    { icon: 'i-clock', titleKey: 'auth.hero.feature2', descKey: 'auth.hero.feature2Desc' },
+    { icon: 'i-trending-up', titleKey: 'auth.hero.feature3', descKey: 'auth.hero.feature3Desc' }
+  ];
 
   forgotPasswordForm!: FormGroup;
 

--- a/front/src/app/features/auth/pages/login.page.scss
+++ b/front/src/app/features/auth/pages/login.page.scss
@@ -1,23 +1,22 @@
-.card {
-  &-header {
-    text-align: center;
-    margin-bottom: 32px;
-  }
 
-  &-title {
-    font-size: 24px;
-    font-weight: 700;
-    color: var(--text-1);
-    margin: 0 0 8px 0;
-    line-height: 1.3;
-  }
+.card-header {
+  text-align: center;
+  margin-bottom: 32px;
+}
 
-  &-subtitle {
-    font-size: 14px;
-    color: var(--muted);
-    margin: 0;
-    line-height: 1.4;
-  }
+.card-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text-1);
+  margin: 0 0 8px 0;
+  line-height: 1.3;
+}
+
+.card-subtitle {
+  font-size: 14px;
+  color: var(--muted);
+  margin: 0;
+  line-height: 1.4;
 }
 
 .auth-form {
@@ -26,50 +25,6 @@
   gap: 20px;
 }
 
-.btn {
-  height: 40px;
-  border-radius: 10px;
-  font-size: 14px;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  transition: all 0.2s ease;
-  text-decoration: none;
-  outline: none;
-
-  &:focus-visible {
-    box-shadow: 0 0 0 3px var(--brand-500);
-    opacity: 0.2;
-  }
-
-  &--primary {
-    background: var(--brand-500);
-    color: white;
-
-    &:hover:not(:disabled) {
-      background: var(--brand-600);
-      transform: translateY(-1px);
-    }
-
-    &:active:not(:disabled) {
-      transform: translateY(0);
-    }
-
-    &:disabled {
-      background: var(--muted);
-      cursor: not-allowed;
-      transform: none;
-    }
-  }
-
-  &.w-100 {
-    width: 100%;
-  }
-}
 
 .loading-spinner {
   display: flex;
@@ -121,50 +76,14 @@
   }
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.visually-hidden {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
-}
-
-// Dark theme adjustments
-@media (prefers-color-scheme: dark) {
-  .btn--primary {
-    &:disabled {
-      background: var(--surface-2);
-      color: var(--muted);
-    }
-  }
-}
-
 // Mobile responsive
 @media (max-width: 480px) {
-  .card {
-    &-title {
-      font-size: 20px;
-    }
+  .card-title {
+    font-size: 20px;
+  }
 
-    &-subtitle {
-      font-size: 13px;
-    }
+  .card-subtitle {
+    font-size: 13px;
   }
 
   .links {

--- a/front/src/app/features/auth/pages/login.page.ts
+++ b/front/src/app/features/auth/pages/login.page.ts
@@ -7,7 +7,7 @@ import { AuthV5Service } from '../../../core/services/auth-v5.service';
 import { TranslationService } from '../../../core/services/translation.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { TranslatePipe } from '../../../shared/pipes/translate.pipe';
-import { AuthLayoutComponent } from '../ui/auth-layout/auth-layout.component';
+import { AuthShellComponent } from '../ui/auth-shell/auth-shell.component';
 import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
 
 @Component({
@@ -18,23 +18,27 @@ import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
     ReactiveFormsModule,
     RouterLink,
     TranslatePipe,
-    AuthLayoutComponent,
+    AuthShellComponent,
     TextFieldComponent
   ],
   template: `
-    <auth-layout 
-      [title]="'auth.hero.welcomeBack' | translate" 
-      [subtitle]="'auth.login.subtitle' | translate">
-      
-      <div class="card" role="form" [attr.aria-labelledby]="'loginTitle'">
-        <h2 id="loginTitle" class="visually-hidden">{{ 'auth.login.title' | translate }}</h2>
-        
-        <div class="card-header">
-          <h1 class="card-title">{{ 'auth.login.title' | translate }}</h1>
-          <p class="card-subtitle">{{ 'auth.login.subtitle' | translate }}</p>
-        </div>
+    <bk-auth-shell
+      [titleKey]="'auth.hero.welcomeBack'"
+      [subtitleKey]="'auth.login.subtitle'"
+      [features]="features">
 
-        <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="auth-form">
+      <h2 id="loginTitle" class="visually-hidden">{{ 'auth.login.title' | translate }}</h2>
+
+      <div class="card-header">
+        <h1 class="card-title">{{ 'auth.login.title' | translate }}</h1>
+        <p class="card-subtitle">{{ 'auth.login.subtitle' | translate }}</p>
+      </div>
+
+      <form
+        [formGroup]="loginForm"
+        (ngSubmit)="onSubmit()"
+        class="auth-form"
+        [attr.aria-labelledby]="'loginTitle'">
           <!-- Email -->
           <ui-text-field
             [label]="'auth.common.email' | translate"
@@ -69,9 +73,9 @@ import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
             </button>
           </ui-text-field>
 
-          <button 
-            type="submit" 
-            class="btn btn--primary w-100" 
+          <button
+            type="submit"
+            class="btn btn--primary w-100"
             [disabled]="loginForm.invalid || isLoading()"
             [attr.aria-describedby]="statusMessage() ? 'status-message' : null">
             @if (isLoading()) {
@@ -91,17 +95,16 @@ import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
             <a routerLink="/auth/register">{{ 'auth.common.signup' | translate }}</a>
           </div>
 
-          <div 
+          <div
             id="status-message"
-            class="sr-only" 
-            role="status" 
+            class="visually-hidden"
+            role="status"
             aria-live="polite"
             [attr.aria-hidden]="!statusMessage()">
             {{ statusMessage() }}
           </div>
         </form>
-      </div>
-    </auth-layout>
+    </bk-auth-shell>
   `,
   styleUrls: ['./login.page.scss']
 })
@@ -116,6 +119,12 @@ export class LoginPage implements OnInit {
   readonly isLoading = signal(false);
   readonly showPassword = signal(false);
   readonly statusMessage = signal('');
+
+  readonly features = [
+    { icon: 'i-grid', titleKey: 'auth.hero.feature1', descKey: 'auth.hero.feature1Desc' },
+    { icon: 'i-clock', titleKey: 'auth.hero.feature2', descKey: 'auth.hero.feature2Desc' },
+    { icon: 'i-trending-up', titleKey: 'auth.hero.feature3', descKey: 'auth.hero.feature3Desc' }
+  ];
 
   loginForm!: FormGroup;
 

--- a/front/src/app/features/auth/pages/register.page.ts
+++ b/front/src/app/features/auth/pages/register.page.ts
@@ -7,7 +7,7 @@ import { AuthV5Service } from '../../../core/services/auth-v5.service';
 import { TranslationService } from '../../../core/services/translation.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { TranslatePipe } from '../../../shared/pipes/translate.pipe';
-import { AuthLayoutComponent } from '../ui/auth-layout/auth-layout.component';
+import { AuthShellComponent } from '../ui/auth-shell/auth-shell.component';
 import { TextFieldComponent } from '../../../ui/atoms/text-field.component';
 
 // Custom validator for password confirmation
@@ -30,23 +30,27 @@ function passwordMatchValidator(control: AbstractControl): { [key: string]: bool
     ReactiveFormsModule,
     RouterLink,
     TranslatePipe,
-    AuthLayoutComponent,
+    AuthShellComponent,
     TextFieldComponent
   ],
   template: `
-    <auth-layout 
-      [title]="'auth.hero.join' | translate" 
-      [subtitle]="'auth.register.subtitle' | translate">
-      
-      <div class="card" role="form" [attr.aria-labelledby]="'registerTitle'">
-        <h2 id="registerTitle" class="visually-hidden">{{ 'auth.register.title' | translate }}</h2>
-        
-        <div class="card-header">
-          <h1 class="card-title">{{ 'auth.register.title' | translate }}</h1>
-          <p class="card-subtitle">{{ 'auth.register.subtitle' | translate }}</p>
-        </div>
+    <bk-auth-shell
+      [titleKey]="'auth.hero.join'"
+      [subtitleKey]="'auth.register.subtitle'"
+      [features]="features">
 
-        <form [formGroup]="registerForm" (ngSubmit)="onSubmit()" class="auth-form">
+      <h2 id="registerTitle" class="visually-hidden">{{ 'auth.register.title' | translate }}</h2>
+
+      <div class="card-header">
+        <h1 class="card-title">{{ 'auth.register.title' | translate }}</h1>
+        <p class="card-subtitle">{{ 'auth.register.subtitle' | translate }}</p>
+      </div>
+
+      <form
+        [formGroup]="registerForm"
+        (ngSubmit)="onSubmit()"
+        class="auth-form"
+        [attr.aria-labelledby]="'registerTitle'">
           <!-- Name -->
           <ui-text-field
             [label]="'auth.name.label' | translate"
@@ -135,17 +139,16 @@ function passwordMatchValidator(control: AbstractControl): { [key: string]: bool
             <a routerLink="/auth/login">{{ 'auth.common.signin' | translate }}</a>
           </div>
 
-          <div 
+          <div
             id="status-message"
-            class="sr-only" 
-            role="status" 
+            class="visually-hidden"
+            role="status"
             aria-live="polite"
             [attr.aria-hidden]="!statusMessage()">
             {{ statusMessage() }}
           </div>
         </form>
-      </div>
-    </auth-layout>
+    </bk-auth-shell>
   `,
   styleUrls: ['./register.page.scss']
 })
@@ -161,6 +164,12 @@ export class RegisterPage implements OnInit {
   readonly showPassword = signal(false);
   readonly showConfirmPassword = signal(false);
   readonly statusMessage = signal('');
+
+  readonly features = [
+    { icon: 'i-grid', titleKey: 'auth.hero.feature1', descKey: 'auth.hero.feature1Desc' },
+    { icon: 'i-clock', titleKey: 'auth.hero.feature2', descKey: 'auth.hero.feature2Desc' },
+    { icon: 'i-trending-up', titleKey: 'auth.hero.feature3', descKey: 'auth.hero.feature3Desc' }
+  ];
 
   registerForm!: FormGroup;
 

--- a/front/src/app/ui/atoms/text-field.component.ts
+++ b/front/src/app/ui/atoms/text-field.component.ts
@@ -53,7 +53,7 @@ export type TextFieldType = 'text' | 'email' | 'password' | 'tel' | 'url' | 'sea
       </div>
       
       @if (hint || errorMessage) {
-        <div class="field-message" [id]="messageId">
+        <div class="field-message" [id]="messageId" aria-live="polite">
           @if (hasError && errorMessage) {
             <span class="error-message">{{ errorMessage }}</span>
           } @else if (hint) {


### PR DESCRIPTION
## Summary
- replace AuthLayout with AuthShell on login, register, and forgot-password pages
- wrap forms in `<bk-auth-shell>` and provide feature lists
- improve text field accessibility with polite error announcements

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' in several specs)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d909c8e083209098f5a46484f07e