### PR TITLE
Add context rate limiter and tests for v5 routes

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -71,6 +71,6 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinutes($decayMinutes, $maxAttempts)->by($request->ip());
         });
 
-        RateLimiter::for('context', fn (Request $r) => Limit::perMinute(60)->by(optional($r->user())->id ?: $r->ip()));
+        RateLimiter::for('context', fn (Request $r) => Limit::perMinute(30)->by(optional($r->user())->id ?: $r->ip()));
     }
 }

--- a/tests/Feature/V5/Context/RateLimitTest.php
+++ b/tests/Feature/V5/Context/RateLimitTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\V5\Context;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class RateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $token;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token')->plainTextToken;
+
+        RateLimiter::clear('context:' . $this->user->id);
+    }
+
+    public function test_allows_30_requests_per_minute()
+    {
+        for ($i = 0; $i < 30; $i++) {
+            $response = $this->getJson('/api/v5/context', [
+                'Authorization' => 'Bearer ' . $this->token,
+            ]);
+
+            $response->assertStatus(200);
+        }
+    }
+
+    public function test_blocks_after_30_requests_per_minute()
+    {
+        for ($i = 0; $i < 30; $i++) {
+            $this->getJson('/api/v5/context', [
+                'Authorization' => 'Bearer ' . $this->token,
+            ]);
+        }
+
+        $response = $this->getJson('/api/v5/context', [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response->assertStatus(429);
+    }
+}
+


### PR DESCRIPTION
## Summary
- tighten v5 context rate limiter to 30 requests per minute keyed by user or IP
- cover context endpoints with a feature test ensuring 200 inside limit and 429 once exceeded

## Testing
- `php artisan route:list --json | jq '.[] | select(.uri=="api/v5/context")'`
- ⚠️ `./vendor/bin/phpunit tests/Feature/V5/Context/RateLimitTest.php` *(hangs without completing)*


------
https://chatgpt.com/codex/tasks/task_e_68a80a472a908320a091b4d0337720b0