### PR TITLE
Add show route for schools and update tests

### DIFF
--- a/app/Http/Controllers/Api/V5/SchoolController.php
+++ b/app/Http/Controllers/Api/V5/SchoolController.php
@@ -52,4 +52,12 @@ class SchoolController extends Controller
             ],
         ]);
     }
+
+    /**
+     * Show a single school.
+     */
+    public function show(School $school): JsonResponse
+    {
+        return SchoolResource::make($school)->response();
+    }
 }

--- a/front/src/app/core/services/context.service.spec.ts
+++ b/front/src/app/core/services/context.service.spec.ts
@@ -92,10 +92,11 @@ describe('ContextService', () => {
       expect(localStorage.getItem('context_seasonId')).toBeNull();
     });
 
-    it('should load school details', async () => {
+    it('should load school details via /schools/{id}', async () => {
       await service.setSchool(1);
 
-      expect(mockApiHttp.get).toHaveBeenCalledWith('/api/v5/schools/1');
+      const expectedPath = '/api/v5/schools/1';
+      expect(mockApiHttp.get).toHaveBeenCalledWith(expectedPath);
       expect(service.school()).toEqual(mockSchool);
     });
 

--- a/front/src/app/core/services/school.service.spec.ts
+++ b/front/src/app/core/services/school.service.spec.ts
@@ -131,10 +131,11 @@ describe('SchoolService', () => {
       mockApiHttp.get.and.returnValue(of(mockSchool));
     });
 
-    it('should call API with correct school ID', () => {
+    it('should fetch a school via /schools/{id}', () => {
       service.getSchoolById(123).subscribe();
 
-      expect(mockApiHttp.get).toHaveBeenCalledWith('/schools/123');
+      const expectedPath = '/schools/123';
+      expect(mockApiHttp.get).toHaveBeenCalledWith(expectedPath);
     });
 
     it('should return school data', (done) => {

--- a/routes/api_v5/schools.php
+++ b/routes/api_v5/schools.php
@@ -3,8 +3,10 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V5\SchoolController;
 
-Route::prefix('schools')
+Route::middleware('auth:sanctum')
+    ->prefix('schools')
     ->name('v5.schools.')
     ->group(function () {
         Route::get('/', [SchoolController::class, 'index'])->name('index');
+        Route::get('/{school}', [SchoolController::class, 'show'])->name('show');
     });

--- a/tests/V5/Feature/RouteNamesTest.php
+++ b/tests/V5/Feature/RouteNamesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\V5\Feature;
 
 use Tests\TestCase;
+use App\Models\School;
 
 class RouteNamesTest extends TestCase
 {
@@ -21,6 +22,14 @@ class RouteNamesTest extends TestCase
     public function test_schools_index_route_requires_authentication(): void
     {
         $response = $this->getJson(route('v5.schools.index'));
+        $response->assertStatus(401);
+    }
+
+    public function test_schools_show_route_requires_authentication(): void
+    {
+        $school = School::factory()->create();
+
+        $response = $this->getJson(route('v5.schools.show', $school));
         $response->assertStatus(401);
     }
 }


### PR DESCRIPTION
## Summary
- secure v5 school routes with auth and expose GET /schools/{id}
- add show method to SchoolController
- adjust client tests to use /schools/{id}

## Testing
- `vendor/bin/phpunit -v tests/V5/Feature/RouteNamesTest.php`
- `node front/node_modules/jest/bin/jest.js front/src/app/core/services/context.service.spec.ts front/src/app/core/services/school.service.spec.ts` *(fails: Cannot find module '../lib/statuses')*


------
https://chatgpt.com/codex/tasks/task_e_68ac900a190c8320b72d980ac2ca47e3