### PR TITLE
feat: fetch all schools for super admins

### DIFF
--- a/front/src/app/core/services/school.service.ts
+++ b/front/src/app/core/services/school.service.ts
@@ -76,6 +76,19 @@ export class SchoolService {
   }
 
   /**
+   * List all schools (super admin only)
+   */
+  listAll(params: { perPage?: number } = {}): Observable<School[]> {
+    const queryParams: Record<string, string | number> = {};
+    if (params.perPage !== undefined) {
+      queryParams['perPage'] = params.perPage;
+    }
+    return from(
+      this.apiHttp.get<SchoolsResponse>('/schools', queryParams)
+    ).pipe(map(response => response.data));
+  }
+
+  /**
    * Search schools by name
    */
   searchSchools(query: string, limit: number = 10): Observable<School[]> {

--- a/front/src/app/features/school-selection/select-school.page.spec.ts
+++ b/front/src/app/features/school-selection/select-school.page.spec.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
 import { expect } from '@jest/globals';
+import { SchoolService } from '@core/services/school.service';
 
 describe('SelectSchoolPageComponent', () => {
   let component: SelectSchoolPageComponent;
@@ -25,7 +26,8 @@ describe('SelectSchoolPageComponent', () => {
     const authV5Spy = {
       selectSchool: jest.fn().mockReturnValue(of({ success: true, data: { school: mockSchools[0] } })),
       user: signal({ schools: mockSchools } as any),
-      tokenSignal: signal('temp-token')
+      tokenSignal: signal('temp-token'),
+      isSuperAdmin: signal(false)
     } as unknown as AuthV5Service;
 
     const sessionSpy = { selectSchool: jest.fn() } as unknown as SessionService;
@@ -35,6 +37,7 @@ describe('SelectSchoolPageComponent', () => {
       get: jest.fn((k: string) => k),
       currentLanguage: jest.fn(() => 'en')
     } as unknown as TranslationService;
+    const schoolServiceSpy = { listAll: jest.fn().mockReturnValue(of(mockSchools)) } as unknown as SchoolService;
 
     await TestBed.configureTestingModule({
       imports: [SelectSchoolPageComponent],
@@ -43,7 +46,8 @@ describe('SelectSchoolPageComponent', () => {
         { provide: SessionService, useValue: sessionSpy },
         { provide: Router, useValue: routerSpy },
         { provide: ToastService, useValue: toastSpy },
-        { provide: TranslationService, useValue: translationSpy }
+        { provide: TranslationService, useValue: translationSpy },
+        { provide: SchoolService, useValue: schoolServiceSpy }
       ]
     }).compileComponents();
 


### PR DESCRIPTION
## Summary
- inject SchoolService into school selection page
- load all schools via API when super admin
- add listAll method to SchoolService and update tests

## Testing
- `npm test` *(fails: TS errors in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acc68e265c8320b143e81fc0f878d2