### PR TITLE
feat: add listAll schools service

### DIFF
--- a/front/src/app/core/services/school.service.ts
+++ b/front/src/app/core/services/school.service.ts
@@ -78,11 +78,27 @@ export class SchoolService {
   /**
    * List all schools (super admin only)
    */
-  listAll(params: { perPage?: number } = {}): Observable<School[]> {
-    const queryParams: Record<string, string | number> = {};
-    if (params.perPage !== undefined) {
-      queryParams['perPage'] = params.perPage;
-    }
+  listAll(params: GetSchoolsParams = {}): Observable<School[]> {
+    // Set default parameters with high perPage
+    const defaultParams: Required<GetSchoolsParams> = {
+      page: 1,
+      perPage: 1000,
+      search: '',
+      active: true,
+      orderBy: 'name',
+      orderDirection: 'asc'
+    };
+
+    const finalParams = { ...defaultParams, ...params };
+
+    // Build query parameters
+    const queryParams: Record<string, string | number | boolean> = {};
+    Object.entries(finalParams).forEach(([key, value]) => {
+      if (value !== null && value !== undefined && value !== '') {
+        queryParams[key] = value;
+      }
+    });
+
     return from(
       this.apiHttp.get<SchoolsResponse>('/schools', queryParams)
     ).pipe(map(response => response.data));


### PR DESCRIPTION
## Summary
- implement `listAll` for fetching all schools with high perPage default
- add jest unit tests for school service including new `listAll`

## Testing
- `npx jest src/app/core/services/school.service.spec.ts`
- `npm test` *(fails: TypeScript errors in other specs)*

------
https://chatgpt.com/codex/tasks/task_e_68acc846e38883209a9ba4ee38856a90