### PR TITLE
test: add specs for settings components

### DIFF
--- a/front/src/app/features/settings/school/school-settings.component.spec.ts
+++ b/front/src/app/features/settings/school/school-settings.component.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { SchoolSettingsComponent } from './school-settings.component';
+import { SettingsService } from '../settings.service';
+import { TranslatePipe } from '@shared/pipes/translate.pipe';
+import { Pipe, PipeTransform } from '@angular/core';
+import { of } from 'rxjs';
+
+@Pipe({ name: 'translate' })
+class TranslatePipeStub implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
+
+describe('SchoolSettingsComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SchoolSettingsComponent],
+      providers: [
+        { provide: SettingsService, useValue: { getMockSchool: () => of({ name: '', email: '', contact_phone: '', address: '', logo: '' }) } },
+        { provide: TranslatePipe, useClass: TranslatePipeStub },
+      ],
+    }).compileComponents();
+  });
+
+  it('should create and render title and save button', () => {
+    const fixture = TestBed.createComponent(SchoolSettingsComponent);
+    fixture.detectChanges();
+    const h2: HTMLElement = fixture.nativeElement.querySelector('h2');
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(h2.textContent).toContain('settings.school.title');
+    expect(button.textContent).toContain('common.save');
+  });
+});

--- a/front/src/app/features/settings/seasons/season-form.component.spec.ts
+++ b/front/src/app/features/settings/seasons/season-form.component.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+import { SeasonFormComponent } from './season-form.component';
+
+describe('SeasonFormComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SeasonFormComponent],
+    }).compileComponents();
+  });
+
+  it('should create and render title and save button', () => {
+    const fixture = TestBed.createComponent(SeasonFormComponent);
+    fixture.detectChanges();
+    const h2: HTMLElement = fixture.nativeElement.querySelector('h2');
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button[type="submit"]');
+    expect(h2.textContent).toContain('Nueva Temporada');
+    expect(button.textContent).toContain('Guardar');
+  });
+});

--- a/front/src/app/features/settings/seasons/seasons.component.spec.ts
+++ b/front/src/app/features/settings/seasons/seasons.component.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { SeasonsComponent } from './seasons.component';
+import { SettingsService } from '../settings.service';
+import { of } from 'rxjs';
+
+describe('SeasonsComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SeasonsComponent],
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: {
+            getMockSeasons: () => of([]),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should create and render title and new button', () => {
+    const fixture = TestBed.createComponent(SeasonsComponent);
+    fixture.detectChanges();
+    const h2: HTMLElement = fixture.nativeElement.querySelector('h2');
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(h2.textContent).toContain('Temporadas');
+    expect(button.textContent).toContain('Nueva Temporada');
+  });
+});

--- a/front/src/app/features/settings/sports-degrees/sports-degrees.component.spec.ts
+++ b/front/src/app/features/settings/sports-degrees/sports-degrees.component.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { SportsDegreesComponent } from './sports-degrees.component';
+import { SettingsService } from '../settings.service';
+import { of } from 'rxjs';
+
+describe('SportsDegreesComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SportsDegreesComponent],
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: {
+            getAllSports: () => of([]),
+            getSelectedSportsIds: () => of([]),
+            getMockDegrees: () => of([]),
+            saveSelectedSports: jest.fn(),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should create and render titles and button', () => {
+    const fixture = TestBed.createComponent(SportsDegreesComponent);
+    fixture.detectChanges();
+    const h2: HTMLElement = fixture.nativeElement.querySelector('h2');
+    const h3: HTMLElement = fixture.nativeElement.querySelector('h3');
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(h2.textContent).toContain('Sports');
+    expect(h3.textContent).toContain('Available Degrees');
+    expect(button.textContent).toContain('Guardar');
+  });
+});

--- a/front/src/app/features/settings/station/station-settings.component.spec.ts
+++ b/front/src/app/features/settings/station/station-settings.component.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { StationSettingsComponent } from './station-settings.component';
+import { SettingsService } from '../settings.service';
+import { of } from 'rxjs';
+
+describe('StationSettingsComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StationSettingsComponent],
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: {
+            getMockStations: () => of({ stations: [], selectedStationIds: [] }),
+            saveSelectedStations: jest.fn(),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should create and render title and button', () => {
+    const fixture = TestBed.createComponent(StationSettingsComponent);
+    fixture.detectChanges();
+    const h2: HTMLElement = fixture.nativeElement.querySelector('h2');
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(h2.textContent).toContain('Estaciones');
+    expect(button.textContent).toContain('Guardar');
+  });
+});


### PR DESCRIPTION
## Summary
- add basic Jest specs for station, seasons, season form, sports degrees and school settings components

## Testing
- `npm install`
- `npm test` *(fails: TS errors in existing specs)*

------
https://chatgpt.com/codex/tasks/task_e_68ad77c44df483209b47c823e7f933af