### PR TITLE
feat(settings): add settings feature with mock data

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -79,6 +79,10 @@ export const routes: Routes = [
         path: 'admin/permissions',
         canActivate: [requireCompleteAuthGuard],
         loadChildren: () => import('./features/admin/permissions/permissions.routes').then(m => m.permissionsRoutes)
+      },
+      {
+        path: 'settings',
+        loadChildren: () => import('./features/settings').then(m => m.routes)
       }
     ]
   },

--- a/front/src/app/features/settings/data/school-settings.ts
+++ b/front/src/app/features/settings/data/school-settings.ts
@@ -1,0 +1,10 @@
+export interface SchoolSetting {
+  id: number;
+  name: string;
+  value: string;
+}
+
+export const SCHOOL_SETTINGS: SchoolSetting[] = [
+  { id: 1, name: 'name', value: 'Escuela Surf' },
+  { id: 2, name: 'location', value: 'Playa Norte' }
+];

--- a/front/src/app/features/settings/data/seasons.ts
+++ b/front/src/app/features/settings/data/seasons.ts
@@ -1,0 +1,11 @@
+export interface Season {
+  id: number;
+  name: string;
+  year: number;
+  active: boolean;
+}
+
+export const SEASONS: Season[] = [
+  { id: 1, name: 'Summer', year: 2024, active: true },
+  { id: 2, name: 'Winter', year: 2023, active: false }
+];

--- a/front/src/app/features/settings/data/sports-degrees.ts
+++ b/front/src/app/features/settings/data/sports-degrees.ts
@@ -1,0 +1,10 @@
+export interface SportsDegree {
+  id: number;
+  name: string;
+}
+
+export const SPORTS_DEGREES: SportsDegree[] = [
+  { id: 1, name: 'Beginner' },
+  { id: 2, name: 'Intermediate' },
+  { id: 3, name: 'Advanced' }
+];

--- a/front/src/app/features/settings/data/station-settings.ts
+++ b/front/src/app/features/settings/data/station-settings.ts
@@ -1,0 +1,10 @@
+export interface StationSetting {
+  id: number;
+  key: string;
+  value: string;
+}
+
+export const STATION_SETTINGS: StationSetting[] = [
+  { id: 1, key: 'timezone', value: 'UTC' },
+  { id: 2, key: 'currency', value: 'EUR' }
+];

--- a/front/src/app/features/settings/index.ts
+++ b/front/src/app/features/settings/index.ts
@@ -1,0 +1,6 @@
+export { routes } from './settings.routes';
+export { SchoolSettingsComponent } from './school-settings.component';
+export { SeasonsComponent } from './seasons.component';
+export { SportsDegreesComponent } from './sports-degrees.component';
+export { StationSettingsComponent } from './station-settings.component';
+export { SettingsService } from './settings.service';

--- a/front/src/app/features/settings/school-settings.component.ts
+++ b/front/src/app/features/settings/school-settings.component.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SettingsService } from './settings.service';
+
+@Component({
+  selector: 'app-school-settings',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>School Settings</h2>
+    <ul>
+      <li *ngFor="let setting of settings$ | async">{{ setting.name }}: {{ setting.value }}</li>
+    </ul>
+  `
+})
+export class SchoolSettingsComponent {
+  private readonly settingsService = inject(SettingsService);
+  readonly settings$ = this.settingsService.getSchoolSettings();
+}

--- a/front/src/app/features/settings/seasons.component.ts
+++ b/front/src/app/features/settings/seasons.component.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SettingsService } from './settings.service';
+
+@Component({
+  selector: 'app-seasons',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Seasons</h2>
+    <ul>
+      <li *ngFor="let season of seasons$ | async">{{ season.name }} - {{ season.year }}</li>
+    </ul>
+  `
+})
+export class SeasonsComponent {
+  private readonly settingsService = inject(SettingsService);
+  readonly seasons$ = this.settingsService.getSeasons();
+}

--- a/front/src/app/features/settings/settings.routes.ts
+++ b/front/src/app/features/settings/settings.routes.ts
@@ -1,0 +1,12 @@
+import { Routes } from '@angular/router';
+import { SchoolSettingsComponent } from './school-settings.component';
+import { SeasonsComponent } from './seasons.component';
+import { SportsDegreesComponent } from './sports-degrees.component';
+import { StationSettingsComponent } from './station-settings.component';
+
+export const routes: Routes = [
+  { path: 'school', component: SchoolSettingsComponent },
+  { path: 'seasons', component: SeasonsComponent },
+  { path: 'sports-degrees', component: SportsDegreesComponent },
+  { path: 'station', component: StationSettingsComponent }
+];

--- a/front/src/app/features/settings/settings.service.ts
+++ b/front/src/app/features/settings/settings.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { SCHOOL_SETTINGS, SchoolSetting } from './data/school-settings';
+import { SEASONS, Season } from './data/seasons';
+import { SPORTS_DEGREES, SportsDegree } from './data/sports-degrees';
+import { STATION_SETTINGS, StationSetting } from './data/station-settings';
+
+@Injectable({ providedIn: 'root' })
+export class SettingsService {
+  getSchoolSettings(): Observable<SchoolSetting[]> {
+    return of(SCHOOL_SETTINGS);
+  }
+
+  getSeasons(): Observable<Season[]> {
+    return of(SEASONS);
+  }
+
+  getSportsDegrees(): Observable<SportsDegree[]> {
+    return of(SPORTS_DEGREES);
+  }
+
+  getStationSettings(): Observable<StationSetting[]> {
+    return of(STATION_SETTINGS);
+  }
+}

--- a/front/src/app/features/settings/sports-degrees.component.ts
+++ b/front/src/app/features/settings/sports-degrees.component.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SettingsService } from './settings.service';
+
+@Component({
+  selector: 'app-sports-degrees',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Sports Degrees</h2>
+    <ul>
+      <li *ngFor="let degree of degrees$ | async">{{ degree.name }}</li>
+    </ul>
+  `
+})
+export class SportsDegreesComponent {
+  private readonly settingsService = inject(SettingsService);
+  readonly degrees$ = this.settingsService.getSportsDegrees();
+}

--- a/front/src/app/features/settings/station-settings.component.ts
+++ b/front/src/app/features/settings/station-settings.component.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SettingsService } from './settings.service';
+
+@Component({
+  selector: 'app-station-settings',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Station Settings</h2>
+    <ul>
+      <li *ngFor="let setting of settings$ | async">{{ setting.key }}: {{ setting.value }}</li>
+    </ul>
+  `
+})
+export class StationSettingsComponent {
+  private readonly settingsService = inject(SettingsService);
+  readonly settings$ = this.settingsService.getStationSettings();
+}


### PR DESCRIPTION
## Summary
- add settings feature with child routes and lazy loading support
- provide mock SettingsService and sample data
- register settings route in main app routes

## Testing
- `npm test` *(fails: Test Suites: 12 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad61852fd08320967f9bacb05c2ec0