### PR TITLE
feat: add clients list page

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -23,13 +23,19 @@ export const routes: Routes = [
   },
   {
     path: 'dashboard',
-    loadComponent: () => 
+    loadComponent: () =>
       import('./features/dashboard/dashboard-page.component').then(c => c.DashboardPageComponent),
     canActivate: [authV5Guard]
   },
   {
+    path: 'clients',
+    loadComponent: () =>
+      import('./features/clients/clients-list.page').then(c => c.ClientsListPageComponent),
+    canActivate: [authV5Guard]
+  },
+  {
     path: 'select-school',
-    loadComponent: () => 
+    loadComponent: () =>
       import('./features/school-selection/select-school.page').then(c => c.SelectSchoolPageComponent),
     canActivate: [authV5Guard, schoolSelectionGuard]
   },

--- a/front/src/app/features/clients/clients-list.page.ts
+++ b/front/src/app/features/clients/clients-list.page.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslatePipe } from '@shared/pipes/translate.pipe';
+
+@Component({
+  selector: 'app-clients-list-page',
+  standalone: true,
+  imports: [CommonModule, TranslatePipe],
+  template: `
+    <div class="page">
+      <div class="page-header">
+        <h1>{{ 'clients.title' | translate }}</h1>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>{{ 'clients.fullName' | translate }}</th>
+            <th>{{ 'clients.email' | translate }}</th>
+            <th>{{ 'clients.phone' | translate }}</th>
+            <th>{{ 'clients.utilizadores' | translate }}</th>
+            <th>{{ 'clients.sportsSummary' | translate }}</th>
+            <th>{{ 'clients.status' | translate }}</th>
+            <th>{{ 'clients.signupDate' | translate }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>John Doe</td>
+            <td>john@example.com</td>
+            <td>555-1234</td>
+            <td>0</td>
+            <td>Surf, Yoga</td>
+            <td>Active</td>
+            <td>2024-01-01</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  `,
+  styles: [
+    `
+      table {
+        width: 100%;
+      }
+      th, td {
+        padding: 8px;
+        text-align: left;
+      }
+    `,
+  ],
+})
+export class ClientsListPageComponent {}
+

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnInit, computed, signal, HostListener, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { ThemeToggleComponent } from '@ui/theme-toggle/theme-toggle.component';
 import { ToastComponent } from '@shared/components/toast/toast.component';
 import { LanguageSelectorComponent } from '@shared/components/language-selector/language-selector.component';
@@ -27,6 +27,8 @@ interface Notification {
   imports: [
     CommonModule,
     RouterOutlet,
+    RouterLink,
+    RouterLinkActive,
     ThemeToggleComponent,
     ToastComponent,
     LanguageSelectorComponent,
@@ -327,7 +329,13 @@ interface Notification {
             </a>
 
             <!-- Clientes -->
-            <a href="#" class="nav-item item" role="menuitem" [title]="ui.sidebarCollapsed() ? ('nav.clientes' | translate) : null">
+            <a
+              routerLink="/clients"
+              routerLinkActive="active"
+              class="nav-item item"
+              role="menuitem"
+              [title]="ui.sidebarCollapsed() ? ('nav.clientes' | translate) : null"
+            >
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>


### PR DESCRIPTION
## Summary
- add standalone clients list page showing basic client info table
- wire up clients route with auth guard
- link clients page in app shell navigation

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' and related TS errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8239d6f048320a5ce8b1f141f8a80