### PR TITLE
refactor: streamline auth flow

### DIFF
--- a/front/src/app/core/services/auth-v5.service.spec.ts
+++ b/front/src/app/core/services/auth-v5.service.spec.ts
@@ -66,8 +66,8 @@ describe.skip('AuthV5Service', () => {
     });
   });
 
-  describe('login', () => {
-    it('should call login with correct credentials', (done) => {
+  describe('checkUser', () => {
+    it('should call checkUser with correct credentials', (done) => {
       const credentials = { email: 'test@example.com', password: 'password123' };
       const mockResponse = {
         success: true,
@@ -77,19 +77,18 @@ describe.skip('AuthV5Service', () => {
           schools: []
         }
       };
-      
+
       // Mock the API service to return a promise
       mockApiService.post.mockReturnValue(Promise.resolve(mockResponse));
-      
-      service.login(credentials).subscribe(response => {
+
+      service.checkUser(credentials).subscribe(response => {
         expect(response.success).toBe(true);
         expect(response.data?.user.email).toBe(credentials.email);
-        expect(service.isAuthenticated()).toBe(true);
         done();
       });
     });
 
-    it('should log login attempt', (done) => {
+    it('should log checkUser attempt', (done) => {
       const credentials = { email: 'test@example.com', password: 'password123' };
       const mockResponse = {
         success: true,
@@ -99,13 +98,13 @@ describe.skip('AuthV5Service', () => {
           schools: []
         }
       };
-      
+
       // Mock the API service to return a promise
       mockApiService.post.mockReturnValue(Promise.resolve(mockResponse));
-      
-      service.login(credentials).subscribe(() => {
+
+      service.checkUser(credentials).subscribe(() => {
         expect(mockLoggingService.logInfo).toHaveBeenCalledWith(
-          'AuthV5Service: Attempting login',
+          'AuthV5Service: Checking user credentials',
           { email: credentials.email }
         );
         done();

--- a/front/src/app/core/services/auth-v5.service.ts
+++ b/front/src/app/core/services/auth-v5.service.ts
@@ -78,15 +78,20 @@ export class AuthV5Service {
   public selectSchool(schoolId: number, tempToken: string): Observable<ApiResponse<any>> {
     this.logger.logInfo('AuthV5Service: Selecting school', { schoolId });
 
-    return from(this.apiService.postWithHeaders<ApiResponse<any>>('/auth/select-school', 
+    return from(this.apiService.postWithHeaders<ApiResponse<any>>('/auth/select-school',
       { school_id: schoolId },
       { 'Authorization': `Bearer ${tempToken}` }
     )).pipe(
       tap(response => {
-        this.logger.logInfo('AuthV5Service: School selection successful', { 
+        this.logger.logInfo('AuthV5Service: School selection successful', {
           schoolId,
           seasonsCount: response.data?.seasons?.length || 0
         });
+
+        if (response.success && response.data) {
+          // Handle login success to ensure user and token are stored
+          this.handleLoginSuccess(response.data);
+        }
       }),
       catchError(error => {
         console.error('AuthV5Service: School selection failed', { schoolId, error });
@@ -180,16 +185,6 @@ export class AuthV5Service {
         throw error;
       })
     );
-  }
-
-  /**
-   * Legacy login method (for backward compatibility)
-   */
-  public login(credentials: LoginRequest): Observable<ApiResponse<any>> {
-    this.logger.logInfo('AuthV5Service: Using legacy login, switching to V5 flow');
-    
-    // Start with checkUser for V5 flow
-    return this.checkUser(credentials);
   }
 
   /**

--- a/front/src/app/features/auth/pages/login.page.ts
+++ b/front/src/app/features/auth/pages/login.page.ts
@@ -239,18 +239,14 @@ export class LoginPage implements OnInit {
           return;
         }
 
-        // The API already returns everything we need: user, school, season, access_token
-        // No need for additional selectSeason call
+        // The API returns user, school, season and final access token
         console.log('✅ School selection successful:', response.data);
-        
-        // Process the login success using the auth service
-        this.authV5.handleLoginSuccess(response.data);
-        
+
         // Complete the login flow
         this.isSubmitting.set(false);
         this.statusMessage.set(this.translationService.get('auth.login.success'));
         this.toast.success(this.translationService.get('auth.login.success'));
-        
+
         // Navigate to dashboard
         this.router.navigate(['/dashboard']);
       },


### PR DESCRIPTION
## Summary
- remove deprecated `login` method from AuthV5Service
- let `selectSchool` handle login success and store user/token
- update tests and login page to call `checkUser`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca0bfddec8320b191ecd8a35011b8