### PR TITLE
feat: use personal schools endpoint and add public listing

### DIFF
--- a/app/Http/Controllers/Api/V5/SchoolController.php
+++ b/app/Http/Controllers/Api/V5/SchoolController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Api\V5;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\API\SchoolResource;
+use App\Models\School;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SchoolController extends Controller
+{
+    /**
+     * Publicly list schools.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $query = School::query();
+
+        if ($search = $request->query('search')) {
+            $query->where('name', 'like', '%'.$search.'%');
+        }
+
+        if ($request->has('active')) {
+            $query->where('active', $request->boolean('active'));
+        }
+
+        $orderBy = $request->query('orderBy', 'name');
+        $direction = $request->query('orderDirection', 'asc');
+        $columns = [
+            'name' => 'name',
+            'createdAt' => 'created_at',
+            'updatedAt' => 'updated_at',
+        ];
+        $orderBy = $columns[$orderBy] ?? 'name';
+        $direction = $direction === 'desc' ? 'desc' : 'asc';
+        $query->orderBy($orderBy, $direction);
+
+        $perPage = $request->integer('perPage', 20);
+        $page = $request->integer('page', 1);
+        $schools = $query->paginate($perPage, ['*'], 'page', $page);
+
+        return response()->json([
+            'data' => SchoolResource::collection($schools->items()),
+            'meta' => [
+                'total' => $schools->total(),
+                'page' => $schools->currentPage(),
+                'perPage' => $schools->perPage(),
+                'lastPage' => $schools->lastPage(),
+                'from' => $schools->firstItem(),
+                'to' => $schools->lastItem(),
+            ],
+        ]);
+    }
+}

--- a/front/src/app/core/services/school.service.spec.ts
+++ b/front/src/app/core/services/school.service.spec.ts
@@ -58,7 +58,7 @@ describe('SchoolService', () => {
       service.getMySchools().subscribe();
 
       expect(mockApiHttp.get).toHaveBeenCalledWith(
-        '/schools?page=1&perPage=20&active=true&orderBy=name&orderDirection=asc'
+        '/me/schools?page=1&perPage=20&active=true&orderBy=name&orderDirection=asc'
       );
     });
 
@@ -75,7 +75,7 @@ describe('SchoolService', () => {
       service.getMySchools(params).subscribe();
 
       expect(mockApiHttp.get).toHaveBeenCalledWith(
-        '/schools?page=2&perPage=10&search=test&active=false&orderBy=createdAt&orderDirection=desc'
+        '/me/schools?page=2&perPage=10&search=test&active=false&orderBy=createdAt&orderDirection=desc'
       );
     });
 
@@ -88,7 +88,7 @@ describe('SchoolService', () => {
       service.getMySchools(params).subscribe();
 
       expect(mockApiHttp.get).toHaveBeenCalledWith(
-        '/schools?page=1&perPage=20&active=true&orderBy=name&orderDirection=asc'
+        '/me/schools?page=1&perPage=20&active=true&orderBy=name&orderDirection=asc'
       );
     });
 
@@ -101,7 +101,7 @@ describe('SchoolService', () => {
       service.getMySchools(params).subscribe();
 
       expect(mockApiHttp.get).toHaveBeenCalledWith(
-        '/schools?page=1&perPage=5&search=swimming&active=true&orderBy=name&orderDirection=asc'
+        '/me/schools?page=1&perPage=5&search=swimming&active=true&orderBy=name&orderDirection=asc'
       );
     });
 
@@ -121,7 +121,7 @@ describe('SchoolService', () => {
       service.getMySchools(params).subscribe();
 
       expect(mockApiHttp.get).toHaveBeenCalledWith(
-        '/schools?page=1&perPage=20&active=true&orderBy=name&orderDirection=asc'
+        '/me/schools?page=1&perPage=20&active=true&orderBy=name&orderDirection=asc'
       );
     });
   });
@@ -261,7 +261,7 @@ describe('SchoolService', () => {
       service.getMySchools(params).subscribe();
 
       expect(mockApiHttp.get).toHaveBeenCalledWith(
-        '/schools?page=1&perPage=20&search=test%20%26%20school&active=true&orderBy=name&orderDirection=asc'
+        '/me/schools?page=1&perPage=20&search=test%20%26%20school&active=true&orderBy=name&orderDirection=asc'
       );
     });
 

--- a/front/src/app/core/services/school.service.ts
+++ b/front/src/app/core/services/school.service.ts
@@ -55,7 +55,7 @@ export class SchoolService {
       }
     });
 
-    return from(this.apiHttp.get<SchoolsResponse>('/schools', queryParams));
+    return from(this.apiHttp.get<SchoolsResponse>('/me/schools', queryParams));
   }
 
   /**

--- a/routes/api_v5/schools.php
+++ b/routes/api_v5/schools.php
@@ -1,12 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V5\SchoolController;
 
-Route::middleware('auth:sanctum')
-    ->prefix('schools')
+Route::prefix('schools')
     ->name('v5.schools.')
     ->group(function () {
-        Route::get('/', function () {
-            return response()->json([]);
-        })->name('index');
+        Route::get('/', [SchoolController::class, 'index'])->name('index');
     });


### PR DESCRIPTION
## Summary
- switch client to `/me/schools` endpoint for user-specific listings
- update service tests for new path
- expose public `/v5/schools` route with controller returning paginated schools

## Testing
- `npm test` *(fails: Property 'toBeFalsy' does not exist on type 'Assertion')*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8cd4c2ec832080791d7ef36b2432