### PR TITLE
feat(front): align auth models with API fields

### DIFF
--- a/front/src/app/core/models/auth-v5.models.ts
+++ b/front/src/app/core/models/auth-v5.models.ts
@@ -46,6 +46,8 @@ export interface User {
   id: number;
   name: string;
   email: string;
+  type?: string;
+  role?: string;
   email_verified_at?: string;
   is_active: boolean;
   last_login_at?: string;
@@ -59,7 +61,10 @@ export interface School {
   name: string;
   slug: string;
   description?: string;
-  status: 'active' | 'inactive';
+  logo?: string;
+  active: boolean;
+  user_role?: string;
+  can_administer?: boolean;
   created_at: string;
   updated_at: string;
   seasons: Season[];

--- a/front/src/app/core/services/auth-v5.service.spec.ts
+++ b/front/src/app/core/services/auth-v5.service.spec.ts
@@ -228,7 +228,7 @@ describe('AuthV5Service', () => {
           id: 1,
           name: 'Test School',
           slug: 'test-school',
-          status: 'active' as const,
+          active: true,
           created_at: '2025-01-01',
           updated_at: '2025-01-01',
           seasons: []
@@ -252,7 +252,7 @@ describe('AuthV5Service', () => {
           id: 1,
           name: 'Test School',
           slug: 'test-school',
-          status: 'active' as const,
+          active: true,
           created_at: '2025-01-01',
           updated_at: '2025-01-01',
           seasons: [

--- a/front/src/app/core/services/context.service.ts
+++ b/front/src/app/core/services/context.service.ts
@@ -5,7 +5,10 @@ export interface School {
   id: number;
   name: string;
   slug?: string;
+  logo?: string;
   active: boolean;
+  user_role?: string;
+  can_administer?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/front/src/app/features/admin/permissions/components/bulk-assignment-modal/bulk-assignment-modal.component.ts
+++ b/front/src/app/features/admin/permissions/components/bulk-assignment-modal/bulk-assignment-modal.component.ts
@@ -1208,9 +1208,9 @@ export class BulkAssignmentModalComponent implements OnInit, OnChanges {
   private loadSchools(): void {
     // Mock schools data - in real app, load from SchoolsService
     this.availableSchools.set([
-      { id: 1, name: 'Escuela Central', code: 'EC001', status: 'active' },
-      { id: 2, name: 'Sede Norte', code: 'SN002', status: 'active' },
-      { id: 3, name: 'Campus Sur', code: 'CS003', status: 'active' }
+      { id: 1, name: 'Escuela Central', code: 'EC001', active: true },
+      { id: 2, name: 'Sede Norte', code: 'SN002', active: true },
+      { id: 3, name: 'Campus Sur', code: 'CS003', active: true }
     ]);
   }
 

--- a/front/src/app/features/admin/permissions/types/school-permissions.types.ts
+++ b/front/src/app/features/admin/permissions/types/school-permissions.types.ts
@@ -2,7 +2,8 @@ export interface School {
   id: number;
   name: string;
   code: string;
-  status: 'active' | 'inactive';
+  active: boolean;
+  logo?: string;
   address?: string;
   adminEmail?: string;
 }

--- a/front/src/app/features/school-selection/select-school.page.ts
+++ b/front/src/app/features/school-selection/select-school.page.ts
@@ -10,16 +10,7 @@ import { ToastService } from '@core/services/toast.service';
 import { TranslationService } from '@core/services/translation.service';
 import { SessionService } from '@core/services/session.service';
 import { SchoolService } from '@core/services/school.service';
-
-interface School {
-  id: number;
-  name: string;
-  slug?: string;
-  logo?: string;
-  active?: boolean;
-  user_role?: string;
-  can_administer?: boolean;
-}
+import { School } from '@core/services/context.service';
 
 @Component({
   selector: 'app-select-school',


### PR DESCRIPTION
## Summary
- add optional `type` and `role` to `User` auth model
- expand `School` model with `logo`, `active`, and role-related fields
- update related services, types, and tests to new `School` shape

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad55bff03c8320a1a5c925fb472128