### PR TITLE
feat(auth): redirect monitor and client users

### DIFF
--- a/front/src/app/features/auth/pages/login.page.spec.ts
+++ b/front/src/app/features/auth/pages/login.page.spec.ts
@@ -1,6 +1,7 @@
-import { expect } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
+import { of } from 'rxjs';
 import { LoginPage } from './login.page';
 import { AuthV5Service } from '../../../core/services/auth-v5.service';
 import { TranslationService } from '../../../core/services/translation.service';
@@ -13,14 +14,22 @@ class MockTranslationService {
 }
 
 describe('LoginPage', () => {
+  let router: { navigate: jest.Mock };
+  let authService: { isAuthenticated: () => boolean; checkUser: jest.Mock };
+  let toast: { error: jest.Mock; success: jest.Mock };
+
   beforeEach(async () => {
+    router = { navigate: jest.fn() };
+    authService = { isAuthenticated: () => false, checkUser: jest.fn() };
+    toast = { error: jest.fn(), success: jest.fn() };
+
     await TestBed.configureTestingModule({
       imports: [LoginPage],
       providers: [
         { provide: TranslationService, useClass: MockTranslationService },
-         { provide: AuthV5Service, useValue: { isAuthenticated: () => false } },
-        { provide: Router, useValue: {} },
-        { provide: ToastService, useValue: {} }
+        { provide: AuthV5Service, useValue: authService },
+        { provide: Router, useValue: router },
+        { provide: ToastService, useValue: toast }
       ]
     }).compileComponents();
   });
@@ -31,5 +40,25 @@ describe('LoginPage', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('auth.login.title');
     expect(compiled.querySelector('form')).toBeTruthy();
+  });
+
+  it('redirects monitor users to the teach app', () => {
+    authService.checkUser.mockReturnValue(of({ success: true, data: { user: { type: 'monitor' }, schools: [], temp_token: 't' } }));
+    const fixture = TestBed.createComponent(LoginPage);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    component.loginForm.setValue({ email: 'm@b.com', password: 'secret' });
+    component.onSubmit();
+    expect(router.navigate).toHaveBeenCalledWith(['/teach']);
+  });
+
+  it('redirects client users to the client app', () => {
+    authService.checkUser.mockReturnValue(of({ success: true, data: { user: { type: 'client' }, schools: [], temp_token: 't' } }));
+    const fixture = TestBed.createComponent(LoginPage);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    component.loginForm.setValue({ email: 'c@b.com', password: 'secret' });
+    component.onSubmit();
+    expect(router.navigate).toHaveBeenCalledWith(['/client']);
   });
 });

--- a/front/src/app/features/auth/pages/login.page.ts
+++ b/front/src/app/features/auth/pages/login.page.ts
@@ -209,7 +209,19 @@ export class LoginPage implements OnInit {
           return;
         }
 
-        const { schools, temp_token } = response.data;
+        const { user, schools, temp_token } = response.data;
+
+        if (user?.type === 'monitor') {
+          this.handleLoginError('Please use the teacher app');
+          this.router.navigate(['/teach']);
+          return;
+        }
+
+        if (user?.type === 'client') {
+          this.handleLoginError('Please use the client app');
+          this.router.navigate(['/client']);
+          return;
+        }
 
         if (schools.length === 0) {
           this.handleLoginError('No schools available for this user');


### PR DESCRIPTION
## Summary
- redirect monitors and clients to their specific apps on login
- add tests asserting role-based redirection

## Testing
- `npx jest src/app/features/auth/pages/login.page.spec.ts` *(fails: TS2345 type mismatch in auth-v5.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ace27a5b008320958d03f9f7314a88