### PR TITLE
Use existing /me/schools endpoint for full school list

### DIFF
--- a/app/Http/Controllers/Api/V5/MeSchoolController.php
+++ b/app/Http/Controllers/Api/V5/MeSchoolController.php
@@ -17,7 +17,14 @@ class MeSchoolController extends Controller
     {
         $this->authorize('viewAny', School::class);
 
-        $schools = $request->user()->schools()->paginate();
+        if ($request->boolean('all')) {
+            $schools = $request->user()->schools()->get();
+
+            return SchoolResource::collection($schools)->response();
+        }
+
+        $perPage = $request->integer('perPage', 15);
+        $schools = $request->user()->schools()->paginate($perPage);
 
         return SchoolResource::collection($schools)->response();
     }

--- a/docs/api/openapi-v5.yaml
+++ b/docs/api/openapi-v5.yaml
@@ -22,6 +22,12 @@ paths:
             minimum: 1
             default: 15
           description: Items per page
+        - in: query
+          name: all
+          schema:
+            type: boolean
+            default: false
+          description: Return all schools without pagination
       responses:
         '200':
           description: Paginated list of schools

--- a/front/src/app/core/guards/school-selection.guard.ts
+++ b/front/src/app/core/guards/school-selection.guard.ts
@@ -30,7 +30,7 @@ export const schoolSelectionGuard: CanActivateFn = () => {
     return false;
   }
 
-  // Get user's schools and apply logic
+  // Get user's schools using /me/schools?all=true and apply logic
   return schoolService.getAllMySchools().pipe(
     switchMap(async (schools) => {
       console.log('🏫 SchoolSelectionGuard: Found schools:', schools.length);

--- a/front/src/app/core/services/school.service.spec.ts
+++ b/front/src/app/core/services/school.service.spec.ts
@@ -147,13 +147,13 @@ describe('SchoolService', () => {
 
   describe('getAllMySchools', () => {
     beforeEach(() => {
-      mockApiHttp.get.and.returnValue(of([mockSchool]));
+      mockApiHttp.get.and.returnValue(of({ data: [mockSchool] }));
     });
 
-    it('should call API without parameters', () => {
+    it('should call API with all flag', () => {
       service.getAllMySchools().subscribe();
 
-      expect(mockApiHttp.get).toHaveBeenCalledWith('/schools/all');
+      expect(mockApiHttp.get).toHaveBeenCalledWith('/me/schools', { all: true });
     });
 
     it('should return schools array', (done) => {

--- a/front/src/app/core/services/school.service.ts
+++ b/front/src/app/core/services/school.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable, from } from 'rxjs';
+import { Observable, from, map } from 'rxjs';
 import { ApiService } from './api.service';
 import { School } from './context.service';
 
@@ -70,7 +70,9 @@ export class SchoolService {
    * Useful for simple lists and school selection
    */
   getAllMySchools(): Observable<School[]> {
-    return from(this.apiHttp.get<School[]>('/schools/all'));
+    return from(
+      this.apiHttp.get<SchoolsResponse>('/me/schools', { all: true })
+    ).pipe(map(response => response.data));
   }
 
   /**

--- a/tests/Feature/V5/Context/SchoolSelectorTest.php
+++ b/tests/Feature/V5/Context/SchoolSelectorTest.php
@@ -55,6 +55,19 @@ class SchoolSelectorTest extends TestCase
     }
 
     /** @test */
+    public function lista_todas_las_schools_sin_paginacion_cuando_all_true()
+    {
+        $response = $this->getJson('/api/v5/me/schools?all=true', [
+            'Authorization' => 'Bearer ' . $this->token,
+        ]);
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertCount(1, $data);
+        $this->assertArrayNotHasKey('meta', $response->json());
+    }
+
+    /** @test */
     public function retorna_403_si_intenta_cambiar_a_una_school_sin_pertenencia()
     {
         $response = $this->postJson('/api/v5/context/school', [


### PR DESCRIPTION
## Summary
- fetch all user schools via `/me/schools?all=true` in the front-end service
- handle `all` and `perPage` in `MeSchoolController` and document the parameter
- add unit/feature tests and update guard comment

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `vendor/bin/phpunit tests/Feature/V5/Context/SchoolSelectorTest.php` *(no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8992e80883209ab4ef78ef5adace