### PR TITLE
feat: add context service binding

### DIFF
--- a/app/Http/Controllers/Api/V5/ContextController.php
+++ b/app/Http/Controllers/Api/V5/ContextController.php
@@ -22,7 +22,7 @@ class ContextController extends Controller
     public function show(Request $request): JsonResponse
     {
         return response()->json(
-            $this->contextService->getContext($request->user())
+            $this->contextService->get($request->user())
         );
     }
 
@@ -41,7 +41,7 @@ class ContextController extends Controller
 
         $this->authorize('switch', $school);
 
-        $context = $this->contextService->switchSchool($user, $schoolId);
+        $context = $this->contextService->setSchool($user, $schoolId);
         if (! $context) {
             return $this->problem('No active access token', Response::HTTP_UNAUTHORIZED);
         }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\Sanctum;
+use App\Services\V5\ContextService;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -17,6 +18,8 @@ class AppServiceProvider extends ServiceProvider
             \App\Services\Weather\WeatherProviderInterface::class,
             \App\Services\Weather\AccuWeatherProvider::class
         );
+
+        $this->app->singleton(ContextService::class);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add ContextService with get and setSchool methods
- update API controller to use new ContextService API
- register ContextService binding in AppServiceProvider

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: ./vendor/bin/phpunit tests/Feature/V5/Context/SchoolSelectorTest.php` *(fails: process did not complete; environment may lack database support)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d9165fac83209926e002f3ebdee1