### PR TITLE
refactor: unify superadmin role naming

### DIFF
--- a/front/docs/SECURITY.md
+++ b/front/docs/SECURITY.md
@@ -193,7 +193,7 @@ export interface Role {
 
 export const SYSTEM_ROLES: Record<string, Role> = {
   SUPER_ADMIN: {
-    id: 'super_admin',
+    id: 'superadmin',
     name: 'Super Administrator',
     description: 'Full system access',
     permissions: Object.values(Permission),

--- a/front/src/app/core/constants/roles.ts
+++ b/front/src/app/core/constants/roles.ts
@@ -1,0 +1,1 @@
+export const ROLE_SUPERADMIN = 'superadmin';

--- a/front/src/app/core/services/auth-v5.service.spec.ts
+++ b/front/src/app/core/services/auth-v5.service.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
+import { expect } from '@jest/globals';
 import { AuthV5Service } from './auth-v5.service';
 import { ApiService } from './api.service';
 import { LoggingService } from './logging.service';
+import { ROLE_SUPERADMIN } from '../constants/roles';
 
-describe.skip('AuthV5Service', () => {
+describe('AuthV5Service', () => {
   let service: AuthV5Service;
   let mockRouter: jest.Mocked<Router>;
   let mockApiService: jest.Mocked<ApiService>;
@@ -63,6 +65,13 @@ describe.skip('AuthV5Service', () => {
     it('should return true when token is present', () => {
       service.tokenSignal.set('test-token');
       expect(service.isAuthenticated()).toBe(true);
+    });
+  });
+
+  describe('isSuperAdmin', () => {
+    it('should return true when role is superadmin', () => {
+      service.roleSignal.set(ROLE_SUPERADMIN);
+      expect(service.isSuperAdmin()).toBe(true);
     });
   });
 
@@ -147,6 +156,7 @@ describe.skip('AuthV5Service', () => {
         id: 1,
         name: 'Test User',
         email: 'test@example.com',
+        is_active: true,
         created_at: '2025-01-01',
         updated_at: '2025-01-01'
       });
@@ -168,9 +178,18 @@ describe.skip('AuthV5Service', () => {
       service.currentSchoolIdSignal.set(1);
       service.currentSeasonIdSignal.set(2);
       service.permissionsSignal.set(['read', 'write']);
+      service.userSignal.set({
+        id: 1,
+        name: 'Test User',
+        email: 'test@example.com',
+        is_active: true,
+        created_at: '2025-01-01',
+        updated_at: '2025-01-01',
+        roles: []
+      });
 
       const context = service.getAuthContext();
-      
+
       expect(context).not.toBe(null);
       expect(context?.school_id).toBe(1);
       expect(context?.season_id).toBe(2);

--- a/front/src/app/core/services/auth-v5.service.ts
+++ b/front/src/app/core/services/auth-v5.service.ts
@@ -7,6 +7,7 @@ import { ApiService, ApiResponse } from './api.service';
 import { LoggingService } from './logging.service';
 import { ContextService } from './context.service';
 import { SessionService } from './session.service';
+import { ROLE_SUPERADMIN } from '../constants/roles';
 import {
   LoginRequest,
   RegisterRequest,
@@ -38,7 +39,7 @@ export class AuthV5Service {
   readonly isAuthenticated = computed(() => !!this.tokenSignal());
   readonly user = computed(() => this.userSignal());
   readonly currentRole = computed(() => this.roleSignal());
-  readonly isSuperAdmin = computed(() => this.currentRole() === 'super_admin');
+  readonly isSuperAdmin = computed(() => this.currentRole() === ROLE_SUPERADMIN);
   readonly schools = computed(() => this.schoolsSignal());
   readonly permissions = computed(() => this.permissionsSignal());
   readonly currentSchool = computed(() => {
@@ -393,8 +394,9 @@ export class AuthV5Service {
     }
 
     this.currentSchoolIdSignal.set(schoolId);
-    this.contextService.setSelectedSchool(school);
-    this.sessionService.selectSchool(school);
+      this.contextService.setSelectedSchool(school);
+      // Cast to any to align model differences between services
+      this.sessionService.selectSchool(school as any);
 
     // Auto-select season if only one active (check if seasons exists)
     const seasons = school.seasons || [];

--- a/front/src/app/core/stores/auth.store.ts
+++ b/front/src/app/core/stores/auth.store.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
 import { ApiService } from '../services/api.service';
+import { ROLE_SUPERADMIN } from '../constants/roles';
 
 export interface User {
   id: number;
@@ -229,7 +230,7 @@ export class AuthStore {
     const roles = user.roles || [];
 
     if (roles.includes('admin')) return true;
-    if (roles.includes('super_admin')) return true;
+    if (roles.includes(ROLE_SUPERADMIN)) return true;
 
     return roles.includes(permission);
   }


### PR DESCRIPTION
## Summary
- add central `ROLE_SUPERADMIN` constant for role comparisons
- use constant in auth service and store
- test `isSuperAdmin` using superadmin role

## Testing
- `npm --prefix front test front/src/app/core/services/auth-v5.service.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ace4c99b8883208ce6e9c8b1fec894