### PR TITLE
feat: localize dashboard charts

### DIFF
--- a/front/src/app/features/dashboard/dashboard-page.component.ts
+++ b/front/src/app/features/dashboard/dashboard-page.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '@shared/pipes/translate.pipe';
 import { NgChartsModule } from 'ng2-charts';
 import { Chart, ChartData, ChartOptions, registerables } from 'chart.js';
+import { TranslationService } from '@core/services/translation.service';
 
 Chart.register(...registerables);
 
@@ -77,7 +78,7 @@ Chart.register(...registerables);
 
       <div class="grid grid--two" style="margin-top:24px">
         <div class="card">
-          <h3>Daily Attendance</h3>
+        <h3>{{ 'dashboard.charts.dailyAttendance' | translate }}</h3>
           <canvas
             baseChart
             [data]="attendanceData"
@@ -86,7 +87,7 @@ Chart.register(...registerables);
           ></canvas>
         </div>
         <div class="card">
-          <h3>Bookings by Hour</h3>
+        <h3>{{ 'dashboard.charts.hourlyBookings' | translate }}</h3>
           <canvas
             baseChart
             [data]="bookingsByHourData"
@@ -176,12 +177,13 @@ Chart.register(...registerables);
   ],
 })
 export class DashboardPageComponent {
+  private readonly translationService = inject(TranslationService);
   attendanceData: ChartData<'line'> = {
     labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
     datasets: [
       {
         data: [20, 25, 22, 30, 28, 35, 40],
-        label: 'Attendance',
+        label: this.translationService.instant('dashboard.charts.legend.attendance'),
         fill: false,
         borderColor: '#3e95cd',
         tension: 0.1,
@@ -202,7 +204,7 @@ export class DashboardPageComponent {
     datasets: [
       {
         data: [2, 4, 6, 8, 5, 3, 1],
-        label: 'Bookings',
+        label: this.translationService.instant('dashboard.charts.legend.bookings'),
         backgroundColor: '#8e5ea2',
       },
     ],

--- a/front/src/assets/i18n/de.json
+++ b/front/src/assets/i18n/de.json
@@ -250,6 +250,14 @@
       "operational": "System betriebsbereit",
       "pending": "Ausstehende Benachrichtigungen",
       "available": "Update verfügbar"
+    },
+    "charts": {
+      "dailyAttendance": "Tägliche Anwesenheit",
+      "hourlyBookings": "Buchungen pro Stunde",
+      "legend": {
+        "attendance": "Anwesenheit",
+        "bookings": "Buchungen"
+      }
     }
   },
     "nav": {

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -211,12 +211,22 @@
   "schoolSelection": {
     "title": "Select School",
     "subtitle": "Choose the school you want to work with",
-    "selectSchool": "Select School", 
+    "selectSchool": "Select School",
     "loading": "Loading schools...",
     "noSchools": "You don't have access to any schools",
     "error": "Error loading schools",
     "continue": "Continue",
     "autoRedirecting": "Automatically redirecting..."
+  },
+  "dashboard": {
+    "charts": {
+      "dailyAttendance": "Daily Attendance",
+      "hourlyBookings": "Bookings by Hour",
+      "legend": {
+        "attendance": "Attendance",
+        "bookings": "Bookings"
+      }
+    }
   },
   "nav": {
     "searchPlaceholder": "Search...",

--- a/front/src/assets/i18n/es.json
+++ b/front/src/assets/i18n/es.json
@@ -249,6 +249,14 @@
       "operational": "Sistema operativo",
       "pending": "Notificaciones pendientes",
       "available": "Actualización disponible"
+    },
+    "charts": {
+      "dailyAttendance": "Asistencia diaria",
+      "hourlyBookings": "Reservas por hora",
+      "legend": {
+        "attendance": "Asistencia",
+        "bookings": "Reservas"
+      }
     }
   },
   "nav": {

--- a/front/src/assets/i18n/fr.json
+++ b/front/src/assets/i18n/fr.json
@@ -242,6 +242,14 @@
       "operational": "Sistema operativo",
       "pending": "Notificaciones pendientes",
       "available": "Actualización disponible"
+    },
+    "charts": {
+      "dailyAttendance": "Présence quotidienne",
+      "hourlyBookings": "Réservations par heure",
+      "legend": {
+        "attendance": "Présence",
+        "bookings": "Réservations"
+      }
     }
   },
   "nav": {

--- a/front/src/assets/i18n/it.json
+++ b/front/src/assets/i18n/it.json
@@ -246,12 +246,20 @@
       "manageCourses": "Gestisci corsi",
       "viewReports": "Visualizza report"
     },
-    "status": {
-      "operational": "Sistema operativo",
-      "pending": "Notifiche in sospeso",
-      "available": "Aggiornamento disponibile"
-    }
-  },
+      "status": {
+        "operational": "Sistema operativo",
+        "pending": "Notifiche in sospeso",
+        "available": "Aggiornamento disponibile"
+      },
+      "charts": {
+        "dailyAttendance": "Presenze giornaliere",
+        "hourlyBookings": "Prenotazioni per ora",
+        "legend": {
+          "attendance": "Presenze",
+          "bookings": "Prenotazioni"
+        }
+      }
+    },
     "nav": {
       "searchPlaceholder": "Cerca...",
       "notifications": "Notifiche",


### PR DESCRIPTION
## Summary
- localize dashboard chart headers and legends
- add chart translation keys for all locales

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module './api-http.service' or its corresponding type declarations, and various assertion errors in multiple specs)*

------
https://chatgpt.com/codex/tasks/task_e_68ad643f954c8320b888351830d8a990