### PR TITLE
feat: add virtual scroll to school selection

### DIFF
--- a/front/src/app/features/school-selection/select-school.styles.scss
+++ b/front/src/app/features/school-selection/select-school.styles.scss
@@ -194,6 +194,10 @@
   margin-bottom: var(--space-8, 32px);
 }
 
+.schools-viewport {
+  height: 600px;
+}
+
 .school-card {
   background: var(--surface);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- integrate Angular CDK virtual scroll to render only visible school cards and load more on scroll
- style viewport for virtual scroll
- expand Cypress tests to validate virtual scroll and infinite scrolling

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm run cypress:run --spec cypress/e2e/school-selection.cy.ts` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad585bd7cc8320bed9727cd24e5489