### PR TITLE
Add soft deletes to school-user pivot table

### DIFF
--- a/database/migrations/old/2023_01_01_000003_create_school_user_pivot_table.php
+++ b/database/migrations/old/2023_01_01_000003_create_school_user_pivot_table.php
@@ -15,24 +15,29 @@ return new class extends Migration
                 $table->json('role_data')->nullable(); // For storing role information
                 $table->boolean('is_active')->default(true);
                 $table->timestamps();
-                
+                $table->softDeletes();
+
                 // Primary key is composite
                 $table->primary(['user_id', 'school_id']);
-                
+
                 // Foreign key constraints
                 $table->foreign('user_id')
                     ->references('id')
                     ->on('users')
                     ->cascadeOnDelete();
-                    
+
                 $table->foreign('school_id')
                     ->references('id')
                     ->on('schools')
                     ->cascadeOnDelete();
-                    
+
                 // Indexes for performance
                 $table->index('is_active');
                 $table->index('created_at');
+            });
+        } elseif (!Schema::hasColumn('school_user', 'deleted_at')) {
+            Schema::table('school_user', function (Blueprint $table) {
+                $table->softDeletes();
             });
         }
     }


### PR DESCRIPTION
## Summary
- add soft deletes to the school_user pivot table
- guard against duplicate deleted_at column on existing installs

## Testing
- `php artisan migrate --database=sqlite --path=database/migrations/old/2023_01_01_000003_create_school_user_pivot_table.php --force`
- `php artisan migrate --database=sqlite --path=database/migrations/old/2023_01_01_000003_create_school_user_pivot_table.php --force` *(idempotent)*
- `php artisan migrate --database=mysql --path=database/migrations/old/2023_01_01_000003_create_school_user_pivot_table.php --force` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b60b79988320a3bb017f961ef355