### PR TITLE
fix: align dark theme tokens and app shell styles

### DIFF
--- a/front/src/app/ui/app-shell/app-shell.styles.scss
+++ b/front/src/app/ui/app-shell/app-shell.styles.scss
@@ -49,14 +49,14 @@
   height: 36px;
   border: 0;
   background: transparent;
-  border-radius: 8px;
+  border-radius: var(--radius-8, 8px);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--text-1);
   cursor: pointer;
   transition: background-color 150ms;
-  &:hover { background: var(--surface-2); }
+  &:hover { background-color: var(--surface-2); }
 }
 
 /* Search */
@@ -67,8 +67,9 @@
 .search input {
   width: 100%;
   height: 36px;
+  box-sizing: border-box;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-8, 8px);
   background: var(--surface-2);
   padding: 0 12px;
   color: var(--text-1);

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -45,6 +45,7 @@
   /* Shadows */
   --elev-1: 0 1px 2px rgba(0,0,0,.06);
   --elev-2: 0 4px 12px rgba(0,0,0,.10);
+  --elev-3: 0 8px 24px rgba(0,0,0,.14);
 
   /* Border Radius */
   --radius-8: 8px;
@@ -56,11 +57,6 @@
   --space-3: 0.75rem;
   --space-4: 1rem;
   --space-6: 1.5rem;
-
-  /* Elevation */
-  --elev-1: 0 1px 2px var(--shadow);
-  --elev-2: 0 4px 10px var(--shadow);
-  --elev-3: 0 8px 24px var(--shadow);
 
   /* Typography */
   --fs-12: 12px;
@@ -117,6 +113,7 @@
   /* Shadows */
   --elev-1: 0 1px 2px rgba(0,0,0,.40);
   --elev-2: 0 6px 18px rgba(0,0,0,.55);
+  --elev-3: 0 8px 24px rgba(0,0,0,.70);
 }
 
 /* Base */


### PR DESCRIPTION
## Summary
- apply token-based styling for app-shell controls
- unify elevation shadow tokens for light and dark themes

## Testing
- `npm test` (fails: Property 'toBe' does not exist on type 'Assertion')
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a99b5a13688320b881a3c7e9b993ff