### PR TITLE
Ensure unique active season per school

### DIFF
--- a/app/V5/Modules/Season/Repositories/SeasonRepository.php
+++ b/app/V5/Modules/Season/Repositories/SeasonRepository.php
@@ -79,6 +79,22 @@ class SeasonRepository extends BaseRepository
         return $result;
     }
 
+    public function unsetActiveForSchool(int $schoolId, ?int $excludeId = null): void
+    {
+        $query = $this->model->newQuery()
+            ->where('school_id', $schoolId)
+            ->where('is_active', true);
+
+        if ($excludeId) {
+            $query->where('id', '!=', $excludeId);
+        }
+
+        $query->update(['is_active' => false]);
+
+        $this->clearCacheForSchool($schoolId);
+        Cache::forget('seasons:all');
+    }
+
     public function findBySeason(int $id): ?Season
     {
         return $this->find($id);


### PR DESCRIPTION
## Summary
- Add `unsetActiveForSchool` to V5 SeasonRepository with cache clearing
- Deactivate other seasons when creating or activating an active season
- Test season activation logic

## Testing
- `./vendor/bin/phpunit tests/Unit/SeasonServiceTest.php`
- `./vendor/bin/pint --test app/V5/Modules/Season/Repositories/SeasonRepository.php app/V5/Modules/Season/Services/SeasonService.php tests/Unit/SeasonServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ace2a50eac8320b4aefda5dce70e21