### PR TITLE
feat: add paginated school listing with search

### DIFF
--- a/front/src/app/core/services/school.service.spec.ts
+++ b/front/src/app/core/services/school.service.spec.ts
@@ -193,12 +193,12 @@ describe('SchoolService', () => {
       mockApiHttp.get.mockResolvedValue(mockSchoolsResponse as any);
     });
 
-    it('should call API with high perPage by default', () => {
+    it('should call API with default pagination', () => {
       service.listAll().subscribe();
 
       expect(mockApiHttp.get).toHaveBeenCalledWith('/schools', {
         page: 1,
-        perPage: 1000,
+        perPage: 20,
         active: true,
         orderBy: 'name',
         orderDirection: 'asc'
@@ -224,9 +224,9 @@ describe('SchoolService', () => {
       });
     });
 
-    it('should return schools array', (done) => {
-      service.listAll().subscribe(schools => {
-        expect(schools).toEqual([mockSchool]);
+    it('should return schools response', (done) => {
+      service.listAll().subscribe(res => {
+        expect(res).toEqual(mockSchoolsResponse);
         done();
       });
     });

--- a/front/src/app/core/services/school.service.ts
+++ b/front/src/app/core/services/school.service.ts
@@ -78,11 +78,11 @@ export class SchoolService {
   /**
    * List all schools (super admin only)
    */
-  listAll(params: GetSchoolsParams = {}): Observable<School[]> {
-    // Set default parameters with high perPage
+  listAll(params: GetSchoolsParams = {}): Observable<SchoolsResponse> {
+    // Set default parameters
     const defaultParams: Required<GetSchoolsParams> = {
       page: 1,
-      perPage: 1000,
+      perPage: 20,
       search: '',
       active: true,
       orderBy: 'name',
@@ -101,7 +101,7 @@ export class SchoolService {
 
     return from(
       this.apiHttp.get<SchoolsResponse>('/schools', queryParams)
-    ).pipe(map(response => response.data));
+    );
   }
 
   /**

--- a/front/src/app/features/school-selection/select-school.page.spec.ts
+++ b/front/src/app/features/school-selection/select-school.page.spec.ts
@@ -8,36 +8,45 @@ import { Router } from '@angular/router';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
 import { expect } from '@jest/globals';
-import { SchoolService } from '@core/services/school.service';
+import { SchoolService, SchoolsResponse } from '@core/services/school.service';
 
 describe('SelectSchoolPageComponent', () => {
   let component: SelectSchoolPageComponent;
   let fixture: ComponentFixture<SelectSchoolPageComponent>;
-  let authV5: AuthV5Service;
-  let session: SessionService;
-  let router: Router;
+  let authV5Spy: any;
+  let sessionSpy: any;
+  let routerSpy: any;
+  let toastSpy: any;
+  let translationSpy: any;
+  let schoolServiceSpy: any;
 
   const mockSchools = [
     { id: 1, name: 'School A', active: true },
     { id: 2, name: 'School B', active: true }
   ];
 
+  const createComponent = () => {
+    fixture = TestBed.createComponent(SelectSchoolPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
   beforeEach(async () => {
-    const authV5Spy = {
+    authV5Spy = {
       selectSchool: jest.fn().mockReturnValue(of({ success: true, data: { school: mockSchools[0] } })),
       user: signal({ schools: mockSchools } as any),
       tokenSignal: signal('temp-token'),
       isSuperAdmin: signal(false)
     } as unknown as AuthV5Service;
 
-    const sessionSpy = { selectSchool: jest.fn() } as unknown as SessionService;
-    const routerSpy = { navigate: jest.fn() } as unknown as Router;
-    const toastSpy = { success: jest.fn(), error: jest.fn() } as unknown as ToastService;
-    const translationSpy = {
+    sessionSpy = { selectSchool: jest.fn() } as unknown as SessionService;
+    routerSpy = { navigate: jest.fn() } as unknown as Router;
+    toastSpy = { success: jest.fn(), error: jest.fn() } as unknown as ToastService;
+    translationSpy = {
       get: jest.fn((k: string) => k),
       currentLanguage: jest.fn(() => 'en')
     } as unknown as TranslationService;
-    const schoolServiceSpy = { listAll: jest.fn().mockReturnValue(of(mockSchools)) } as unknown as SchoolService;
+    schoolServiceSpy = { listAll: jest.fn() } as unknown as SchoolService;
 
     await TestBed.configureTestingModule({
       imports: [SelectSchoolPageComponent],
@@ -50,25 +59,82 @@ describe('SelectSchoolPageComponent', () => {
         { provide: SchoolService, useValue: schoolServiceSpy }
       ]
     }).compileComponents();
-
-    fixture = TestBed.createComponent(SelectSchoolPageComponent);
-    component = fixture.componentInstance;
-    authV5 = TestBed.inject(AuthV5Service);
-    session = TestBed.inject(SessionService);
-    router = TestBed.inject(Router);
-
-    fixture.detectChanges();
   });
 
   it('should load schools from AuthV5Service', () => {
+    createComponent();
     expect(component.schools()).toEqual(mockSchools);
   });
 
   it('should persist school id on selection', () => {
+    createComponent();
     component.selectSchool(mockSchools[0] as any);
+    expect(sessionSpy.selectSchool).toHaveBeenCalledWith(mockSchools[0] as any);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/select-season']);
+  });
 
-    expect(session.selectSchool).toHaveBeenCalledWith(mockSchools[0] as any);
-    expect(router.navigate).toHaveBeenCalledWith(['/select-season']);
+  describe('super admin', () => {
+    beforeEach(() => {
+      authV5Spy.isSuperAdmin = signal(true);
+      authV5Spy.user = signal({} as any);
+    });
+
+    it('should fetch first page of schools', () => {
+      const response: SchoolsResponse = {
+        data: mockSchools,
+        meta: { total: 2, page: 1, perPage: 20, lastPage: 1, from: 1, to: 2 }
+      };
+      schoolServiceSpy.listAll.mockReturnValue(of(response));
+
+      createComponent();
+
+      expect(schoolServiceSpy.listAll).toHaveBeenCalledWith({ page: 1, perPage: 20, search: '' });
+      expect(component.schools()).toEqual(mockSchools);
+    });
+
+    it('should load next page of schools', () => {
+      const firstPage: SchoolsResponse = {
+        data: [mockSchools[0]],
+        meta: { total: 2, page: 1, perPage: 20, lastPage: 2, from: 1, to: 1 }
+      };
+      const secondPage: SchoolsResponse = {
+        data: [mockSchools[1]],
+        meta: { total: 2, page: 2, perPage: 20, lastPage: 2, from: 2, to: 2 }
+      };
+      schoolServiceSpy.listAll
+        .mockReturnValueOnce(of(firstPage))
+        .mockReturnValueOnce(of(secondPage));
+
+      createComponent();
+      component.loadMore();
+
+      expect(schoolServiceSpy.listAll).toHaveBeenLastCalledWith({ page: 2, perPage: 20, search: '' });
+      expect(component.schools()).toEqual([...firstPage.data, ...secondPage.data]);
+    });
+
+    it('should search schools via API', () => {
+      jest.useFakeTimers();
+      const firstPage: SchoolsResponse = {
+        data: mockSchools,
+        meta: { total: 2, page: 1, perPage: 20, lastPage: 1, from: 1, to: 2 }
+      };
+      const searchPage: SchoolsResponse = {
+        data: [mockSchools[1]],
+        meta: { total: 1, page: 1, perPage: 20, lastPage: 1, from: 1, to: 1 }
+      };
+      schoolServiceSpy.listAll
+        .mockReturnValueOnce(of(firstPage))
+        .mockReturnValueOnce(of(searchPage));
+
+      createComponent();
+      component.searchQuery = 'School B';
+      component.onSearchInput();
+      jest.advanceTimersByTime(300);
+
+      expect(schoolServiceSpy.listAll).toHaveBeenNthCalledWith(2, { page: 1, perPage: 20, search: 'School B' });
+      expect(component.schools()).toEqual([mockSchools[1]]);
+      jest.useRealTimers();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- expose pagination and search options in school service
- load schools page-by-page with server-side search in selection page
- add integration tests covering pagination and search

## Testing
- `npm test` *(fails: Cannot find module '@angular/core/testing' from 'node_modules/jest-preset-angular/setup-jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ad4b726ea88320b1c706f5597a6f62