### PR TITLE
feat: add charts to dashboard

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -19,6 +19,8 @@
         "@angular/platform-browser-dynamic": "^18.2.0",
         "@angular/router": "^18.2.0",
         "@ngx-translate/core": "^17.0.0",
+        "chart.js": "^4.5.0",
+        "ng2-charts": "^5.0.4",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.0"
@@ -6054,6 +6056,12 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -10936,6 +10944,18 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/check-error": {
       "version": "2.1.1",
@@ -19096,6 +19116,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -20042,6 +20068,24 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/ng2-charts": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-5.0.4.tgz",
+      "integrity": "sha512-AnOZ2KSRw7QjiMMNtXz9tdnO+XrIKP/2MX1TfqEEo2fwFU5c8LFJIYqmkMPkIzAEm/U9y/1psA5TDNmxxjEdgA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": ">=16.0.0",
+        "@angular/common": ">=16.0.0",
+        "@angular/core": ">=16.0.0",
+        "@angular/platform-browser": ">=16.0.0",
+        "chart.js": "^3.4.0 || ^4.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
     },
     "node_modules/nice-napi": {
       "version": "1.0.2",

--- a/front/package.json
+++ b/front/package.json
@@ -116,6 +116,8 @@
     "@angular/platform-browser-dynamic": "^18.2.0",
     "@angular/router": "^18.2.0",
     "@ngx-translate/core": "^17.0.0",
+    "chart.js": "^4.5.0",
+    "ng2-charts": "^5.0.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.0"
@@ -141,6 +143,8 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/jasmine": "~5.1.0",
     "@types/jest": "^29.5.12",
+    "@typescript-eslint/eslint-plugin": "8.34.1",
+    "@typescript-eslint/parser": "8.34.1",
     "angular-eslint": "20.1.1",
     "cypress": "^14.5.4",
     "eslint": "^9.29.0",
@@ -164,8 +168,6 @@
     "storybook": "^8.6.14",
     "ts-jest": "^29.1.1",
     "typescript": "^5.4.0",
-    "@typescript-eslint/parser": "8.34.1",
-    "@typescript-eslint/eslint-plugin": "8.34.1",
     "vite": "^5.0.0",
     "vite-tsconfig-paths": "^4.2.0"
   }

--- a/front/src/app/features/dashboard/dashboard-page.component.ts
+++ b/front/src/app/features/dashboard/dashboard-page.component.ts
@@ -1,11 +1,15 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '@shared/pipes/translate.pipe';
+import { NgChartsModule } from 'ng2-charts';
+import { Chart, ChartData, ChartOptions, registerables } from 'chart.js';
+
+Chart.register(...registerables);
 
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [CommonModule, TranslatePipe, NgChartsModule],
   template: `
     <div class="page" data-cy="dashboard">
       <div class="page-header">
@@ -68,6 +72,27 @@ import { TranslatePipe } from '@shared/pipes/translate.pipe';
               <span class="chip chip--blue">{{ 'dashboard.activity.updated' | translate }}</span>
             </div>
           </div>
+        </div>
+      </div>
+
+      <div class="grid grid--two" style="margin-top:24px">
+        <div class="card">
+          <h3>Daily Attendance</h3>
+          <canvas
+            baseChart
+            [data]="attendanceData"
+            [options]="attendanceOptions"
+            [type]="'line'"
+          ></canvas>
+        </div>
+        <div class="card">
+          <h3>Bookings by Hour</h3>
+          <canvas
+            baseChart
+            [data]="bookingsByHourData"
+            [options]="bookingsByHourOptions"
+            [type]="'bar'"
+          ></canvas>
         </div>
       </div>
 
@@ -150,4 +175,44 @@ import { TranslatePipe } from '@shared/pipes/translate.pipe';
     `,
   ],
 })
-export class DashboardPageComponent {}
+export class DashboardPageComponent {
+  attendanceData: ChartData<'line'> = {
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    datasets: [
+      {
+        data: [20, 25, 22, 30, 28, 35, 40],
+        label: 'Attendance',
+        fill: false,
+        borderColor: '#3e95cd',
+        tension: 0.1,
+      },
+    ],
+  };
+
+  attendanceOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { beginAtZero: true },
+    },
+  };
+
+  bookingsByHourData: ChartData<'bar'> = {
+    labels: ['8h', '9h', '10h', '11h', '12h', '13h', '14h'],
+    datasets: [
+      {
+        data: [2, 4, 6, 8, 5, 3, 1],
+        label: 'Bookings',
+        backgroundColor: '#8e5ea2',
+      },
+    ],
+  };
+
+  bookingsByHourOptions: ChartOptions<'bar'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { beginAtZero: true },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- install chart.js and ng2-charts dependencies
- visualize attendance and bookings data with new charts on dashboard
- mock chart datasets and options for standalone rendering

## Testing
- `npm test --prefix front` *(fails: Test Suites: 12 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62db78608320b2625b6304a47293