### PR TITLE
chore(front): add scoped auth lint

### DIFF
--- a/front/eslint.config.cjs
+++ b/front/eslint.config.cjs
@@ -1,5 +1,8 @@
 /** @type {import('eslint').Linter.FlatConfig[]} */
-const tseslint = require('typescript-eslint');
+const tsParser = require('@typescript-eslint/parser');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const angularTemplateParser = require('@angular-eslint/template-parser');
+const angularTemplatePlugin = require('@angular-eslint/eslint-plugin-template');
 
 module.exports = [
   {
@@ -13,19 +16,23 @@ module.exports = [
       '.storybook/**',
       'cypress.config.ts',
       'jest.config.cjs',
-      'src/environments/**'
+      'src/environments/**',
+      '**/*.scss',
+      '**/*.stories.ts'
     ]
   },
   {
-    files: ['src/**/*.ts'],
+    files: ['src/app/features/auth/**/*.ts'],
     languageOptions: {
-      parser: tseslint.parser,
+      parser: tsParser,
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module'
       }
     },
-    plugins: { '@typescript-eslint': tseslint.plugin },
+    plugins: {
+      '@typescript-eslint': tsPlugin
+    },
     rules: {
       '@typescript-eslint/no-unused-vars': [
         'error',
@@ -36,5 +43,15 @@ module.exports = [
         }
       ]
     }
+  },
+  {
+    files: ['src/app/features/auth/**/*.html'],
+    languageOptions: {
+      parser: angularTemplateParser
+    },
+    plugins: {
+      '@angular-eslint/template': angularTemplatePlugin
+    },
+    rules: {}
   }
 ];

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -44,6 +44,8 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/jasmine": "~5.1.0",
         "@types/jest": "^29.5.12",
+        "@typescript-eslint/eslint-plugin": "8.34.1",
+        "@typescript-eslint/parser": "8.34.1",
         "angular-eslint": "20.1.1",
         "cypress": "^14.5.4",
         "eslint": "^9.29.0",
@@ -67,7 +69,6 @@
         "storybook": "^8.6.14",
         "ts-jest": "^29.1.1",
         "typescript": "^5.4.0",
-        "typescript-eslint": "8.34.1",
         "vite": "^5.0.0",
         "vite-tsconfig-paths": "^4.2.0"
       }
@@ -24154,6 +24155,7 @@
       "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.34.1.tgz",
       "integrity": "sha512-XjS+b6Vg9oT1BaIUfkW3M3LvqZE++rbzAMEHuccCfO/YkP43ha6w3jTEMilQxMF92nVOYCcdjv1ZUhAa1D/0ow==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.34.1",
         "@typescript-eslint/parser": "8.34.1",
@@ -24176,6 +24178,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.1.tgz",
       "integrity": "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.34.1",
         "@typescript-eslint/types": "^8.34.1",
@@ -24197,6 +24200,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.1.tgz",
       "integrity": "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.34.1",
         "@typescript-eslint/visitor-keys": "8.34.1"
@@ -24214,6 +24218,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz",
       "integrity": "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -24230,6 +24235,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.1.tgz",
       "integrity": "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -24243,6 +24249,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
       "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/project-service": "8.34.1",
         "@typescript-eslint/tsconfig-utils": "8.34.1",
@@ -24271,6 +24278,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
       "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.34.1",
@@ -24294,6 +24302,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.1.tgz",
       "integrity": "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.34.1",
         "eslint-visitor-keys": "^4.2.1"
@@ -24311,6 +24320,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -24320,6 +24330,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -24332,6 +24343,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -30,6 +30,7 @@
     "test:karma": "ng test",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
+    "lint:auth": "eslint src/app/features/auth --ext .ts,.html,.scss",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
@@ -162,7 +163,8 @@
     "storybook": "^8.6.14",
     "ts-jest": "^29.1.1",
     "typescript": "^5.4.0",
-    "typescript-eslint": "8.34.1",
+    "@typescript-eslint/parser": "8.34.1",
+    "@typescript-eslint/eslint-plugin": "8.34.1",
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0"
   }


### PR DESCRIPTION
## Summary
- add `lint:auth` script scoped to Auth feature
- configure ESLint to lint Auth feature only and skip stories & style assets
- ensure TypeScript ESLint parser and plugin are included as dev dependencies

## Testing
- `npm run lint:auth -- --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a98d8432dc8320afef5a0f83c0a03b