### PR TITLE
style(auth): unify auth shell layout

### DIFF
--- a/front/src/app/features/auth/ui/auth-shell/auth-shell.component.scss
+++ b/front/src/app/features/auth/ui/auth-shell/auth-shell.component.scss
@@ -1,6 +1,41 @@
-.auth-shell{ padding: var(--space-6); min-height: 100vh; background: var(--bg); }
-.row{ display: grid; grid-template-columns: repeat(12, 1fr); gap: var(--space-6); }
-.col-12{ grid-column: span 12; }
-@media(min-width: 1200px){ .col-xl-6{ grid-column: span 6; } }
-.auth-card{ background: var(--surface); border:1px solid var(--border); border-radius: var(--radius-2xl); padding: var(--space-6); box-shadow: var(--elev-2); }
-.features li{ display:flex; gap: var(--space-3); align-items:flex-start; }
+.auth-shell {
+  padding: var(--space-6);
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: var(--space-6);
+}
+
+.col-12 {
+  grid-column: span 12;
+}
+
+@media (min-width: 1200px) {
+  .col-xl-6 {
+    grid-column: span 6;
+  }
+}
+
+.auth-card {
+  max-inline-size: 600px;
+  margin-inline: auto;
+  padding: var(--space-6);
+  border-radius: var(--radius-2xl);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--elev-2);
+}
+
+.features {
+  margin-block-start: var(--space-4);
+}
+
+.features li {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+}


### PR DESCRIPTION
## Summary
- standardize auth shell geometry so card and features share consistent layout across pages and themes

## Testing
- `npm run lint:auth`
- `npm run test:auth`


------
https://chatgpt.com/codex/tasks/task_e_68a992b34e948320a782ab10385505fd