### PR TITLE
Add tests for season activation filtering

### DIFF
--- a/tests/Feature/V5/SeasonControllerTest.php
+++ b/tests/Feature/V5/SeasonControllerTest.php
@@ -368,4 +368,34 @@ class SeasonControllerTest extends TestCase
                     ],
                 ]);
     }
+
+    /** @test */
+    public function test_activate_season_and_filter_active()
+    {
+        $season1 = $this->postJson($this->baseUrl, [
+            'name' => 'S1',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-06-30',
+            'is_active' => true,
+        ])->assertStatus(201)->json('data');
+
+        $season2 = $this->postJson($this->baseUrl, [
+            'name' => 'S2',
+            'start_date' => '2024-07-01',
+            'end_date' => '2024-12-31',
+            'is_active' => false,
+        ])->assertStatus(201)->json('data');
+
+        $this->postJson("{$this->baseUrl}/{$season2['id']}/activate")
+            ->assertStatus(200);
+
+        $this->getJson("{$this->baseUrl}/{$season1['id']}")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_active', false);
+
+        $this->getJson("{$this->baseUrl}?school_id={$this->school->id}&filterActive=1")
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $season2['id']);
+    }
 }


### PR DESCRIPTION
## Summary
- test filtering active seasons via `/api/seasons?filterActive=1`
- test activating seasons via `/api/v5/seasons/{id}/activate`

## Testing
- `./vendor/bin/phpunit tests/Feature/SeasonApiTest.php`
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' ./vendor/bin/phpunit tests/Feature/V5/SeasonControllerTest.php --filter test_activate_season_and_filter_active` *(fails: hung due to missing DB)*

------
https://chatgpt.com/codex/tasks/task_e_68ace4e966bc8320835f1d1b2ddcfb28