### PR TITLE
Seed default sports and salary levels

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        $this->call([
+            SportsTableSeeder::class,
+            SchoolSalaryLevelsTableSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/SchoolSalaryLevelsTableSeeder.php
+++ b/database/seeders/SchoolSalaryLevelsTableSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use App\Models\School;
+use App\Models\SchoolSalaryLevel;
 
 class SchoolSalaryLevelsTableSeeder extends Seeder
 {
@@ -13,6 +15,25 @@ class SchoolSalaryLevelsTableSeeder extends Seeder
      */
     public function run()
     {
+        $school = School::firstOrCreate(
+            ['slug' => 'default-school'],
+            [
+                'name' => 'Default School',
+                'description' => 'Initial school for salary levels',
+                'settings' => '{}',
+            ]
+        );
 
+        $levels = [
+            ['name' => 'Junior', 'pay' => 20],
+            ['name' => 'Senior', 'pay' => 30],
+        ];
+
+        foreach ($levels as $level) {
+            SchoolSalaryLevel::firstOrCreate(
+                ['school_id' => $school->id, 'name' => $level['name']],
+                ['pay' => $level['pay'], 'active' => true]
+            );
+        }
     }
 }

--- a/database/seeders/SportsTableSeeder.php
+++ b/database/seeders/SportsTableSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use App\Models\Sport;
+use App\Models\SportType;
 
 class SportsTableSeeder extends Seeder
 {
@@ -13,6 +15,32 @@ class SportsTableSeeder extends Seeder
      */
     public function run()
     {
+        $types = ['Hiver', 'Été', 'Autres'];
 
+        $typeIds = [];
+        foreach ($types as $typeName) {
+            $type = SportType::firstOrCreate(['name' => $typeName]);
+            $typeIds[$typeName] = $type->id;
+        }
+
+        $sports = [
+            ['name' => 'Ski', 'sport_type' => $typeIds['Hiver']],
+            ['name' => 'Snowboard', 'sport_type' => $typeIds['Hiver']],
+            ['name' => 'VTT', 'sport_type' => $typeIds['Été']],
+        ];
+
+        foreach ($sports as $sport) {
+            Sport::firstOrCreate(
+                ['name' => $sport['name']],
+                [
+                    'icon_collective' => 'icon.png',
+                    'icon_prive' => 'icon.png',
+                    'icon_activity' => 'icon.png',
+                    'icon_selected' => 'icon.png',
+                    'icon_unselected' => 'icon.png',
+                    'sport_type' => $sport['sport_type'],
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add baseline sports and sport types using `firstOrCreate`
- seed default school and salary levels if missing
- wire new seeders into `DatabaseSeeder`

## Testing
- `php artisan db:seed --force`
- `php artisan db:seed --force` *(verify idempotency)*
- `php artisan db:seed --force` *(duplicate check counts unchanged)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c23243ac83208e3ba52cbb841518