### PR TITLE
Handle superadmin schools and expose user roles

### DIFF
--- a/tests/Feature/V5/Auth/DevUsersLoginTest.php
+++ b/tests/Feature/V5/Auth/DevUsersLoginTest.php
@@ -50,7 +50,7 @@ class DevUsersLoginTest extends TestCase
                     'success',
                     'message',
                     'data' => [
-                        'user' => ['id', 'name', 'email'],
+                        'user' => ['id', 'name', 'email', 'role'],
                         'schools' => [
                             '*' => ['id', 'name', 'slug', 'logo', 'user_role', 'can_administer']
                         ],
@@ -62,7 +62,8 @@ class DevUsersLoginTest extends TestCase
                     'success' => true,
                     'data' => [
                         'user' => [
-                            'email' => 'admin@boukii-v5.com'
+                            'email' => 'admin@boukii-v5.com',
+                            'role' => 'admin'
                         ],
                         'requires_school_selection' => true
                     ]
@@ -93,7 +94,8 @@ class DevUsersLoginTest extends TestCase
                     'success' => true,
                     'data' => [
                         'user' => [
-                            'email' => 'multi@boukii-v5.com'
+                            'email' => 'multi@boukii-v5.com',
+                            'role' => 'admin'
                         ],
                         'requires_school_selection' => false // Single school = no selection needed
                     ]


### PR DESCRIPTION
## Summary
- Allow superadmins to access all active schools and return user role in check-user API
- Expose user role in `checkUser` responses for frontend routing
- Cover superadmin flow and role exposure in authentication tests

## Testing
- `composer install`
- `phpunit --filter test_superadmin_without_school_assignments_gets_all_active_schools tests/Feature/V5/Auth/LoginTest.php` *(fails: process did not complete in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68acd7e46508832090c9ae0cce018226