### PR TITLE
feat: persist sidebar collapse state in UiStore

### DIFF
--- a/front/src/app/core/stores/ui.store.ts
+++ b/front/src/app/core/stores/ui.store.ts
@@ -14,12 +14,6 @@ function getStoredTheme(): Theme {
   return (localStorage.getItem('theme') as Theme) ?? 'system';
 }
 
-// Helper to get stored sidebar state with fallback
-function getStoredSidebarState(): boolean {
-  if (typeof localStorage === 'undefined') return false;
-  const stored = localStorage.getItem('sidebarCollapsed');
-  return stored === 'true';
-}
 
 // Helper to get effective theme (resolve 'system' to actual theme)
 function getEffectiveTheme(theme: Theme): 'light' | 'dark' {
@@ -29,7 +23,7 @@ function getEffectiveTheme(theme: Theme): 'light' | 'dark' {
 @Injectable({ providedIn: 'root' })
 export class UiStore {
   // Private signals
-  private readonly _sidebarCollapsed = signal(getStoredSidebarState());
+  private readonly _sidebarCollapsed = signal(false);
   private readonly _theme = signal<Theme>(getStoredTheme());
 
   // Public readonly signals
@@ -42,20 +36,18 @@ export class UiStore {
   readonly sidebarIcon = computed(() => (this._sidebarCollapsed() ? 'panel-right' : 'panel-left'));
 
   // Methods
+  initFromStorage(): void {
+    if (typeof localStorage === 'undefined') return;
+    const stored = localStorage.getItem('sidebar-collapsed');
+    this._sidebarCollapsed.set(stored === 'true');
+  }
+
   toggleSidebar(): void {
     const newState = !this._sidebarCollapsed();
     this._sidebarCollapsed.set(newState);
     // Persist sidebar state
     if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('sidebarCollapsed', String(newState));
-    }
-  }
-
-  setSidebarCollapsed(collapsed: boolean): void {
-    this._sidebarCollapsed.set(collapsed);
-    // Persist sidebar state
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('sidebarCollapsed', String(collapsed));
+      localStorage.setItem('sidebar-collapsed', String(newState));
     }
   }
 

--- a/front/src/app/ui/app-shell/app-shell.component.spec.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.spec.ts
@@ -39,13 +39,17 @@ class MockUiStore {
   private theme = signal<'light' | 'dark' | 'system'>('light');
   isDark = computed(() => this.theme() === 'dark');
 
+  initFromStorage(): void {
+    const stored = localStorage.getItem('sidebar-collapsed');
+    this.sidebarCollapsed.set(stored === 'true');
+  }
   initializeTheme(): void {
     this.setTheme(this.theme());
   }
   toggleSidebar(): void {
     const newState = !this.sidebarCollapsed();
     this.sidebarCollapsed.set(newState);
-    localStorage.setItem('sidebarCollapsed', String(newState));
+    localStorage.setItem('sidebar-collapsed', String(newState));
   }
   setTheme(theme: 'light' | 'dark' | 'system'): void {
     this.theme.set(theme);
@@ -102,18 +106,18 @@ describe('AppShellComponent interactions', () => {
   it('chevron toggles collapsed class, rotates and persists', async () => {
     const fixture = renderComponent();
     const user = userEvent.setup();
-    const button = screen.getByLabelText('sidebar.toggle');
-    const shell = fixture.nativeElement.querySelector('.app-shell');
-    expect(shell.classList).not.toContain('app-sidebar--collapsed');
+    const button = screen.getByLabelText('nav.collapse');
+    const sidebar = fixture.nativeElement.querySelector('aside.app-sidebar');
+    expect(sidebar.classList).not.toContain('collapsed');
     await user.click(button);
     fixture.detectChanges();
-    expect(shell.classList).toContain('app-sidebar--collapsed');
+    expect(sidebar.classList).toContain('collapsed');
     expect(fixture.nativeElement.querySelector('.chev')?.classList).toContain('rot');
-    expect(localStorage.getItem('sidebarCollapsed')).toBe('true');
+    expect(localStorage.getItem('sidebar-collapsed')).toBe('true');
     // Click again to expand and ensure button remains focusable
     await user.click(button);
     fixture.detectChanges();
-    expect(shell.classList).not.toContain('app-sidebar--collapsed');
+    expect(sidebar.classList).not.toContain('collapsed');
     fixture.nativeElement.remove();
   });
 

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -39,7 +39,7 @@ interface Notification {
     <!-- Show full layout only when authenticated and has school selected -->
     @if (shouldShowFullLayout()) {
       {{ logFullLayoutRender() }}
-      <div class="app-shell" [class.sidebar-collapsed]="ui.sidebarCollapsed()">
+      <div class="app-shell">
         
         <!-- NAVBAR -->
         <header class="app-navbar" role="banner">
@@ -298,7 +298,8 @@ interface Notification {
               class="collapse"
               type="button"
               (click)="ui.toggleSidebar()"
-              [attr.aria-label]="translationService.instant('sidebar.toggle')"
+              [attr.aria-expanded]="!ui.sidebarCollapsed()"
+              [attr.aria-label]="ui.sidebarCollapsed() ? translationService.instant('nav.expand') : translationService.instant('nav.collapse')"
             >
               <i class="chev" [class.rot]="ui.sidebarCollapsed()"></i>
             </button>
@@ -585,6 +586,8 @@ export class AppShellComponent implements OnInit {
   });
 
   ngOnInit(): void {
+    // Load stored UI preferences
+    this.ui.initFromStorage();
     // Initialize theme system
     this.ui.initializeTheme();
 

--- a/front/src/app/ui/app-shell/app-shell.stories.ts
+++ b/front/src/app/ui/app-shell/app-shell.stories.ts
@@ -38,22 +38,22 @@ class MockAuthV5Service {
 
 class MockUiStore {
   private themeSignal = signal<'light' | 'dark'>('light');
-  private collapsedSignal = signal(false);
+  sidebarCollapsed = signal(false);
   theme = computed(() => this.themeSignal());
   isDark = computed(() => this.themeSignal() === 'dark');
-  sidebarCollapsed = computed(() => this.collapsedSignal());
-  
-  toggleTheme() { 
+
+  initFromStorage() {}
+  toggleTheme() {
     const newTheme = this.themeSignal() === 'light' ? 'dark' : 'light';
-    this.themeSignal.set(newTheme); 
+    this.themeSignal.set(newTheme);
     document.documentElement.dataset['theme'] = newTheme;
   }
-  
+
   toggleSidebar() {
-    this.collapsedSignal.set(!this.collapsedSignal());
+    this.sidebarCollapsed.set(!this.sidebarCollapsed());
   }
-  
-  initializeTheme() { 
+
+  initializeTheme() {
     document.documentElement.dataset['theme'] = this.themeSignal();
   }
 }
@@ -102,10 +102,11 @@ export const Default: Story = {
 
 // Collapsed sidebar
 export const SidebarCollapsed: Story = {
+  name: '📐 Sidebar Colapsado',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // Click the sidebar collapse button
-    const collapseBtn = canvas.getByLabelText('sidebar.toggle');
+    const collapseBtn = canvas.getByLabelText('nav.collapse');
     await userEvent.click(collapseBtn);
   },
   parameters: {
@@ -141,9 +142,9 @@ export const DarkCollapsed: Story = {
     // Toggle theme first
     const themeBtn = canvas.getByTitle('theme.toggle');
     await userEvent.click(themeBtn);
-    
+
     // Then collapse sidebar
-    const collapseBtn = canvas.getByLabelText('sidebar.toggle');
+    const collapseBtn = canvas.getByLabelText('nav.collapse');
     await userEvent.click(collapseBtn);
   },
   parameters: {

--- a/front/src/app/ui/app-shell/app-shell.styles.scss
+++ b/front/src/app/ui/app-shell/app-shell.styles.scss
@@ -18,15 +18,10 @@
   grid-template-areas:
     "sidebar navbar"
     "sidebar main";
-  grid-template-columns: var(--sidebar-w) 1fr;
+  grid-template-columns: auto 1fr;
   grid-template-rows: var(--navbar-h) 1fr;
   height: 100vh;
   background: var(--bg);
-}
-
-/* Colapsado: aplicar a .app-shell */
-.app-shell.sidebar-collapsed {
-  grid-template-columns: var(--sidebar-w-collapsed) 1fr;
 }
 
 /* =============================================
@@ -178,16 +173,12 @@
     background: var(--text-1);
     mask: url('/assets/icons/chevron-left.svg') no-repeat center/contain;
     transition: transform .18s;
-    &.rot {
-      transform: rotate(180deg);
-    }
   }
 }
+.sidebar-header .chev.rot { transform: rotate(180deg); }
 /* Ocultar textos en colapsado */
 .app-sidebar.collapsed .logo-text,
-.app-sidebar.collapsed .nav-text,
-.app-shell.sidebar-collapsed .logo-text,
-.app-shell.sidebar-collapsed .nav-text {
+.app-sidebar.collapsed .nav-text {
   opacity: 0; pointer-events: none;
 }
 
@@ -216,8 +207,7 @@
 .badge--red    { background: var(--red); color: var(--active-contrast); }
 
 /* En colapsado: convertir en punto */
-.app-sidebar.collapsed .badge,
-.app-shell.sidebar-collapsed .badge {
+.app-sidebar.collapsed .badge {
   position: absolute; top: 8px; right: 8px;
   width: 8px; height: 8px; min-width: 8px; border-radius: 50%;
   padding: 0; font-size: 0;
@@ -253,8 +243,7 @@
 }
 
 /* En colapsado: ocultar contenido y mostrar FAB opcional (si lo tienes) */
-.app-sidebar.collapsed .support-content,
-.app-shell.sidebar-collapsed .support-content { display: none; }
+.app-sidebar.collapsed .support-content { display: none; }
 
 /* =============================================
    MAIN CONTENT


### PR DESCRIPTION
## Summary
- centralize sidebar collapse state in UiStore with localStorage persistence
- simplify AppShell to rely on UiStore and single `.collapsed` class on `<aside>`
- update styles, tests and stories for persistent collapsible sidebar

## Testing
- `npm install`
- `npm test` *(fails: Property 'toBeTruthy' does not exist on type 'Assertion', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a99a6d7358832095fc00db1cb6dc49