### PR TITLE
Load schools for superadmin login

### DIFF
--- a/app/Services/Auth/LoginService.php
+++ b/app/Services/Auth/LoginService.php
@@ -46,6 +46,7 @@ class LoginService
             switch ($user->type) {
                 case 'superadmin':
                 case '4':
+                    $user->load('schools');
                     $token = $user->createToken('Boukii', ['permissions:all'])->plainTextToken;
                     break;
                 case 'admin':


### PR DESCRIPTION
## Summary
- ensure superadmins load their related schools when authenticating
- cover admin and superadmin login responses with school data

## Testing
- `vendor/bin/phpunit tests/Feature/LoginTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aca2178c908320b0f444f24d4c771a