### PR TITLE
feat: add token context service for interceptor

### DIFF
--- a/front/src/app/core/interceptors/auth.interceptor.ts
+++ b/front/src/app/core/interceptors/auth.interceptor.ts
@@ -1,14 +1,14 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { AuthV5Service } from '../services/auth-v5.service';
+import { TokenContextService } from '../services/token-context.service';
 
 /**
  * HTTP Interceptor V5 that adds Authorization header and context headers
  * (X-School-ID, X-Season-ID) to authenticated requests
  */
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
-  const authV5 = inject(AuthV5Service);
-  const token = authV5.getToken();
+  const tokenContext = inject(TokenContextService);
+  const token = tokenContext.getToken();
 
   // Skip auth header for certain URLs
   const skipAuthUrls = [
@@ -33,7 +33,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
     };
 
     // Add school/season context headers if available
-    const context = authV5.getAuthContext();
+    const context = tokenContext.getAuthContext();
     if (context) {
       headers['X-School-ID'] = context.school_id.toString();
       headers['X-Season-ID'] = context.season_id.toString();

--- a/front/src/app/core/services/token-context.service.spec.ts
+++ b/front/src/app/core/services/token-context.service.spec.ts
@@ -1,0 +1,54 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { expect } from '@jest/globals';
+
+import { TokenContextService } from './token-context.service';
+import { SessionService } from './session.service';
+import { ContextService } from './context.service';
+
+describe('TokenContextService', () => {
+  let service: TokenContextService;
+  let mockSession: { currentSchool$: BehaviorSubject<any> };
+  let mockContext: {
+    getSelectedSchoolId: jest.Mock<number | null, []>;
+    getSelectedSeasonId: jest.Mock<number | null, []>;
+  };
+
+  beforeEach(() => {
+    mockSession = {
+      currentSchool$: new BehaviorSubject<any>({ id: 1 })
+    };
+    mockContext = {
+      getSelectedSchoolId: jest.fn().mockReturnValue(1),
+      getSelectedSeasonId: jest.fn().mockReturnValue(2)
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        TokenContextService,
+        { provide: SessionService, useValue: mockSession },
+        { provide: ContextService, useValue: mockContext }
+      ]
+    });
+
+    service = TestBed.inject(TokenContextService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('returns token from localStorage', () => {
+    localStorage.setItem('boukii_auth_token', 'abc123');
+    expect(service.getToken()).toBe('abc123');
+  });
+
+  it('returns auth context when ids available', () => {
+    expect(service.getAuthContext()).toEqual({ school_id: 1, season_id: 2 });
+  });
+
+  it('returns null when context incomplete', () => {
+    mockContext.getSelectedSeasonId.mockReturnValue(null);
+    expect(service.getAuthContext()).toBeNull();
+  });
+});

--- a/front/src/app/core/services/token-context.service.ts
+++ b/front/src/app/core/services/token-context.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, inject } from '@angular/core';
+import { SessionService } from './session.service';
+import { ContextService } from './context.service';
+
+/**
+ * Lightweight service to provide authentication token and context IDs
+ * without depending on ApiService.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class TokenContextService {
+  private readonly sessionService = inject(SessionService);
+  private readonly contextService = inject(ContextService);
+
+  /**
+   * Retrieve the stored authentication token.
+   */
+  getToken(): string | null {
+    return localStorage.getItem('boukii_auth_token');
+  }
+
+  /**
+   * Get current school and season IDs from context/session.
+   */
+  getAuthContext(): { school_id: number; season_id: number } | null {
+    let schoolId = this.contextService.getSelectedSchoolId();
+    if (schoolId === null) {
+      const currentSchool = this.sessionService.currentSchool$.getValue();
+      schoolId = currentSchool ? currentSchool.id : null;
+    }
+    const seasonId = this.contextService.getSelectedSeasonId();
+    if (schoolId !== null && seasonId !== null) {
+      return { school_id: schoolId, season_id: seasonId };
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add TokenContextService to supply auth token and context IDs
- refactor auth interceptor to use TokenContextService
- add unit tests for TokenContextService

## Testing
- `npm test` *(fails: multiple test suites failing due to missing providers and assertion typings)*

------
https://chatgpt.com/codex/tasks/task_e_68ad660f10fc8320badcca768d7bd25a