### PR TITLE
test(auth): add auth page form validation specs

### DIFF
--- a/front/src/app/features/auth/pages/forgot-password.page.spec.ts
+++ b/front/src/app/features/auth/pages/forgot-password.page.spec.ts
@@ -1,0 +1,78 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { APP_BASE_HREF } from '@angular/common';
+
+import { ForgotPasswordPage } from './forgot-password.page';
+import { AuthV5Service } from '../../../core/services/auth-v5.service';
+import { TranslationService } from '../../../core/services/translation.service';
+import { ToastService } from '../../../core/services/toast.service';
+
+describe('ForgotPasswordPage', () => {
+  let component: ForgotPasswordPage;
+  let fixture: ComponentFixture<ForgotPasswordPage>;
+  let mockAuth: jest.Mocked<AuthV5Service>;
+  let mockTranslation: jest.Mocked<TranslationService>;
+
+  beforeEach(async () => {
+    const authSpy: Partial<AuthV5Service> = {
+      isAuthenticated: (() => false) as any,
+      forgotPassword: jest.fn()
+    };
+    const translationSpy: Partial<TranslationService> = {
+      get: jest.fn((key: string) => key),
+      currentLanguage: jest.fn().mockReturnValue('en')
+    };
+    const routerSpy = { navigate: jest.fn() };
+    const toastSpy = { success: jest.fn(), error: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [ForgotPasswordPage, RouterTestingModule.withRoutes([])],
+      providers: [
+        { provide: AuthV5Service, useValue: authSpy },
+        { provide: TranslationService, useValue: translationSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: APP_BASE_HREF, useValue: '/' }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPasswordPage);
+    component = fixture.componentInstance;
+    mockAuth = TestBed.inject(AuthV5Service) as jest.Mocked<AuthV5Service>;
+    mockTranslation = TestBed.inject(TranslationService) as jest.Mocked<TranslationService>;
+    fixture.detectChanges();
+  });
+
+  it('should show required email error', () => {
+    component.forgotPasswordForm.get('email')?.markAsTouched();
+    const error = component.getFieldError('email');
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.requiredEmail');
+    expect(error).toBe('auth.errors.requiredEmail');
+  });
+
+  it('should validate email format', () => {
+    component.forgotPasswordForm.patchValue({ email: 'invalid' });
+    component.forgotPasswordForm.get('email')?.markAsTouched();
+    const error = component.getFieldError('email');
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.invalidEmail');
+    expect(error).toBe('auth.errors.invalidEmail');
+  });
+
+  it('should enable submit button only when form valid', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button[type="submit"]');
+    expect(button.disabled).toBe(true);
+
+    component.forgotPasswordForm.patchValue({ email: 'test@example.com' });
+    fixture.detectChanges();
+
+    expect(button.disabled).toBe(false);
+  });
+
+  it('should use translation keys for rendering', () => {
+    mockTranslation.get.mockClear();
+    fixture.detectChanges();
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.forgotPassword.button');
+  });
+});
+

--- a/front/src/app/features/auth/pages/login.page.spec.ts
+++ b/front/src/app/features/auth/pages/login.page.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { APP_BASE_HREF } from '@angular/common';
+
+import { LoginPage } from './login.page';
+import { AuthV5Service } from '../../../core/services/auth-v5.service';
+import { TranslationService } from '../../../core/services/translation.service';
+import { ToastService } from '../../../core/services/toast.service';
+
+describe('LoginPage', () => {
+  let component: LoginPage;
+  let fixture: ComponentFixture<LoginPage>;
+  let mockAuth: jest.Mocked<AuthV5Service>;
+  let mockTranslation: jest.Mocked<TranslationService>;
+
+  beforeEach(async () => {
+    const authSpy: Partial<AuthV5Service> = {
+      isAuthenticated: (() => false) as any,
+      checkUser: jest.fn()
+    };
+    const translationSpy: Partial<TranslationService> = {
+      get: jest.fn((key: string) => key),
+      currentLanguage: jest.fn().mockReturnValue('en')
+    };
+    const routerSpy = { navigate: jest.fn() };
+    const toastSpy = { success: jest.fn(), error: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [LoginPage, RouterTestingModule.withRoutes([])],
+      providers: [
+        { provide: AuthV5Service, useValue: authSpy },
+        { provide: TranslationService, useValue: translationSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: APP_BASE_HREF, useValue: '/' }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPage);
+    component = fixture.componentInstance;
+    mockAuth = TestBed.inject(AuthV5Service) as jest.Mocked<AuthV5Service>;
+    mockTranslation = TestBed.inject(TranslationService) as jest.Mocked<TranslationService>;
+    fixture.detectChanges();
+  });
+
+  it('should show required field errors', () => {
+    component.loginForm.get('email')?.markAsTouched();
+    component.loginForm.get('password')?.markAsTouched();
+
+    const emailError = component.getFieldError('email');
+    const passwordError = component.getFieldError('password');
+
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.requiredEmail');
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.requiredPassword');
+    expect(emailError).toBe('auth.errors.requiredEmail');
+    expect(passwordError).toBe('auth.errors.requiredPassword');
+  });
+
+  it('should validate email format', () => {
+    component.loginForm.patchValue({ email: 'invalid' });
+    component.loginForm.get('email')?.markAsTouched();
+
+    const error = component.getFieldError('email');
+
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.invalidEmail');
+    expect(error).toBe('auth.errors.invalidEmail');
+  });
+
+  it('should enable submit button only when form valid', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button[type="submit"]');
+    expect(button.disabled).toBe(true);
+
+    component.loginForm.patchValue({ email: 'test@example.com', password: 'abcdef' });
+    fixture.detectChanges();
+
+    expect(button.disabled).toBe(false);
+  });
+
+  it('should use translation keys for rendering', () => {
+    mockTranslation.get.mockClear();
+    fixture.detectChanges();
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.common.signin');
+  });
+});
+

--- a/front/src/app/features/auth/pages/register.page.spec.ts
+++ b/front/src/app/features/auth/pages/register.page.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { APP_BASE_HREF } from '@angular/common';
+
+import { RegisterPage } from './register.page';
+import { AuthV5Service } from '../../../core/services/auth-v5.service';
+import { TranslationService } from '../../../core/services/translation.service';
+import { ToastService } from '../../../core/services/toast.service';
+
+describe('RegisterPage', () => {
+  let component: RegisterPage;
+  let fixture: ComponentFixture<RegisterPage>;
+  let mockAuth: jest.Mocked<AuthV5Service>;
+  let mockTranslation: jest.Mocked<TranslationService>;
+
+  beforeEach(async () => {
+    const authSpy: Partial<AuthV5Service> = {
+      isAuthenticated: (() => false) as any,
+      register: jest.fn()
+    };
+    const translationSpy: Partial<TranslationService> = {
+      get: jest.fn((key: string) => key),
+      currentLanguage: jest.fn().mockReturnValue('en')
+    };
+    const routerSpy = { navigate: jest.fn() };
+    const toastSpy = { success: jest.fn(), error: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [RegisterPage, RouterTestingModule.withRoutes([])],
+      providers: [
+        { provide: AuthV5Service, useValue: authSpy },
+        { provide: TranslationService, useValue: translationSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: APP_BASE_HREF, useValue: '/' }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegisterPage);
+    component = fixture.componentInstance;
+    mockAuth = TestBed.inject(AuthV5Service) as jest.Mocked<AuthV5Service>;
+    mockTranslation = TestBed.inject(TranslationService) as jest.Mocked<TranslationService>;
+    fixture.detectChanges();
+  });
+
+  it('should show required field errors', () => {
+    component.registerForm.get('email')?.markAsTouched();
+    component.registerForm.get('password')?.markAsTouched();
+    component.registerForm.get('confirmPassword')?.markAsTouched();
+
+    const emailError = component.getFieldError('email');
+    const passwordError = component.getFieldError('password');
+    const confirmError = component.getFieldError('confirmPassword');
+
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.requiredEmail');
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.requiredPassword');
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.requiredConfirmPassword');
+    expect(emailError).toBe('auth.errors.requiredEmail');
+    expect(passwordError).toBe('auth.errors.requiredPassword');
+    expect(confirmError).toBe('auth.errors.requiredConfirmPassword');
+  });
+
+  it('should validate email format', () => {
+    component.registerForm.patchValue({ email: 'invalid' });
+    component.registerForm.get('email')?.markAsTouched();
+
+    const error = component.getFieldError('email');
+
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.invalidEmail');
+    expect(error).toBe('auth.errors.invalidEmail');
+  });
+
+  it('should show password mismatch error', () => {
+    component.registerForm.patchValue({ password: 'abc123', confirmPassword: 'xyz789' });
+    component.registerForm.get('password')?.markAsTouched();
+    component.registerForm.get('confirmPassword')?.markAsTouched();
+    component.registerForm.updateValueAndValidity();
+
+    const error = component.getPasswordMatchError();
+
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.errors.passwordsNoMatch');
+    expect(error).toBe('auth.errors.passwordsNoMatch');
+  });
+
+  it('should enable submit button only when form valid', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button[type="submit"]');
+    expect(button.disabled).toBe(true);
+
+    component.registerForm.patchValue({
+      name: 'Test',
+      email: 'test@example.com',
+      password: 'abcdef',
+      confirmPassword: 'abcdef'
+    });
+    fixture.detectChanges();
+
+    expect(button.disabled).toBe(false);
+  });
+
+  it('should use translation keys for rendering', () => {
+    mockTranslation.get.mockClear();
+    fixture.detectChanges();
+    expect(mockTranslation.get).toHaveBeenCalledWith('auth.common.signup');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add login page spec covering required fields, email format, button state, and translation usage
- add register page spec including password mismatch checks and translation assertions
- add forgot password page spec verifying validation and translation keys

## Testing
- `cd front && npm test` *(fails: Cannot read properties of undefined (reading 'root') and other existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e0abce24832085f434c414154093