### PR TITLE
refactor: rename client search param

### DIFF
--- a/front/src/app/core/services/clients-v5.service.ts
+++ b/front/src/app/core/services/clients-v5.service.ts
@@ -22,7 +22,7 @@ export interface ClientsResponse {
 
 export interface GetClientsParams {
   school_id: number;
-  q?: string;
+  search?: string;
   sport_id?: number;
   active?: boolean;
   page?: number;

--- a/front/src/app/features/clients/clients-list.page.spec.ts
+++ b/front/src/app/features/clients/clients-list.page.spec.ts
@@ -32,7 +32,7 @@ describe('ClientsListPageComponent', () => {
 
     const activatedRouteStub = {
       snapshot: {
-        queryParamMap: convertToParamMap({ q: 'john', sport_id: '2', active: 'true' })
+        queryParamMap: convertToParamMap({ search: 'john', sport_id: '2', active: 'true' })
       }
     } as ActivatedRoute;
 
@@ -64,10 +64,10 @@ describe('ClientsListPageComponent', () => {
   });
 
   it('should restore filters from query params on init', () => {
-    expect(component.filtersForm.value).toEqual({ q: 'john', sport_id: '2', active: 'true' });
+    expect(component.filtersForm.value).toEqual({ search: 'john', sport_id: '2', active: 'true' });
     expect(clientsService.getClients).toHaveBeenCalledWith({
       school_id: 1,
-      q: 'john',
+      search: 'john',
       sport_id: 2,
       active: true,
       page: 1
@@ -78,15 +78,15 @@ describe('ClientsListPageComponent', () => {
     clientsService.getClients.mockClear();
     router.navigate.mockClear();
 
-    component.filtersForm.setValue({ q: 'jane', sport_id: '3', active: 'false' });
+    component.filtersForm.setValue({ search: 'jane', sport_id: '3', active: 'false' });
 
     expect(router.navigate).toHaveBeenCalledWith([], {
-      queryParams: { q: 'jane', sport_id: '3', active: 'false', page: 1 },
+      queryParams: { search: 'jane', sport_id: '3', active: 'false', page: 1 },
       queryParamsHandling: 'merge'
     });
     expect(clientsService.getClients).toHaveBeenCalledWith({
       school_id: 1,
-      q: 'jane',
+      search: 'jane',
       sport_id: 3,
       active: false,
       page: 1

--- a/front/src/app/features/clients/clients-list.page.ts
+++ b/front/src/app/features/clients/clients-list.page.ts
@@ -29,7 +29,7 @@ export interface ClientListItem {
       </div>
 
       <form [formGroup]="filtersForm" class="filters">
-        <input type="text" formControlName="q" placeholder="Search" />
+        <input type="text" formControlName="search" placeholder="Search" />
         <input type="number" formControlName="sport_id" placeholder="Sport ID" />
         <select formControlName="active">
           <option value="">All</option>
@@ -186,7 +186,7 @@ export class ClientsListPageComponent implements OnInit {
   private readonly contextService = inject(ContextService);
 
   filtersForm = this.fb.group({
-    q: [''],
+    search: [''],
     sport_id: [''],
     active: [''],
   });
@@ -202,7 +202,7 @@ export class ClientsListPageComponent implements OnInit {
     const params = this.route.snapshot.queryParamMap;
     this.filtersForm.patchValue(
       {
-        q: params.get('q') || '',
+        search: params.get('search') || '',
         sport_id: params.get('sport_id') || '',
         active: params.get('active') || '',
       },
@@ -248,7 +248,7 @@ export class ClientsListPageComponent implements OnInit {
   private updateQueryParams(): void {
     const value = this.filtersForm.value;
     const queryParams: any = { page: this.currentPage };
-    if (value.q) queryParams.q = value.q;
+    if (value.search) queryParams.search = value.search;
     if (value.sport_id) queryParams.sport_id = value.sport_id;
     if (value.active) queryParams.active = value.active;
     this.router.navigate([], {
@@ -261,7 +261,7 @@ export class ClientsListPageComponent implements OnInit {
     const value = this.filtersForm.value;
     const params: GetClientsParams = {
       school_id: this.contextService.schoolId() || 0,
-      q: value.q || undefined,
+      search: value.search || undefined,
       sport_id: value.sport_id ? Number(value.sport_id) : undefined,
       active: value.active !== '' ? value.active === 'true' : undefined,
       page: this.currentPage,


### PR DESCRIPTION
## Summary
- rename client list query param `q` to `search`
- update clients list component to use `search`
- adjust tests for new search param

## Testing
- `npm run lint`
- `npm test` *(fails: cannot find module './api-http.service', Missing provider _HttpClient, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad77444038832094db4a07fd01cb8d