### PR TITLE
test: stabilize Cypress e2e with global mocks

### DIFF
--- a/front/cypress/fixtures/clients/detail.json
+++ b/front/cypress/fixtures/clients/detail.json
@@ -1,0 +1,1 @@
+{ "id":1,"fullName":"Jane Doe","email":"jane@ex.com","phone":"+41 111","utilizadores":[{"id":101,"name":"Kid 1"}], "sports":[] }

--- a/front/cypress/fixtures/clients/list.json
+++ b/front/cypress/fixtures/clients/list.json
@@ -1,0 +1,4 @@
+{ "data":[
+  {"id":1,"fullName":"Jane Doe","email":"jane@ex.com","phone":"+41 111","utilizadores":2,"sportsSummary":"Ski, SB","status":"active","signupDate":"2024-01-01"},
+  {"id":2,"fullName":"John Roe","email":"john@ex.com","phone":"+41 222","utilizadores":1,"sportsSummary":"Ski","status":"inactive","signupDate":"2024-02-01"}
+], "meta":{"total":2} }

--- a/front/cypress/fixtures/config/runtime-config.json
+++ b/front/cypress/fixtures/config/runtime-config.json
@@ -1,0 +1,1 @@
+{ "name":"Boukii Admin V5 - Test","type":"test","apiBaseUrl":"http://localhost/api","production":false }

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -1,171 +1,33 @@
-/// <reference types="cypress" />
-
-/**
- * Custom commands for Boukii V5 E2E testing
- */
-
-// Login command
-Cypress.Commands.add('login', (email: string, password: string) => {
-  cy.visit('/auth/login')
-  cy.get('[data-cy=email-input]').type(email)
-  cy.get('[data-cy=password-input]').type(password)
-  cy.get('[data-cy=login-button]').click()
-})
-
-// Login with valid credentials
-Cypress.Commands.add('loginWithValidCredentials', () => {
-  cy.login('test@boukii.com', 'password123')
-})
-
-// Wait for app to load
-Cypress.Commands.add('waitForAppToLoad', () => {
-  cy.get('[data-cy=app-loaded]', { timeout: 10000 }).should('exist')
-})
-
-// Check if user is on login page
-Cypress.Commands.add('shouldBeOnLoginPage', () => {
-  cy.url().should('include', '/auth/login')
-  cy.get('[data-cy=login-form]').should('be.visible')
-})
-
-// Check if user is on school selection page
-Cypress.Commands.add('shouldBeOnSchoolSelectionPage', () => {
-  cy.url().should('include', '/select-school')
-  cy.get('[data-cy=school-selection]').should('be.visible')
-})
-
-// Check if user is on dashboard
-Cypress.Commands.add('shouldBeOnDashboard', () => {
-  cy.url().should('include', '/dashboard')
-  cy.get('[data-cy=dashboard]').should('be.visible')
-})
-
-// Select first school
-Cypress.Commands.add('selectFirstSchool', () => {
-  cy.get('[data-cy=school-item]').first().click()
-})
-
-// Toggle theme
-Cypress.Commands.add('toggleTheme', () => {
-  cy.get('[data-cy=theme-toggle]').click()
-})
-
-// Check theme
-Cypress.Commands.add('shouldHaveTheme', (theme: 'light' | 'dark') => {
-  cy.get('html').should('have.attr', 'data-theme', theme)
-})
-
-// Mock API interceptors
-Cypress.Commands.add('mockLoginSuccess', () => {
-  cy.intercept('POST', '**/api/v5/auth/login', {
-    statusCode: 200,
-    body: {
-      success: true,
-      data: {
-        user: {
-          id: 1,
-          name: 'Test User',
-          email: 'test@boukii.com',
-          created_at: '2025-01-01',
-          updated_at: '2025-01-01'
-        },
-        token: 'mock-jwt-token',
-        schools: [
-          {
-            id: 1,
-            name: 'Test School',
-            slug: 'test-school',
-            status: 'active',
-            created_at: '2025-01-01',
-            updated_at: '2025-01-01',
-            seasons: [
-              {
-                id: 1,
-                school_id: 1,
-                name: 'Test Season',
-                slug: 'test-season',
-                start_date: '2025-01-01',
-                end_date: '2025-12-31',
-                status: 'active',
-                is_current: true,
-                created_at: '2025-01-01',
-                updated_at: '2025-01-01'
-              }
-            ]
-          }
-        ]
-      }
-    }
-  }).as('loginSuccess')
-})
-
-Cypress.Commands.add('mockLoginError', () => {
-  cy.intercept('POST', '**/api/v5/auth/login', {
-    statusCode: 401,
-    body: {
-      success: false,
-      message: 'Invalid credentials',
-      errors: {
-        email: ['Invalid email or password']
-      }
-    }
-  }).as('loginError')
-})
-
-Cypress.Commands.add('mockMultipleSchools', () => {
-  cy.intercept('POST', '**/api/v5/auth/login', {
-    statusCode: 200,
-    body: {
-      success: true,
-      data: {
-        user: {
-          id: 1,
-          name: 'Test User',
-          email: 'test@boukii.com',
-          created_at: '2025-01-01',
-          updated_at: '2025-01-01'
-        },
-        token: 'mock-jwt-token',
-        schools: [
-          {
-            id: 1,
-            name: 'School One',
-            slug: 'school-one',
-            status: 'active',
-            created_at: '2025-01-01',
-            updated_at: '2025-01-01',
-            seasons: []
-          },
-          {
-            id: 2,
-            name: 'School Two',
-            slug: 'school-two',
-            status: 'active',
-            created_at: '2025-01-01',
-            updated_at: '2025-01-01',
-            seasons: []
-          }
-        ]
-      }
-    }
-  }).as('loginMultipleSchools')
-})
-
 declare global {
   namespace Cypress {
     interface Chainable {
-      login(email: string, password: string): Chainable<void>
-      loginWithValidCredentials(): Chainable<void>
-      waitForAppToLoad(): Chainable<void>
-      shouldBeOnLoginPage(): Chainable<void>
-      shouldBeOnSchoolSelectionPage(): Chainable<void>
-      shouldBeOnDashboard(): Chainable<void>
-      selectFirstSchool(): Chainable<void>
-      toggleTheme(): Chainable<void>
-      shouldHaveTheme(theme: 'light' | 'dark'): Chainable<void>
-      mockLoginSuccess(): Chainable<void>
-      mockLoginError(): Chainable<void>
-      mockMultipleSchools(): Chainable<void>
+      login(): Chainable<void>;
+      selectSchoolAndSeason(): Chainable<void>;
+      setTheme(theme:'light'|'dark'): Chainable<void>;
     }
   }
 }
+Cypress.Commands.add('login', () => {
+  cy.intercept('POST','/api/v5/auth/login',{
+    statusCode:200,
+    body:{access_token:'fake',token_type:'Bearer',expires_in:3600,
+      user:{id:1,name:'Test User',email:'test@boukii.dev'}}
+  }).as('loginApi');
+  cy.visit('/login');
+  cy.get('[data-testid="email"]').type('test@boukii.dev');
+  cy.get('[data-testid="password"]').type('Password_123!');
+  cy.get('[data-testid="submit"]').click();
+  cy.wait('@loginApi');
+});
+Cypress.Commands.add('selectSchoolAndSeason', () => {
+  cy.visit('/select-school');
+  cy.wait(['@schools','@seasons']);
+  cy.get('[data-testid="school-card"]').first().click();
+  cy.url().should('include','/select-season');
+  cy.get('[data-testid="season-card"]').first().click();
+});
+Cypress.Commands.add('setTheme',(theme:'light'|'dark')=>{
+  window.localStorage.setItem('theme',theme);
+  document.body.dataset.theme = theme;
+});
+export {};

--- a/front/cypress/support/e2e.ts
+++ b/front/cypress/support/e2e.ts
@@ -1,32 +1,20 @@
-// Ignora errores de navegador que no son de app (ruido CI)
+import './commands';
+// Ignorar ruido del navegador
 Cypress.on('uncaught:exception', (err) => {
-  const msg = err?.message || '';
-  if (
-    msg.includes('ResizeObserver loop') ||
-    msg.includes('Script error') ||
-    msg.includes('Failed to fetch') // mientras se mockean llamadas
-  ) {
-    return false;
-  }
-  // Para el resto, deja fallar
+  const m = err?.message || '';
+  if (m.includes('ResizeObserver loop') || m.includes('Script error') || m.includes('Failed to fetch')) return false;
   return true;
 });
-
-// Mocks globales de API que la app pide al cargar
 beforeEach(() => {
-  cy.intercept('GET', '/api/v5/me', { fixture: 'auth/me.json' }).as('me');
-  cy.intercept('GET', '/api/v5/context', { fixture: 'auth/context.json' }).as('context');
-  cy.intercept('GET', '/api/v5/feature-flags', { fixture: 'auth/feature-flags.json' }).as('flags');
-
-  cy.intercept('GET', '/api/v5/schools*', { fixture: 'schools/list.json' }).as('schools');
-  cy.intercept('GET', '/api/v5/seasons*', { fixture: 'seasons/list.json' }).as('seasons');
-
-  // Fallback genérico para evitar timeouts si aparece otra ruta
-  cy.intercept({ method: /GET|POST|PUT|PATCH|DELETE/, url: '/api/**' }, (req) => {
-    req.reply({ ok: true });
-  }).as('apiFallback');
-
-  // Asegura tema por defecto
-  window.localStorage.setItem('theme', 'light');
+  cy.intercept('GET','/assets/config/runtime-config.json',{fixture:'config/runtime-config.json'}).as('runtime');
+  cy.intercept('GET','/api/v5/me',{fixture:'auth/me.json'}).as('me');
+  cy.intercept('GET','/api/v5/context',{fixture:'auth/context.json'}).as('context');
+  cy.intercept('GET','/api/v5/feature-flags',{fixture:'auth/feature-flags.json'}).as('flags');
+  cy.intercept('GET','/api/v5/schools*',{fixture:'schools/list.json'}).as('schools');
+  cy.intercept('GET','/api/v5/seasons*',{fixture:'seasons/list.json'}).as('seasons');
+  cy.intercept('GET','/api/v5/clients*',{fixture:'clients/list.json'}).as('clients');
+  cy.intercept('GET','/api/v5/clients/*',{fixture:'clients/detail.json'}).as('clientDetail');
+  cy.intercept({method:/GET|POST|PUT|PATCH|DELETE/,url:'/api/**'}, (req)=> req.reply({ok:true})).as('apiFallback');
+  window.localStorage.setItem('theme','light');
   document.body.dataset.theme = 'light';
 });

--- a/front/src/app/features/school-selection/select-school.page.ts
+++ b/front/src/app/features/school-selection/select-school.page.ts
@@ -101,7 +101,7 @@ interface PaginationState {
           <!-- Schools Grid -->
           <div class="schools-grid">
             @for (school of schools(); track school.id) {
-              <article class="school-card" [class.selecting]="isSelecting() === school.id">
+              <article class="school-card" data-testid="school-card" [class.selecting]="isSelecting() === school.id">
                 <div class="school-header">
                   <h3 class="school-name">{{ school.name }}</h3>
                   @if (school.slug) {


### PR DESCRIPTION
## Summary
- add Cypress helper commands for login, theme, and selecting school/season
- mock runtime config, auth, clients, and other APIs globally
- provide fixtures and stable `data-testid` for school selection

## Testing
- `npm run test:e2e:ci` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c2856b048320a9367c483d69a5b3