### PR TITLE
Make RolePermissionSeeder idempotent

### DIFF
--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -19,7 +19,7 @@ class RolePermissionSeeder extends Seeder
         // Crear roles
         $roles = ['superadmin', 'admin', 'monitor', 'client'];
         foreach ($roles as $role) {
-            Role::create(['name' => $role]);
+            Role::firstOrCreate(['name' => $role]);
         }
 
         // Crear permisos para cada tabla
@@ -27,12 +27,14 @@ class RolePermissionSeeder extends Seeder
         foreach ($tablas as $tabla) {
             $permisos = ["view $tabla", "create $tabla", "update $tabla", "delete $tabla"];
             foreach ($permisos as $permiso) {
-                Permission::create(['name' => $permiso]);
+                Permission::firstOrCreate(['name' => $permiso]);
             }
         }
 
         // Asignar todos los permisos al rol superadmin
-        $superAdmin = Role::findByName('superadmin');
-        $superAdmin->givePermissionTo(Permission::all());
+        $superAdmin = Role::where('name', 'superadmin')->first();
+        if ($superAdmin && Permission::count() > 0) {
+            $superAdmin->givePermissionTo(Permission::all());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid duplicate role and permission entries by using `firstOrCreate`
- check for existing roles and permissions before assigning to superadmin

## Testing
- `php artisan db:seed --class=RolePermissionSeeder --force`
- `php artisan db:seed --class=RolePermissionSeeder --force`
- `sqlite3 database/data.sqlite 'SELECT COUNT(*) FROM roles;'`
- `sqlite3 database/data.sqlite 'SELECT COUNT(*) FROM permissions;'`
- `php artisan db:seed --class=RolePermissionSeeder --force`
- `sqlite3 database/data.sqlite 'SELECT COUNT(*) FROM roles;'`
- `sqlite3 database/data.sqlite 'SELECT COUNT(*) FROM permissions;'`


------
https://chatgpt.com/codex/tasks/task_e_68a8bb6a86708320b781276fb9d50903