### PR TITLE
Ensure superadmin receives all active schools on login

### DIFF
--- a/app/Services/Auth/LoginService.php
+++ b/app/Services/Auth/LoginService.php
@@ -46,7 +46,8 @@ class LoginService
             switch ($user->type) {
                 case 'superadmin':
                 case '4':
-                    $user->load('schools');
+                    $schools = School::where('active', 1)->get();
+                    $user->setRelation('schools', $schools);
                     $token = $user->createToken('Boukii', ['permissions:all'])->plainTextToken;
                     break;
                 case 'admin':


### PR DESCRIPTION
## Summary
- Return all active schools for superadmin login by setting relation instead of using pivot load
- Test that superadmin gets full list of active schools even without pivot associations

## Testing
- `./vendor/bin/phpunit tests/Feature/LoginTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68acb3c38de8832086d13cc438dccdfb