### PR TITLE
feat(front): add client creation and edit routes

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -61,7 +61,17 @@ export const routes: Routes = [
           {
             path: 'new',
             loadComponent: () =>
-              import('./features/clients/client-form.page').then(c => c.ClientFormPageComponent)
+              import('./features/clients/client-form.page').then(c => c.ClientFormPage)
+          },
+          {
+            path: 'create',
+            loadComponent: () =>
+              import('./features/clients/client-form.page').then(c => c.ClientFormPage)
+          },
+          {
+            path: ':id/edit',
+            loadComponent: () =>
+              import('./features/clients/client-form.page').then(c => c.ClientFormPage)
           },
           {
             path: ':id',

--- a/front/src/app/features/clients/client-form.page.ts
+++ b/front/src/app/features/clients/client-form.page.ts
@@ -11,7 +11,7 @@ import { TranslatePipe } from '@shared/pipes/translate.pipe';
   templateUrl: './client-form.page.html',
   styleUrls: ['./client-form.page.scss']
 })
-export class ClientFormPageComponent {
+export class ClientFormPage {
   private readonly fb = inject(FormBuilder);
 
   submitted = false;


### PR DESCRIPTION
## Summary
- add create and edit routes for clients
- rename client form component to ClientFormPage

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' and numerous Jasmine/Chai assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad751a31c083209bdda3d66e1fec8f