### PR TITLE
feat: centralize theme toggle

### DIFF
--- a/front/src/app/core/stores/ui.store.ts
+++ b/front/src/app/core/stores/ui.store.ts
@@ -5,18 +5,18 @@ export type Theme = 'light' | 'dark';
 
 @Injectable({ providedIn: 'root' })
 export class UiStore {
-  // Private signals
-
+  // Signals
   private readonly _sidebarCollapsed = signal(getStoredSidebarState());
-  private readonly _theme = signal<Theme>('light');
+
+  // Public theme signal
+  readonly theme = signal<Theme>('light');
 
   // Public readonly signals
   readonly sidebarCollapsed = this._sidebarCollapsed.asReadonly();
-  readonly theme = this._theme.asReadonly();
 
   // Computed signals
-  readonly effectiveTheme = computed(() => this._theme());
-  readonly isDark = computed(() => this._theme() === 'dark');
+  readonly effectiveTheme = computed(() => this.theme());
+  readonly isDark = computed(() => this.theme() === 'dark');
   readonly sidebarIcon = computed(() => (this._sidebarCollapsed() ? 'panel-right' : 'panel-left'));
 
   // Methods
@@ -36,7 +36,7 @@ export class UiStore {
   }
 
   setTheme(theme: Theme): void {
-    this._theme.set(theme);
+    this.theme.set(theme);
     if (typeof document !== 'undefined') {
       document.body.dataset.theme = theme;
     }
@@ -46,17 +46,26 @@ export class UiStore {
   }
 
   toggleTheme(): void {
-    const next = this._theme() === 'light' ? 'dark' : 'light';
-    this.setTheme(next);
+    this.theme.update((v) => (v === 'light' ? 'dark' : 'light'));
+    if (typeof document !== 'undefined') {
+      document.body.dataset.theme = this.theme();
+    }
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('theme', this.theme());
+    }
   }
 
   initTheme(): void {
     const v =
-      (typeof localStorage !== 'undefined' && (localStorage.getItem('theme') as Theme)) ||
-      'light';
-    this._theme.set(v);
+      (typeof localStorage !== 'undefined' && (localStorage.getItem('theme') as Theme)) || 'light';
+    this.theme.set(v);
     if (typeof document !== 'undefined') {
       document.body.dataset.theme = v;
     }
   }
+}
+
+function getStoredSidebarState(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem('sidebar-collapsed') === 'true';
 }

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -531,7 +531,9 @@ export class AppShellComponent implements OnInit {
   constructor(
     public readonly translationService: TranslationService,
     public readonly environmentService: EnvironmentService,
-  ) {}
+  ) {
+    this.ui.initTheme();
+  }
 
   @ViewChild('languageMenu') languageMenu?: ElementRef<HTMLDivElement>;
   @ViewChild('languageButton') languageButton?: ElementRef<HTMLButtonElement>;
@@ -602,8 +604,6 @@ export class AppShellComponent implements OnInit {
   ngOnInit(): void {
     // Load stored UI preferences
     this.ui.initFromStorage();
-    // Initialize theme system
-    this.ui.initTheme();
 
     // Try to load user session if token exists
     this.auth.loadMe();


### PR DESCRIPTION
## Summary
- centralize theme state in `UiStore` using `document.body.dataset.theme`
- initialize stored theme on AppShell bootstrap

## Testing
- `npm test` *(fails: Namespace 'jasmine' has no exported member 'SpyObj')*

------
https://chatgpt.com/codex/tasks/task_e_68a9a55587b083209eda4457f7a64a9a