### PR TITLE
feat(clients): add standalone client form

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -59,6 +59,11 @@ export const routes: Routes = [
               import('./features/clients/clients-list.page').then(c => c.ClientsListPageComponent)
           },
           {
+            path: 'new',
+            loadComponent: () =>
+              import('./features/clients/client-form.page').then(c => c.ClientFormPageComponent)
+          },
+          {
             path: ':id',
             loadComponent: () =>
               import('./features/clients/client-detail.page').then(c => c.ClientDetailPageComponent)

--- a/front/src/app/features/clients/client-form.page.html
+++ b/front/src/app/features/clients/client-form.page.html
@@ -1,0 +1,56 @@
+<div class="client-form-page">
+  <h1>{{ 'clients.form.title' | translate }}</h1>
+
+  <form [formGroup]="clientForm" (ngSubmit)="submit()" novalidate>
+    <div class="form-field">
+      <label for="first_name">{{ 'clients.fields.firstName' | translate }}</label>
+      <input
+        id="first_name"
+        type="text"
+        formControlName="first_name"
+        [class.is-invalid]="submitted && clientForm.get('first_name')?.invalid"
+      />
+      <div class="field-error" *ngIf="submitted && clientForm.get('first_name')?.invalid">
+        {{ 'clients.validation.firstNameRequired' | translate }}
+      </div>
+    </div>
+
+    <div class="form-field">
+      <label for="last_name">{{ 'clients.fields.lastName' | translate }}</label>
+      <input
+        id="last_name"
+        type="text"
+        formControlName="last_name"
+        [class.is-invalid]="submitted && clientForm.get('last_name')?.invalid"
+      />
+      <div class="field-error" *ngIf="submitted && clientForm.get('last_name')?.invalid">
+        {{ 'clients.validation.lastNameRequired' | translate }}
+      </div>
+    </div>
+
+    <div class="form-field">
+      <label for="email">{{ 'clients.fields.email' | translate }}</label>
+      <input
+        id="email"
+        type="email"
+        formControlName="email"
+        [class.is-invalid]="submitted && clientForm.get('email')?.invalid"
+      />
+      <div class="field-error" *ngIf="submitted && clientForm.get('email')?.errors?.['required']">
+        {{ 'clients.validation.emailRequired' | translate }}
+      </div>
+      <div class="field-error" *ngIf="submitted && clientForm.get('email')?.errors?.['email']">
+        {{ 'clients.validation.emailInvalid' | translate }}
+      </div>
+    </div>
+
+    <div class="form-field">
+      <label for="phone">{{ 'clients.fields.phone' | translate }}</label>
+      <input id="phone" type="tel" formControlName="phone" />
+    </div>
+
+    <button type="submit" class="btn btn--primary">
+      {{ 'common.save' | translate }}
+    </button>
+  </form>
+</div>

--- a/front/src/app/features/clients/client-form.page.scss
+++ b/front/src/app/features/clients/client-form.page.scss
@@ -1,0 +1,47 @@
+.client-form-page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: var(--space-6, 24px);
+  background: var(--surface);
+  border-radius: var(--radius-8, 8px);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 4px);
+  margin-bottom: var(--space-4, 16px);
+
+  label {
+    font-weight: 500;
+    color: var(--text-1);
+  }
+
+  input {
+    padding: var(--space-2, 8px) var(--space-3, 12px);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-6, 6px);
+    background: var(--surface);
+    color: var(--text-1);
+
+    &:focus {
+      outline: none;
+      border-color: var(--brand-500);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-500) 15%, transparent);
+    }
+
+    &.is-invalid {
+      border-color: var(--error-500, #dc2626);
+
+      &:focus {
+        border-color: var(--error-500, #dc2626);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--error-500, #dc2626) 15%, transparent);
+      }
+    }
+  }
+
+  .field-error {
+    color: var(--error-500, #dc2626);
+    font-size: 0.75rem;
+  }
+}

--- a/front/src/app/features/clients/client-form.page.ts
+++ b/front/src/app/features/clients/client-form.page.ts
@@ -1,0 +1,36 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+
+import { TranslatePipe } from '@shared/pipes/translate.pipe';
+
+@Component({
+  selector: 'app-client-form-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  templateUrl: './client-form.page.html',
+  styleUrls: ['./client-form.page.scss']
+})
+export class ClientFormPageComponent {
+  private readonly fb = inject(FormBuilder);
+
+  submitted = false;
+
+  clientForm = this.fb.group({
+    first_name: ['', Validators.required],
+    last_name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    phone: ['']
+  });
+
+  submit(): void {
+    this.submitted = true;
+    if (this.clientForm.invalid) {
+      this.clientForm.markAllAsTouched();
+      return;
+    }
+
+    // Placeholder for save logic
+    console.log('Client form submitted', this.clientForm.value);
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone client form page with reactive fields and validation
- register `/clients/new` route for lazy loading

## Testing
- `npm run lint`
- `npm test` *(fails: TS errors in existing tests, missing window.matchMedia in spec)*

------
https://chatgpt.com/codex/tasks/task_e_68ad71490be483209969385e73b0d1bf