### PR TITLE
feat(clients): sync filters with query params

### DIFF
--- a/front/src/app/features/clients/clients-list.page.spec.ts
+++ b/front/src/app/features/clients/clients-list.page.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ClientsListPageComponent } from './clients-list.page';
+import { ClientsV5Service, ClientsResponse } from '@core/services/clients-v5.service';
+import { ContextService } from '@core/services/context.service';
+import { TranslationService } from '@core/services/translation.service';
+
+describe('ClientsListPageComponent', () => {
+  let component: ClientsListPageComponent;
+  let fixture: ComponentFixture<ClientsListPageComponent>;
+  let clientsService: jest.Mocked<ClientsV5Service>;
+  let router: jest.Mocked<Router>;
+
+  beforeEach(async () => {
+    const mockResponse: ClientsResponse = {
+      data: [],
+      meta: { pagination: { page: 1, limit: 0, total: 0, totalPages: 0 } }
+    };
+
+    const clientsServiceMock = {
+      getClients: jest.fn().mockReturnValue(of(mockResponse))
+    } as Partial<jest.Mocked<ClientsV5Service>>;
+
+    const routerMock = {
+      navigate: jest.fn()
+    } as Partial<jest.Mocked<Router>>;
+
+    const contextServiceStub = { schoolId: () => 1 } as unknown as ContextService;
+
+    const activatedRouteStub = {
+      snapshot: {
+        queryParamMap: convertToParamMap({ q: 'john', sport_id: '2', active: 'true' })
+      }
+    } as ActivatedRoute;
+
+    const translationServiceStub = {
+      get: () => '',
+      currentLanguage: () => 'en',
+      instant: () => '',
+      formatDate: () => '',
+      formatNumber: () => ''
+    } as Partial<TranslationService>;
+
+    await TestBed.configureTestingModule({
+      imports: [ClientsListPageComponent],
+      providers: [
+        { provide: ClientsV5Service, useValue: clientsServiceMock },
+        { provide: Router, useValue: routerMock },
+        { provide: ActivatedRoute, useValue: activatedRouteStub },
+        { provide: ContextService, useValue: contextServiceStub },
+        { provide: TranslationService, useValue: translationServiceStub }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ClientsListPageComponent);
+    component = fixture.componentInstance;
+    clientsService = TestBed.inject(ClientsV5Service) as jest.Mocked<ClientsV5Service>;
+    router = TestBed.inject(Router) as jest.Mocked<Router>;
+
+    fixture.detectChanges();
+  });
+
+  it('should restore filters from query params on init', () => {
+    expect(component.filtersForm.value).toEqual({ q: 'john', sport_id: '2', active: 'true' });
+    expect(clientsService.getClients).toHaveBeenCalledWith({
+      school_id: 1,
+      q: 'john',
+      sport_id: 2,
+      active: true
+    });
+  });
+
+  it('should update query params and fetch clients when filters change', () => {
+    clientsService.getClients.mockClear();
+    router.navigate.mockClear();
+
+    component.filtersForm.setValue({ q: 'jane', sport_id: '3', active: 'false' });
+
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      queryParams: { q: 'jane', sport_id: '3', active: 'false' },
+      queryParamsHandling: 'merge'
+    });
+    expect(clientsService.getClients).toHaveBeenCalledWith({
+      school_id: 1,
+      q: 'jane',
+      sport_id: 3,
+      active: false
+    });
+  });
+});
+

--- a/front/src/app/features/clients/clients-list.page.ts
+++ b/front/src/app/features/clients/clients-list.page.ts
@@ -1,16 +1,30 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { TranslatePipe } from '@shared/pipes/translate.pipe';
+import { ClientsV5Service, Client, GetClientsParams } from '@core/services/clients-v5.service';
+import { ContextService } from '@core/services/context.service';
 
 @Component({
   selector: 'app-clients-list-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
   template: `
     <div class="page">
       <div class="page-header">
         <h1>{{ 'clients.title' | translate }}</h1>
       </div>
+
+      <form [formGroup]="filtersForm" class="filters">
+        <input type="text" formControlName="q" placeholder="Search" />
+        <input type="number" formControlName="sport_id" placeholder="Sport ID" />
+        <select formControlName="active">
+          <option value="">All</option>
+          <option value="true">Active</option>
+          <option value="false">Inactive</option>
+        </select>
+      </form>
 
       <table>
         <thead>
@@ -25,14 +39,14 @@ import { TranslatePipe } from '@shared/pipes/translate.pipe';
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>John Doe</td>
-            <td>john@example.com</td>
-            <td>555-1234</td>
-            <td>0</td>
-            <td>Surf, Yoga</td>
-            <td>Active</td>
-            <td>2024-01-01</td>
+          <tr *ngFor="let client of clients">
+            <td>{{ client.fullName }}</td>
+            <td>{{ client.email }}</td>
+            <td>{{ client.phone }}</td>
+            <td>{{ client.utilizadores }}</td>
+            <td>{{ client.sportsSummary }}</td>
+            <td>{{ client.status }}</td>
+            <td>{{ client.signupDate }}</td>
           </tr>
         </tbody>
       </table>
@@ -47,8 +61,71 @@ import { TranslatePipe } from '@shared/pipes/translate.pipe';
         padding: 8px;
         text-align: left;
       }
+      form.filters {
+        margin-bottom: 1rem;
+        display: flex;
+        gap: 0.5rem;
+      }
     `,
   ],
 })
-export class ClientsListPageComponent {}
+export class ClientsListPageComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly clientsService = inject(ClientsV5Service);
+  private readonly contextService = inject(ContextService);
+
+  filtersForm = this.fb.group({
+    q: [''],
+    sport_id: [''],
+    active: [''],
+  });
+
+  clients: Client[] = [];
+
+  ngOnInit(): void {
+    const params = this.route.snapshot.queryParamMap;
+    this.filtersForm.patchValue(
+      {
+        q: params.get('q') || '',
+        sport_id: params.get('sport_id') || '',
+        active: params.get('active') || '',
+      },
+      { emitEvent: false }
+    );
+
+    this.loadClients();
+
+    this.filtersForm.valueChanges.subscribe(() => {
+      this.updateQueryParams();
+      this.loadClients();
+    });
+  }
+
+  private updateQueryParams(): void {
+    const value = this.filtersForm.value;
+    const queryParams: any = {};
+    if (value.q) queryParams.q = value.q;
+    if (value.sport_id) queryParams.sport_id = value.sport_id;
+    if (value.active) queryParams.active = value.active;
+    this.router.navigate([], {
+      queryParams,
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  private loadClients(): void {
+    const value = this.filtersForm.value;
+    const params: GetClientsParams = {
+      school_id: this.contextService.schoolId() || 0,
+      q: value.q || undefined,
+      sport_id: value.sport_id ? Number(value.sport_id) : undefined,
+      active: value.active !== '' ? value.active === 'true' : undefined,
+    };
+    this.clientsService.getClients(params).subscribe((res) => {
+      this.clients = res.data;
+    });
+  }
+}
 


### PR DESCRIPTION
## Summary
- add search, sport, and active-state filters to ClientsListPageComponent
- persist filters in URL query params and reload clients on changes
- cover filter sync behavior with unit tests

## Testing
- `npm test --prefix front src/app/features/clients/clients-list.page.spec.ts`
- `npm test --prefix front` *(fails: missing modules and existing test issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a82d53316c832085b9ff67aded6a0c