### PR TITLE
Ensure single active season when updating via PUT

### DIFF
--- a/tests/Feature/SeasonApiTest.php
+++ b/tests/Feature/SeasonApiTest.php
@@ -82,4 +82,55 @@ class SeasonApiTest extends TestCase
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $season2['id']);
     }
+
+    public function test_only_one_active_season_per_school(): void
+    {
+        $school = School::create([
+            'name' => 'Test School',
+            'slug' => 'test-school',
+        ]);
+
+        $season1 = $this->postJson('/api/seasons', [
+            'name' => 'S1',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-02-01',
+            'is_active' => false,
+            'school_id' => $school->id,
+        ])->assertStatus(200)->json('data');
+
+        $season2 = $this->postJson('/api/seasons', [
+            'name' => 'S2',
+            'start_date' => '2024-03-01',
+            'end_date' => '2024-04-01',
+            'is_active' => false,
+            'school_id' => $school->id,
+        ])->assertStatus(200)->json('data');
+
+        $this->putJson('/api/seasons/' . $season1['id'], [
+            'name' => 'S1',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-02-01',
+            'school_id' => $school->id,
+            'is_active' => true,
+        ])->assertStatus(200)
+            ->assertJsonPath('data.is_active', true);
+
+        $this->putJson('/api/seasons/' . $season2['id'], [
+            'name' => 'S2',
+            'start_date' => '2024-03-01',
+            'end_date' => '2024-04-01',
+            'school_id' => $school->id,
+            'is_active' => true,
+        ])->assertStatus(200)
+            ->assertJsonPath('data.is_active', true);
+
+        $this->getJson('/api/seasons/' . $season1['id'])
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_active', false);
+
+        $this->getJson('/api/seasons?school_id=' . $school->id . '&filterActive=1')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $season2['id']);
+    }
 }


### PR DESCRIPTION
## Summary
- add test verifying activating a season via PUT deactivates previously active one

## Testing
- `vendor/bin/phpunit tests/Feature/SeasonApiTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad4f3c0930832092cfcf4a51d41423