### PR TITLE
fix(front): align school permissions endpoints

### DIFF
--- a/front/src/app/features/admin/permissions/services/school-permissions.service.spec.ts
+++ b/front/src/app/features/admin/permissions/services/school-permissions.service.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { SchoolPermissionsService } from './school-permissions.service';
+import { ApiService } from '../../../../core/services/api.service';
+
+describe('SchoolPermissionsService', () => {
+  let service: SchoolPermissionsService;
+  let api: jest.Mocked<ApiService>;
+
+  beforeEach(() => {
+    const apiSpy = {
+      get: jest.fn().mockResolvedValue({}),
+      post: jest.fn().mockResolvedValue({}),
+      put: jest.fn().mockResolvedValue({}),
+      delete: jest.fn().mockResolvedValue({}),
+      getBlob: jest.fn().mockResolvedValue(new Blob()),
+    } as unknown as jest.Mocked<ApiService>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        SchoolPermissionsService,
+        { provide: ApiService, useValue: apiSpy },
+      ],
+    });
+
+    service = TestBed.inject(SchoolPermissionsService);
+    api = TestBed.inject(ApiService) as jest.Mocked<ApiService>;
+  });
+
+  it('calls getPermissionMatrix with /admin/permissions/matrix', () => {
+    service.getPermissionMatrix();
+    expect(api.get).toHaveBeenCalledWith('/admin/permissions/matrix', undefined);
+  });
+
+  it('calls getUserSchoolPermissions with /admin/users/:id/school-permissions', () => {
+    service.getUserSchoolPermissions(1);
+    expect(api.get).toHaveBeenCalledWith('/admin/users/1/school-permissions');
+  });
+
+  it('calls assignUserSchoolRoles with /admin/permissions/assign', () => {
+    const payload = { userId: 1, schoolId: 2, roles: ['admin'] } as any;
+    service.assignUserSchoolRoles(payload);
+    expect(api.post).toHaveBeenCalledWith('/admin/permissions/assign', payload);
+  });
+
+  it('calls updateUserSchoolRoles with /admin/permissions/:id', () => {
+    const payload = { roles: ['coach'] } as any;
+    service.updateUserSchoolRoles(3, payload);
+    expect(api.put).toHaveBeenCalledWith('/admin/permissions/3', payload);
+  });
+
+  it('calls removeUserSchoolRoles with /admin/permissions/:id', () => {
+    service.removeUserSchoolRoles(4);
+    expect(api.delete).toHaveBeenCalledWith('/admin/permissions/4');
+  });
+
+  it('calls bulkAssignRoles with /admin/permissions/bulk-assign', () => {
+    const payload = { assignments: [] } as any;
+    service.bulkAssignRoles(payload);
+    expect(api.post).toHaveBeenCalledWith('/admin/permissions/bulk-assign', payload);
+  });
+
+  it('calls getUserEffectivePermissions with /admin/users/:id/effective-permissions', () => {
+    service.getUserEffectivePermissions(5, 10);
+    expect(api.get).toHaveBeenCalledWith('/admin/users/5/effective-permissions?school_id=10');
+  });
+
+  it('calls validatePermissionAssignment with /admin/permissions/validate', () => {
+    const payload = { userId: 1, schoolId: 2, roles: ['admin'] } as any;
+    service.validatePermissionAssignment(payload);
+    expect(api.post).toHaveBeenCalledWith('/admin/permissions/validate', payload);
+  });
+
+  it('calls getUserPermissionHistory with /admin/users/:id/permission-history', () => {
+    service.getUserPermissionHistory(7, 8);
+    expect(api.get).toHaveBeenCalledWith('/admin/users/7/permission-history', { school_id: 8 });
+  });
+
+  it('calls exportPermissionMatrix with /admin/permissions/export', () => {
+    service.exportPermissionMatrix();
+    expect(api.getBlob).toHaveBeenCalledWith('/admin/permissions/export', { format: 'xlsx' });
+  });
+});

--- a/front/src/app/features/admin/permissions/services/school-permissions.service.ts
+++ b/front/src/app/features/admin/permissions/services/school-permissions.service.ts
@@ -21,63 +21,63 @@ export class SchoolPermissionsService {
    */
   getPermissionMatrix(filters?: PermissionAssignmentFilters): Observable<PermissionMatrixResponse> {
     const params = this.buildParams(filters);
-    return from(this.api.get<PermissionMatrixResponse>('/api/v5/admin/permissions/matrix', params));
+    return from(this.api.get<PermissionMatrixResponse>('/admin/permissions/matrix', params));
   }
 
   /**
    * Get user permissions across all schools
    */
   getUserSchoolPermissions(userId: number): Observable<UserPermissionMatrix> {
-    return from(this.api.get<UserPermissionMatrix>(`/api/v5/admin/users/${userId}/school-permissions`));
+    return from(this.api.get<UserPermissionMatrix>(`/admin/users/${userId}/school-permissions`));
   }
 
   /**
    * Get all role assignments for a specific school
    */
   getSchoolRoleAssignments(schoolId: number): Observable<SchoolRoleAssignment> {
-    return from(this.api.get<SchoolRoleAssignment>(`/api/v5/admin/schools/${schoolId}/role-assignments`));
+    return from(this.api.get<SchoolRoleAssignment>(`/admin/schools/${schoolId}/role-assignments`));
   }
 
   /**
    * Assign roles to user in specific school
    */
   assignUserSchoolRoles(assignment: Omit<UserSchoolRole, 'id'>): Observable<UserSchoolRole> {
-    return from(this.api.post<UserSchoolRole>('/api/v5/admin/permissions/assign', assignment));
+    return from(this.api.post<UserSchoolRole>('/admin/permissions/assign', assignment));
   }
 
   /**
    * Update user school roles
    */
   updateUserSchoolRoles(assignmentId: number, assignment: Partial<UserSchoolRole>): Observable<UserSchoolRole> {
-    return from(this.api.put<UserSchoolRole>(`/api/v5/admin/permissions/${assignmentId}`, assignment));
+    return from(this.api.put<UserSchoolRole>(`/admin/permissions/${assignmentId}`, assignment));
   }
 
   /**
    * Remove user school roles
    */
   removeUserSchoolRoles(assignmentId: number): Observable<void> {
-    return from(this.api.delete<void>(`/api/v5/admin/permissions/${assignmentId}`));
+    return from(this.api.delete<void>(`/admin/permissions/${assignmentId}`));
   }
 
   /**
    * Bulk assign roles to multiple users
    */
   bulkAssignRoles(assignment: BulkPermissionAssignment): Observable<{ successful: number; failed: number; errors: string[] }> {
-    return from(this.api.post<{ successful: number; failed: number; errors: string[] }>('/api/v5/admin/permissions/bulk-assign', assignment));
+    return from(this.api.post<{ successful: number; failed: number; errors: string[] }>('/admin/permissions/bulk-assign', assignment));
   }
 
   /**
    * Get effective permissions for user in school context
    */
   getUserEffectivePermissions(userId: number, schoolId: number): Observable<string[]> {
-    return from(this.api.get<string[]>(`/api/v5/admin/users/${userId}/effective-permissions?school_id=${schoolId}`));
+    return from(this.api.get<string[]>(`/admin/users/${userId}/effective-permissions?school_id=${schoolId}`));
   }
 
   /**
    * Validate permission assignment
    */
   validatePermissionAssignment(assignment: Omit<UserSchoolRole, 'id'>): Observable<{ valid: boolean; warnings: string[]; errors: string[] }> {
-    return from(this.api.post<{ valid: boolean; warnings: string[]; errors: string[] }>('/api/v5/admin/permissions/validate', assignment));
+    return from(this.api.post<{ valid: boolean; warnings: string[]; errors: string[] }>('/admin/permissions/validate', assignment));
   }
 
   /**
@@ -109,7 +109,7 @@ export class SchoolPermissionsService {
         changedAt: string;
         reason?: string;
       }>;
-    }>(`/api/v5/admin/users/${userId}/permission-history`, params));
+    }>(`/admin/users/${userId}/permission-history`, params));
   }
 
   /**
@@ -117,7 +117,7 @@ export class SchoolPermissionsService {
    */
   exportPermissionMatrix(filters?: PermissionAssignmentFilters, format: 'csv' | 'xlsx' = 'xlsx'): Observable<Blob> {
     const params = { ...this.buildParams(filters), format };
-    return from(this.api.getBlob('/api/v5/admin/permissions/export', params));
+    return from(this.api.getBlob('/admin/permissions/export', params));
   }
 
   /**


### PR DESCRIPTION
## Summary
- drop `/api/v5` prefix from school permissions API paths so ApiService adds version
- add unit tests for `SchoolPermissionsService` using new URLs

## Testing
- `npm test` *(fails: Namespace 'jasmine' has no exported member 'SpyObj')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac93955d748320ab0c64cd4941bc32