### PR TITLE
Ensure single active season per school

### DIFF
--- a/app/Http/Controllers/API/SeasonAPIController.php
+++ b/app/Http/Controllers/API/SeasonAPIController.php
@@ -109,6 +109,9 @@ class SeasonAPIController extends AppBaseController
     public function store(CreateSeasonAPIRequest $request): JsonResponse
     {
         $input = $request->all();
+        if (!empty($input['is_active'])) {
+            $this->seasonRepository->unsetActiveForSchool($input['school_id']);
+        }
 
         $season = $this->seasonRepository->create($input);
 
@@ -212,6 +215,10 @@ class SeasonAPIController extends AppBaseController
 
         if (empty($season)) {
             return $this->sendError('Season not found');
+        }
+
+        if (!empty($input['is_active'])) {
+            $this->seasonRepository->unsetActiveForSchool($season->school_id, $season->id);
         }
 
         $season = $this->seasonRepository->update($input, $id);

--- a/app/Repositories/SeasonRepository.php
+++ b/app/Repositories/SeasonRepository.php
@@ -27,4 +27,12 @@ class SeasonRepository extends BaseRepository
     {
         return Season::class;
     }
+
+    public function unsetActiveForSchool(int $schoolId, ?int $excludeId = null): void {
+        $query = $this->model->newQuery()
+            ->where('school_id', $schoolId)
+            ->where('is_active', true);
+        if ($excludeId) $query->where('id', '!=', $excludeId);
+        $query->update(['is_active' => false]);
+    }
 }


### PR DESCRIPTION
## Summary
- deactivate other seasons when a new active season is created
- on update, unset existing active seasons before marking one active

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: ./vendor/bin/phpunit tests/Repositories/SeasonRepositoryTest.php --testdox` *(fails: SQLSTATE[HY000]: General error: 1 no such table: schools)*

------
https://chatgpt.com/codex/tasks/task_e_68acd7a17d0c832097897d9ae0411177