### PR TITLE
Add v5 client controller and routes

### DIFF
--- a/app/V5/Modules/Client/Controllers/ClientController.php
+++ b/app/V5/Modules/Client/Controllers/ClientController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\V5\Modules\Client\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\V5\Modules\Client\Services\ClientService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ClientController extends Controller
+{
+    public function __construct(private ClientService $service)
+    {
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $schoolId = (int) $request->get('school_id');
+        $filters = $request->except(['page', 'limit', 'school_id']);
+        $page = (int) $request->get('page', 1);
+        $limit = (int) $request->get('limit', 20);
+        $clients = $this->service->getClients($schoolId, $filters, $page, $limit);
+
+        return response()->json($clients->toArray());
+    }
+
+    public function show(int $clientId, Request $request): JsonResponse
+    {
+        $schoolId = (int) $request->get('school_id');
+        $client = $this->service->findClientById($clientId, $schoolId);
+
+        return response()->json(['data' => $client->toArray()]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $schoolId = (int) $request->get('school_id');
+        $client = $this->service->createClient($request->all(), $schoolId);
+
+        return response()->json(['data' => $client->toArray()], 201);
+    }
+
+    public function update(int $clientId, Request $request): JsonResponse
+    {
+        $schoolId = (int) $request->get('school_id');
+        $client = $this->service->updateClient($clientId, $request->all(), $schoolId);
+
+        return response()->json(['data' => $client->toArray()]);
+    }
+
+    public function destroy(int $clientId, Request $request): JsonResponse
+    {
+        $schoolId = (int) $request->get('school_id');
+        $deleted = $this->service->deleteClient($clientId, $schoolId);
+
+        return response()->json(['deleted' => $deleted]);
+    }
+
+    public function storeUtilizador(int $clientId, Request $request): JsonResponse
+    {
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    public function updateUtilizador(int $clientId, int $utilizadorId, Request $request): JsonResponse
+    {
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    public function destroyUtilizador(int $clientId, int $utilizadorId): JsonResponse
+    {
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    public function storeSport(int $clientId, Request $request): JsonResponse
+    {
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    public function updateSport(int $clientId, int $sportId, Request $request): JsonResponse
+    {
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    public function destroySport(int $clientId, int $sportId): JsonResponse
+    {
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,6 +45,7 @@ Route::prefix('v5')
         require base_path('routes/api_v5/auth.php');
         require base_path('routes/api_v5/schools.php');
         require base_path('routes/api_v5/seasons.php');
+        require base_path('routes/api_v5/clients.php');
         require base_path('routes/api_v5/logs.php');
         require base_path('routes/api_v5/me.php');
         require base_path('routes/api_v5/context.php');

--- a/routes/api_v5/clients.php
+++ b/routes/api_v5/clients.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\V5\Modules\Client\Controllers\ClientController;
+
+Route::middleware('auth:sanctum')
+    ->prefix('clients')
+    ->name('v5.clients.')
+    ->group(function () {
+        Route::get('/', [ClientController::class, 'index'])->name('index');
+        Route::post('/', [ClientController::class, 'store'])->name('store');
+        Route::get('/{client}', [ClientController::class, 'show'])->name('show');
+        Route::patch('/{client}', [ClientController::class, 'update'])->name('update');
+        Route::delete('/{client}', [ClientController::class, 'destroy'])->name('destroy');
+
+        Route::post('/{client}/utilizadores', [ClientController::class, 'storeUtilizador'])->name('utilizadores.store');
+        Route::patch('/{client}/utilizadores/{utilizador}', [ClientController::class, 'updateUtilizador'])->name('utilizadores.update');
+        Route::delete('/{client}/utilizadores/{utilizador}', [ClientController::class, 'destroyUtilizador'])->name('utilizadores.destroy');
+
+        Route::post('/{client}/sports', [ClientController::class, 'storeSport'])->name('sports.store');
+        Route::patch('/{client}/sports/{sport}', [ClientController::class, 'updateSport'])->name('sports.update');
+        Route::delete('/{client}/sports/{sport}', [ClientController::class, 'destroySport'])->name('sports.destroy');
+    });


### PR DESCRIPTION
## Summary
- Add ClientController with CRUD and stubbed nested handlers for utilizadores and sports
- Define v5 client routes and register under API v5 prefix

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: syntax error in tests/Feature/SeasonApiTest.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7a4ffe8083209e01cc4694d7f826