### PR TITLE
feat: add session service for school context management

### DIFF
--- a/front/src/app/core/services/auth-v5.service.ts
+++ b/front/src/app/core/services/auth-v5.service.ts
@@ -6,6 +6,7 @@ import { tap, catchError, switchMap } from 'rxjs/operators';
 import { ApiService, ApiResponse } from './api.service';
 import { LoggingService } from './logging.service';
 import { ContextService } from './context.service';
+import { SessionService } from './session.service';
 import {
   LoginRequest,
   RegisterRequest,
@@ -22,6 +23,7 @@ export class AuthV5Service {
   private readonly logger = inject(LoggingService);
   private readonly router = inject(Router);
   private readonly contextService = inject(ContextService);
+  private readonly sessionService = inject(SessionService);
 
   // Reactive state using signals
   readonly tokenSignal = signal<string | null>(null);
@@ -389,6 +391,7 @@ export class AuthV5Service {
 
     this.currentSchoolIdSignal.set(schoolId);
     this.contextService.setSelectedSchool(school);
+    this.sessionService.selectSchool(school);
 
     // Auto-select season if only one active (check if seasons exists)
     const seasons = school.seasons || [];
@@ -452,6 +455,7 @@ export class AuthV5Service {
       console.log('🏫 Setting current school:', data.school);
       this.currentSchoolIdSignal.set(data.school.id);
       this.contextService.setSelectedSchool(data.school);
+      this.sessionService.selectSchool(data.school);
     } else {
       console.log('❌ No school data in response');
     }

--- a/front/src/app/core/services/session.service.ts
+++ b/front/src/app/core/services/session.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { School } from './context.service';
+import { SchoolService } from './school.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionService {
+  private readonly schoolService = inject(SchoolService);
+
+  /**
+   * BehaviorSubject that emits the current school or null when none selected
+   */
+  readonly currentSchool$ = new BehaviorSubject<School | null>(null);
+
+  /**
+   * Select a school and persist it
+   */
+  selectSchool(school: School): void {
+    this.currentSchool$.next(school);
+    localStorage.setItem('boukiiSchoolId', school.id.toString());
+  }
+
+  /**
+   * Load stored school from localStorage and initialize the BehaviorSubject
+   */
+  async loadStoredSchool(): Promise<void> {
+    const storedId = localStorage.getItem('boukiiSchoolId');
+    if (storedId) {
+      try {
+        const school = await firstValueFrom(this.schoolService.getSchoolById(Number(storedId)));
+        this.currentSchool$.next(school);
+      } catch {
+        this.currentSchool$.next(null);
+      }
+    }
+  }
+}

--- a/front/src/app/features/school-selection/select-school.page.spec.ts
+++ b/front/src/app/features/school-selection/select-school.page.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelectSchoolPageComponent } from './select-school.page';
 import { AuthV5Service } from '@core/services/auth-v5.service';
-import { ContextService } from '@core/services/context.service';
+import { SessionService } from '@core/services/session.service';
 import { ToastService } from '@core/services/toast.service';
 import { TranslationService } from '@core/services/translation.service';
 import { Router } from '@angular/router';
@@ -13,7 +13,7 @@ describe('SelectSchoolPageComponent', () => {
   let component: SelectSchoolPageComponent;
   let fixture: ComponentFixture<SelectSchoolPageComponent>;
   let authV5: AuthV5Service;
-  let context: ContextService;
+  let session: SessionService;
   let router: Router;
 
   const mockSchools = [
@@ -28,7 +28,7 @@ describe('SelectSchoolPageComponent', () => {
       tokenSignal: signal('temp-token')
     } as unknown as AuthV5Service;
 
-    const contextSpy = { setSelectedSchool: jest.fn() } as unknown as ContextService;
+    const sessionSpy = { selectSchool: jest.fn() } as unknown as SessionService;
     const routerSpy = { navigate: jest.fn() } as unknown as Router;
     const toastSpy = { success: jest.fn(), error: jest.fn() } as unknown as ToastService;
     const translationSpy = {
@@ -40,7 +40,7 @@ describe('SelectSchoolPageComponent', () => {
       imports: [SelectSchoolPageComponent],
       providers: [
         { provide: AuthV5Service, useValue: authV5Spy },
-        { provide: ContextService, useValue: contextSpy },
+        { provide: SessionService, useValue: sessionSpy },
         { provide: Router, useValue: routerSpy },
         { provide: ToastService, useValue: toastSpy },
         { provide: TranslationService, useValue: translationSpy }
@@ -50,7 +50,7 @@ describe('SelectSchoolPageComponent', () => {
     fixture = TestBed.createComponent(SelectSchoolPageComponent);
     component = fixture.componentInstance;
     authV5 = TestBed.inject(AuthV5Service);
-    context = TestBed.inject(ContextService);
+    session = TestBed.inject(SessionService);
     router = TestBed.inject(Router);
 
     fixture.detectChanges();
@@ -61,12 +61,9 @@ describe('SelectSchoolPageComponent', () => {
   });
 
   it('should persist school id on selection', () => {
-    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-
     component.selectSchool(mockSchools[0] as any);
 
-    expect(context.setSelectedSchool).toHaveBeenCalledWith(mockSchools[0] as any);
-    expect(setItemSpy).toHaveBeenCalledWith('boukiiSchoolId', mockSchools[0].id.toString());
+    expect(session.selectSchool).toHaveBeenCalledWith(mockSchools[0] as any);
     expect(router.navigate).toHaveBeenCalledWith(['/select-season']);
   });
 });

--- a/front/src/app/features/school-selection/select-school.page.ts
+++ b/front/src/app/features/school-selection/select-school.page.ts
@@ -8,7 +8,7 @@ import { TranslatePipe } from '@shared/pipes/translate.pipe';
 import { AuthV5Service } from '@core/services/auth-v5.service';
 import { ToastService } from '@core/services/toast.service';
 import { TranslationService } from '@core/services/translation.service';
-import { ContextService } from '@core/services/context.service';
+import { SessionService } from '@core/services/session.service';
 
 interface School {
   id: number;
@@ -154,7 +154,7 @@ export class SelectSchoolPageComponent implements OnInit, OnDestroy {
   private readonly toast = inject(ToastService);
   private readonly translationService = inject(TranslationService);
   private readonly router = inject(Router);
-  private readonly contextService = inject(ContextService);
+  private readonly sessionService = inject(SessionService);
 
   // Component state
   private readonly _isLoading = signal(false);
@@ -252,9 +252,8 @@ export class SelectSchoolPageComponent implements OnInit, OnDestroy {
 
         console.log('✅ School selection successful:', response.data);
 
-        // Persist selected school
-        this.contextService.setSelectedSchool(school);
-        localStorage.setItem('boukiiSchoolId', school.id.toString());
+        // Persist selected school using session service
+        this.sessionService.selectSchool(school);
 
         // Show success message
         this.toast.success(this.translationService.get('auth.login.success'));

--- a/front/src/app/features/school-selection/select-school.stories.ts
+++ b/front/src/app/features/school-selection/select-school.stories.ts
@@ -2,12 +2,13 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata, applicationConfig } from '@storybook/angular';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { of, throwError, BehaviorSubject } from 'rxjs';
 import { signal } from '@angular/core';
 
 import { SelectSchoolPageComponent } from './select-school.page';
 import { SchoolService, SchoolsResponse } from '@core/services/school.service';
-import { ContextService, School } from '@core/services/context.service';
+import { School } from '@core/services/context.service';
+import { SessionService } from '@core/services/session.service';
 import { TranslationService } from '@core/services/translation.service';
 
 // Mock data
@@ -116,19 +117,13 @@ class MockTranslationService {
   }
 }
 
-class MockContextService {
-  private schoolId = signal<number | null>(null);
-  
-  hasSchoolSelected = this.schoolId.asReadonly();
-
-  async setSchool(schoolId: number): Promise<void> {
-    this.schoolId.set(schoolId);
-    console.log('Mock: School selected:', schoolId);
+class MockSessionService {
+  selectSchool(school: School): void {
+    console.log('Mock: School selected:', school.id);
   }
 
-  clearContext(): void {
-    this.schoolId.set(null);
-  }
+  // Simple BehaviorSubject for compatibility if needed
+  currentSchool$ = new BehaviorSubject<School | null>(null);
 }
 
 class MockSchoolService {
@@ -191,7 +186,7 @@ const meta: Meta<SelectSchoolPageComponent> = {
         provideAnimations(),
         provideRouter([]),
         { provide: SchoolService, useClass: MockSchoolService },
-        { provide: ContextService, useClass: MockContextService },
+        { provide: SessionService, useClass: MockSessionService },
         { provide: TranslationService, useClass: MockTranslationService },
       ],
     }),
@@ -257,7 +252,7 @@ export const Empty: Story = {
             return service;
           }
         },
-        { provide: ContextService, useClass: MockContextService },
+        { provide: SessionService, useClass: MockSessionService },
         { provide: TranslationService, useClass: MockTranslationService },
       ],
     }),
@@ -287,7 +282,7 @@ export const Error: Story = {
             return service;
           }
         },
-        { provide: ContextService, useClass: MockContextService },
+        { provide: SessionService, useClass: MockSessionService },
         { provide: TranslationService, useClass: MockTranslationService },
       ],
     }),
@@ -317,7 +312,7 @@ export const Paginated: Story = {
             return service;
           }
         },
-        { provide: ContextService, useClass: MockContextService },
+        { provide: SessionService, useClass: MockSessionService },
         { provide: TranslationService, useClass: MockTranslationService },
       ],
     }),


### PR DESCRIPTION
## Summary
- add SessionService with `currentSchool$` and storage helpers
- wire SessionService into AuthV5Service and school selection page
- update stories and specs to use the new service

## Testing
- `npm test` *(fails: missing modules, numerous spec type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acae3c82308320a0beaa411ae1a91a