### PR TITLE
Enforce single active season per school with database trigger

### DIFF
--- a/database/migrations/2025_07_28_214716_add_active_season_trigger.php
+++ b/database/migrations/2025_07_28_214716_add_active_season_trigger.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'mysql') {
+            DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_update');
+
+            DB::unprepared('CREATE TRIGGER seasons_before_insert
+                BEFORE INSERT ON seasons
+                FOR EACH ROW
+                BEGIN
+                    IF NEW.is_active = 1 THEN
+                        UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1;
+                    END IF;
+                END');
+
+            DB::unprepared('CREATE TRIGGER seasons_before_update
+                BEFORE UPDATE ON seasons
+                FOR EACH ROW
+                BEGIN
+                    IF NEW.is_active = 1 THEN
+                        UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1 AND id != NEW.id;
+                    END IF;
+                END');
+        } else {
+            DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_insert');
+            DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_update');
+
+            DB::unprepared('CREATE TRIGGER seasons_before_insert
+                BEFORE INSERT ON seasons
+                WHEN NEW.is_active = 1
+                BEGIN
+                    UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1;
+                END;');
+
+            DB::unprepared('CREATE TRIGGER seasons_before_update
+                BEFORE UPDATE ON seasons
+                WHEN NEW.is_active = 1
+                BEGIN
+                    UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1 AND id <> NEW.id;
+                END;');
+        }
+    }
+
+    public function down(): void
+    {
+        DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_insert');
+        DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_update');
+    }
+};

--- a/tests/Feature/SeasonApiTest.php
+++ b/tests/Feature/SeasonApiTest.php
@@ -4,19 +4,23 @@ namespace Tests\Feature;
 
 use App\Models\School;
 use App\V5\Models\Season;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
 
 class SeasonApiTest extends TestCase
 {
     use WithoutMiddleware;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         Schema::disableForeignKeyConstraints();
+        DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_insert');
+        DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_update');
         Schema::dropIfExists('seasons');
         Schema::dropIfExists('schools');
         Schema::enableForeignKeyConstraints();
@@ -39,11 +43,47 @@ class SeasonApiTest extends TestCase
             $table->timestamps();
             $table->timestamp('deleted_at')->nullable();
         });
+
+        if (DB::getDriverName() === 'mysql') {
+            DB::unprepared('CREATE TRIGGER seasons_before_insert
+                BEFORE INSERT ON seasons
+                FOR EACH ROW
+                BEGIN
+                    IF NEW.is_active = 1 THEN
+                        UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1;
+                    END IF;
+                END');
+
+            DB::unprepared('CREATE TRIGGER seasons_before_update
+                BEFORE UPDATE ON seasons
+                FOR EACH ROW
+                BEGIN
+                    IF NEW.is_active = 1 THEN
+                        UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1 AND id != NEW.id;
+                    END IF;
+                END');
+        } else {
+            DB::unprepared('CREATE TRIGGER seasons_before_insert
+                BEFORE INSERT ON seasons
+                WHEN NEW.is_active = 1
+                BEGIN
+                    UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1;
+                END;');
+
+            DB::unprepared('CREATE TRIGGER seasons_before_update
+                BEFORE UPDATE ON seasons
+                WHEN NEW.is_active = 1
+                BEGIN
+                    UPDATE seasons SET is_active = 0 WHERE school_id = NEW.school_id AND is_active = 1 AND id <> NEW.id;
+                END;');
+        }
     }
 
     protected function tearDown(): void
     {
         Schema::disableForeignKeyConstraints();
+        DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_insert');
+        DB::unprepared('DROP TRIGGER IF EXISTS seasons_before_update');
         Schema::dropIfExists('seasons');
         Schema::dropIfExists('schools');
         Schema::enableForeignKeyConstraints();
@@ -73,13 +113,41 @@ class SeasonApiTest extends TestCase
             'school_id' => $school->id,
         ])->assertStatus(200)->json('data');
 
-        $this->getJson('/api/seasons/' . $season1['id'])
+        $this->getJson('/api/seasons/'.$season1['id'])
             ->assertStatus(200)
             ->assertJsonPath('data.is_active', false);
 
-        $this->getJson('/api/seasons?school_id=' . $school->id . '&filterActive=1')
+        $this->getJson('/api/seasons?school_id='.$school->id.'&filterActive=1')
             ->assertStatus(200)
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $season2['id']);
+    }
+
+    public function test_database_prevents_multiple_active_seasons(): void
+    {
+        $school = School::create([
+            'name' => 'Another School',
+            'slug' => 'another-school',
+        ]);
+
+        $first = Season::create([
+            'name' => 'Primera',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-02-01',
+            'is_active' => true,
+            'school_id' => $school->id,
+        ]);
+
+        $second = Season::create([
+            'name' => 'Segunda',
+            'start_date' => '2024-03-01',
+            'end_date' => '2024-04-01',
+            'is_active' => true,
+            'school_id' => $school->id,
+        ]);
+
+        $this->assertFalse($first->fresh()->is_active);
+        $this->assertTrue($second->fresh()->is_active);
+        $this->assertEquals(1, Season::where('school_id', $school->id)->where('is_active', true)->count());
     }
 }


### PR DESCRIPTION
## Summary
- add migration creating triggers to keep only one active season per school
- extend SeasonApiTest with trigger setup and new check for duplicate active seasons

## Testing
- `vendor/bin/phpunit tests/Feature/SeasonApiTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad4f3129c08320831271102feeddb1