### PR TITLE
Add configurable school-user pivot table

### DIFF
--- a/app/Models/School.php
+++ b/app/Models/School.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes; use Illuminate\Database\Eloquent\F
 use Illuminate\Support\Facades\Log;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
+use App\Support\Pivot;
 
 /**
  * @OA\Schema(
@@ -498,7 +499,7 @@ class School extends Model
 
     public function users(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'school_user', 'school_id', 'user_id');
+        return $this->belongsToMany(User::class, Pivot::schoolUserTable(), 'school_id', 'user_id');
     }
 
     public function seasons(): \Illuminate\Database\Eloquent\Relations\HasMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Traits\HasRoles;
 use App\V5\Models\UserSeasonRole;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Support\Pivot;
 
 /**
  * @OA\Schema(
@@ -187,7 +188,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
     {
         return $this->belongsToMany(
             \App\Models\School::class,
-            'school_user', // Tabla pivote
+            Pivot::schoolUserTable(), // Tabla pivote
             'user_id', // Clave foránea del modelo actual
             'school_id' // Clave foránea del modelo relacionado
         )->where('schools.active', 1)

--- a/app/Support/Pivot.php
+++ b/app/Support/Pivot.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Support;
+
+class Pivot
+{
+    public static function schoolUserTable(): string
+    {
+        return config('v5.pivot.school_user_table', 'school_user');
+    }
+}
+

--- a/config/v5.php
+++ b/config/v5.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'pivot' => [
+        'school_user_table' => 'school_user',
+    ],
+];
+


### PR DESCRIPTION
## Summary
- add `Pivot` support class to centralize dynamic pivot table names
- provide `v5.pivot.school_user_table` config with default `school_user`
- update `User::schools()` and `School::users()` to use dynamic pivot table

## Testing
- `./vendor/bin/phpunit` *(fails: no tests run or output not produced; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68a6de6271ec83209a4a82bdd2cdf96c