### PR TITLE
Use role field instead of type in login flow

### DIFF
--- a/app/Http/Controllers/Api/V5/AuthController.php
+++ b/app/Http/Controllers/Api/V5/AuthController.php
@@ -114,7 +114,8 @@ class AuthController extends Controller
                     'name' => $user->name,
                     'email' => $user->email,
                     'email_verified_at' => $user->email_verified_at,
-                    'role' => $this->getUserPrimaryRole($user)
+                    'role' => $this->getUserPrimaryRole($user),
+                    'type' => $this->getUserPrimaryRole($user)
                 ],
                 'schools' => $schools->values()->all(),
                 'requires_school_selection' => $requiresSchoolSelection,
@@ -175,7 +176,8 @@ class AuthController extends Controller
                     'id' => $user->id,
                     'name' => $user->name,
                     'email' => $user->email,
-                    'role' => $this->getUserPrimaryRole($user)
+                    'role' => $this->getUserPrimaryRole($user),
+                    'type' => $this->getUserPrimaryRole($user)
                 ],
                 'school' => [
                     'id' => $school->id,
@@ -267,7 +269,9 @@ class AuthController extends Controller
                     'id' => $user->id,
                     'name' => $user->name,
                     'email' => $user->email,
-                    'email_verified_at' => $user->email_verified_at
+                    'email_verified_at' => $user->email_verified_at,
+                    'role' => $this->getUserPrimaryRole($user),
+                    'type' => $this->getUserPrimaryRole($user)
                 ],
                 'school' => [
                     'id' => $school->id,
@@ -599,6 +603,7 @@ class AuthController extends Controller
                 'name' => $user->name,
                 'email' => $user->email,
                 'role' => $this->getUserPrimaryRole($user),
+                'type' => $this->getUserPrimaryRole($user),
                 'permissions' => $this->getUserPermissions($user, $school->id)
             ],
             'school' => [

--- a/front/src/app/features/auth/pages/login.page.spec.ts
+++ b/front/src/app/features/auth/pages/login.page.spec.ts
@@ -43,7 +43,7 @@ describe('LoginPage', () => {
   });
 
   it('redirects monitor users to the teach app', () => {
-    authService.checkUser.mockReturnValue(of({ success: true, data: { user: { type: 'monitor' }, schools: [], temp_token: 't' } }));
+    authService.checkUser.mockReturnValue(of({ success: true, data: { user: { role: 'monitor' }, schools: [], temp_token: 't' } }));
     const fixture = TestBed.createComponent(LoginPage);
     const component = fixture.componentInstance;
     fixture.detectChanges();
@@ -53,7 +53,7 @@ describe('LoginPage', () => {
   });
 
   it('redirects client users to the client app', () => {
-    authService.checkUser.mockReturnValue(of({ success: true, data: { user: { type: 'client' }, schools: [], temp_token: 't' } }));
+    authService.checkUser.mockReturnValue(of({ success: true, data: { user: { role: 'client' }, schools: [], temp_token: 't' } }));
     const fixture = TestBed.createComponent(LoginPage);
     const component = fixture.componentInstance;
     fixture.detectChanges();

--- a/front/src/app/features/auth/pages/login.page.ts
+++ b/front/src/app/features/auth/pages/login.page.ts
@@ -211,13 +211,13 @@ export class LoginPage implements OnInit {
 
         const { user, schools, temp_token } = response.data;
 
-        if (user?.type === 'monitor') {
+        if (user?.role === 'monitor') {
           this.handleLoginError('Please use the teacher app');
           this.router.navigate(['/teach']);
           return;
         }
 
-        if (user?.type === 'client') {
+        if (user?.role === 'client') {
           this.handleLoginError('Please use the client app');
           this.router.navigate(['/client']);
           return;


### PR DESCRIPTION
## Summary
- Replace `user.type` checks with `user.role` in login page
- Update login page test mocks to use `role`
- Include both `role` and `type` in AuthController API responses for compatibility

## Testing
- `npx jest src/app/features/auth/pages/login.page.spec.ts --runTestsByPath` *(fails: NullInjectorError – No provider for _HttpClient)*
- `vendor/bin/phpunit tests/Feature/V5/Auth/LoginTest.php` *(fails: no output, likely due to missing database setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ad50bce35483208004567116f64fa1