### PR TITLE
Add filterActive option for seasons list

### DIFF
--- a/app/Http/Controllers/API/SeasonAPIController.php
+++ b/app/Http/Controllers/API/SeasonAPIController.php
@@ -55,8 +55,14 @@ class SeasonAPIController extends AppBaseController
      */
     public function index(Request $request): JsonResponse
     {
+        $filters = $request->except(['skip', 'limit', 'search', 'exclude', 'user', 'perPage', 'order', 'orderColumn', 'page', 'with']);
+
+        if ($request->boolean('filterActive')) {
+            $filters['is_active'] = true;
+        }
+
         $seasons = $this->seasonRepository->all(
-            $request->except(['skip', 'limit', 'search', 'exclude', 'user', 'perPage', 'order', 'orderColumn', 'page', 'with']),
+            $filters,
             $request->get('search'),
             $request->get('skip'),
             $request->get('limit'),

--- a/routes/api/public.php
+++ b/routes/api/public.php
@@ -118,6 +118,7 @@ Route::middleware(['guest'])->group(function () {
     Route::resource('tasks', App\Http\Controllers\API\TaskAPIController::class)
         ->except(['create', 'edit']);
 
+    // GET /seasons?filterActive=true returns only active seasons
     Route::resource('seasons', App\Http\Controllers\API\SeasonAPIController::class)
         ->except(['create', 'edit']);
 


### PR DESCRIPTION
## Summary
- allow filtering seasons by `filterActive` query parameter
- document new `filterActive` parameter in public routes

## Testing
- `vendor/bin/phpunit -c phpunit.ci.xml`


------
https://chatgpt.com/codex/tasks/task_e_68acd15b88a883209e66a3ad3801450f