### PR TITLE
docs: document context_data storage

### DIFF
--- a/docs/backend/ARCHITECTURE.md
+++ b/docs/backend/ARCHITECTURE.md
@@ -90,6 +90,8 @@ Route::middleware(['auth:sanctum', 'context.middleware'])->group(function () {
 
 ## 🎪 Tokens y Context Data
 
+La columna `personal_access_tokens.context_data` almacena un objeto JSON con las claves `school_id` y `season_id`, por lo que no debe crearse una tabla separada para el contexto.
+
 ### Estructura del Token
 ```php
 'context_data' => json_encode([


### PR DESCRIPTION
## Summary
- clarify that `personal_access_tokens.context_data` stores `{school_id, season_id}` and no extra table is needed

## Testing
- `vendor/bin/phpunit tests/Unit/V5/ContextMiddlewareTest.php` *(fails: Mockery exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e845e3a483209aa4a0e95f1dd157