### PR TITLE
guard current season id migration

### DIFF
--- a/database/migrations/2025_07_28_214715_add_current_season_id_to_schools.php
+++ b/database/migrations/2025_07_28_214715_add_current_season_id_to_schools.php
@@ -8,7 +8,11 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('schools') && Schema::hasTable('seasons')) {
+        if (
+            Schema::hasTable('schools') &&
+            Schema::hasTable('seasons') &&
+            ! Schema::hasColumn('schools', 'current_season_id')
+        ) {
             Schema::table('schools', function (Blueprint $table) {
                 $table->foreignId('current_season_id')->nullable()->constrained('seasons');
             });
@@ -17,10 +21,9 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable('schools')) {
+        if (Schema::hasTable('schools') && Schema::hasColumn('schools', 'current_season_id')) {
             Schema::table('schools', function (Blueprint $table) {
-                $table->dropForeign(['current_season_id']);
-                $table->dropColumn('current_season_id');
+                $table->dropConstrainedForeignId('current_season_id');
             });
         }
     }


### PR DESCRIPTION
## Summary
- guard `current_season_id` column creation in schools migration
- safely remove `current_season_id` with `dropConstrainedForeignId` in down method

## Testing
- `php artisan migrate --path=database/migrations/2025_07_28_214715_add_current_season_id_to_schools.php --force` (sqlite)
- `sqlite3 database/data.sqlite "PRAGMA table_info('schools');"`
- `DB_CONNECTION=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_DATABASE=boukii_v5 DB_USERNAME=root DB_PASSWORD= DB_SOCKET=/tmp/mysql.sock php artisan migrate --path=database/migrations/2025_07_28_214715_add_current_season_id_to_schools.php --force`
- `DB_CONNECTION=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_DATABASE=boukii_v5 DB_USERNAME=root DB_PASSWORD= DB_SOCKET=/tmp/mysql.sock php artisan migrate:rollback --step=1 --force`
- `DB_CONNECTION=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_DATABASE=boukii_v5 DB_USERNAME=root DB_PASSWORD= DB_SOCKET=/tmp/mysql.sock php artisan migrate --path=database/migrations/2025_07_28_214715_add_current_season_id_to_schools.php --force`
- `mysql -u root --socket=/tmp/mysql.sock boukii_v5 -e "SHOW COLUMNS FROM schools LIKE 'current_season_id';"`


------
https://chatgpt.com/codex/tasks/task_e_68a8c46f84788320826d78b18ee01895