### PR TITLE
feat: preserve user role on login

### DIFF
--- a/front/src/app/core/services/auth-v5.service.ts
+++ b/front/src/app/core/services/auth-v5.service.ts
@@ -447,9 +447,11 @@ export class AuthV5Service {
     this.tokenSignal.set(token);
     this.userSignal.set(data.user);
 
-    // Extract user role from roles array or type property
-    let role: string | null = null;
-    if (data.user?.type) {
+    // Extract user role from response or preserve existing role
+    let role: string | null = this.roleSignal();
+    if (data.user?.role) {
+      role = data.user.role;
+    } else if (data.user?.type) {
       role = data.user.type;
     } else if (Array.isArray(data.user?.roles) && data.user.roles.length > 0) {
       const firstRole = data.user.roles[0];

--- a/tests/Feature/V5/Auth/DevUsersLoginTest.php
+++ b/tests/Feature/V5/Auth/DevUsersLoginTest.php
@@ -207,6 +207,27 @@ class DevUsersLoginTest extends TestCase
     }
 
     /** @test */
+    public function select_school_response_includes_user_role()
+    {
+        $checkUserResponse = $this->postJson('/api/v5/auth/check-user', [
+            'email' => 'admin@boukii-v5.com',
+            'password' => 'password123'
+        ]);
+
+        $tempToken = $checkUserResponse->json('data.temp_token');
+
+        $response = $this->postJson('/api/v5/auth/select-school', [
+            'school_id' => 2,
+            'remember_me' => false
+        ], [
+            'Authorization' => "Bearer {$tempToken}"
+        ]);
+
+        $response->assertStatus(200)
+                ->assertJsonPath('data.user.role', 'admin');
+    }
+
+    /** @test */
     public function invalid_credentials_are_rejected()
     {
         $response = $this->postJson('/api/v5/auth/check-user', [


### PR DESCRIPTION
## Summary
- include role in selectSchool response
- keep previously stored role when login response omits it
- test selectSchool returns user role

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=database/data.sqlite ./vendor/bin/phpunit --filter select_school_response_includes_user_role tests/Feature/V5/Auth/DevUsersLoginTest.php` *(fails: Admin user should exist)*
- `npm test --prefix front` *(fails: numerous spec errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad53ca8b088320b57a1fa665b1d1a8