### PR TITLE
refactor: centralize user-school pivot

### DIFF
--- a/app/Models/School.php
+++ b/app/Models/School.php
@@ -499,7 +499,15 @@ class School extends Model
 
     public function users(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
-        return $this->belongsToMany(User::class, Pivot::schoolUserTable(), 'school_id', 'user_id');
+        return $this->belongsToMany(
+            User::class,
+            Pivot::USER_SCHOOLS,
+            'school_id',
+            'user_id'
+        )
+        ->whereNull(Pivot::USER_SCHOOLS . '.deleted_at')
+        ->where('users.active', 1)
+        ->whereNull('users.deleted_at');
     }
 
     public function seasons(): \Illuminate\Database\Eloquent\Relations\HasMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -188,11 +188,13 @@ use App\Support\Pivot;
     {
         return $this->belongsToMany(
             \App\Models\School::class,
-            Pivot::schoolUserTable(), // Tabla pivote
-            'user_id', // Clave foránea del modelo actual
-            'school_id' // Clave foránea del modelo relacionado
-        )->where('schools.active', 1)
-         ->whereNull('schools.deleted_at');
+            Pivot::USER_SCHOOLS,
+            'user_id',
+            'school_id'
+        )
+        ->whereNull(Pivot::USER_SCHOOLS . '.deleted_at')
+        ->where('schools.active', 1)
+        ->whereNull('schools.deleted_at');
     }
 
     /**

--- a/app/Support/Pivot.php
+++ b/app/Support/Pivot.php
@@ -4,9 +4,11 @@ namespace App\Support;
 
 class Pivot
 {
+    public const USER_SCHOOLS = 'school_user';
+
     public static function schoolUserTable(): string
     {
-        return config('v5.pivot.school_user_table', 'school_user');
+        return self::USER_SCHOOLS;
     }
 }
 

--- a/tests/Feature/V5/Context/RelationsTest.php
+++ b/tests/Feature/V5/Context/RelationsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature\V5\Context;
+
+use App\Models\School;
+use App\Models\User;
+use App\Support\Pivot;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class RelationsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['database.default' => 'sqlite']);
+        config(['database.connections.sqlite.database' => ':memory:']);
+        config(['activitylog.enabled' => false]);
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->nullable();
+            $table->string('password');
+            $table->string('type', 100)->nullable();
+            $table->boolean('active')->default(1);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        Schema::create('schools', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->string('slug')->nullable();
+            $table->boolean('active')->default(1);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        Schema::create(Pivot::USER_SCHOOLS, function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('school_id');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists(Pivot::USER_SCHOOLS);
+        Schema::dropIfExists('schools');
+        Schema::dropIfExists('users');
+
+        parent::tearDown();
+    }
+
+    public function test_attach_and_detach_schools()
+    {
+        $user = User::create([
+            'email' => 'user@example.com',
+            'password' => 'secret',
+            'type' => 'admin',
+            'active' => true,
+        ]);
+
+        $school = School::create([
+            'name' => 'Test School',
+            'description' => 'desc',
+            'slug' => 'test',
+            'active' => true,
+        ]);
+
+        $user->schools()->attach($school->id);
+
+        $this->assertDatabaseHas(Pivot::USER_SCHOOLS, [
+            'user_id' => $user->id,
+            'school_id' => $school->id,
+            'deleted_at' => null,
+        ]);
+
+        $user->schools()->detach($school->id);
+
+        $this->assertDatabaseMissing(Pivot::USER_SCHOOLS, [
+            'user_id' => $user->id,
+            'school_id' => $school->id,
+            'deleted_at' => null,
+        ]);
+    }
+
+    public function test_sync_schools()
+    {
+        $user = User::create([
+            'email' => 'user@example.com',
+            'password' => 'secret',
+            'type' => 'admin',
+            'active' => true,
+        ]);
+
+        $school1 = School::create([
+            'name' => 'School 1',
+            'description' => 'desc1',
+            'slug' => 'school-1',
+            'active' => true,
+        ]);
+
+        $school2 = School::create([
+            'name' => 'School 2',
+            'description' => 'desc2',
+            'slug' => 'school-2',
+            'active' => true,
+        ]);
+
+        $user->schools()->sync([$school1->id, $school2->id]);
+
+        $this->assertDatabaseHas(Pivot::USER_SCHOOLS, [
+            'user_id' => $user->id,
+            'school_id' => $school1->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->assertDatabaseHas(Pivot::USER_SCHOOLS, [
+            'user_id' => $user->id,
+            'school_id' => $school2->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->assertCount(2, $user->schools()->get());
+    }
+}
+

--- a/tests/Feature/V5/Context/SchoolSelectorTest.php
+++ b/tests/Feature/V5/Context/SchoolSelectorTest.php
@@ -7,7 +7,6 @@ use App\Models\User;
 use App\Services\ContextService;
 use App\Support\Pivot;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Permission;
 use Tests\TestCase;
@@ -25,8 +24,6 @@ class SchoolSelectorTest extends TestCase
     {
         parent::setUp();
 
-        Config::set('v5.pivot.school_user_table', 'school_users');
-
         Permission::create(['name' => 'schools.view']);
         Permission::create(['name' => 'schools.switch']);
 
@@ -36,7 +33,7 @@ class SchoolSelectorTest extends TestCase
         $this->schoolOwned = School::factory()->create(['active' => true]);
         $this->otherSchool = School::factory()->create(['active' => true]);
 
-        DB::table(Pivot::schoolUserTable())->insert([
+        DB::table(Pivot::USER_SCHOOLS)->insert([
             'user_id' => $this->user->id,
             'school_id' => $this->schoolOwned->id,
         ]);


### PR DESCRIPTION
## Summary
- define `Pivot::USER_SCHOOLS` constant for existing `school_user` table
- use pivot constant in `User::schools()` and `School::users()` with soft delete filters
- cover attach/detach/sync behaviour of the user-school relation in tests

## Testing
- `composer install`
- `vendor/bin/phpunit tests/Feature/V5/Context/RelationsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a81620ee4083209f02adfe7ae0cb26