### PR TITLE
feat: add scheduling calendar module and route

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -96,6 +96,11 @@ export const routes: Routes = [
         loadChildren: () => import('./features/admin/permissions/permissions.routes').then(m => m.permissionsRoutes)
       },
       {
+        path: 'scheduling',
+        canActivate: [requireCompleteAuthGuard],
+        loadChildren: () => import('./features/scheduling/scheduling.module').then(m => m.SchedulingModule)
+      },
+      {
         path: 'settings',
         loadChildren: () => import('./features/settings').then(m => m.routes)
       }

--- a/front/src/app/features/scheduling/scheduling-calendar.component.ts
+++ b/front/src/app/features/scheduling/scheduling-calendar.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-scheduling-calendar',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="page" data-cy="scheduling-calendar">
+      <div class="page-header">
+        <h1>Scheduling Calendar</h1>
+      </div>
+      <div class="page-content">
+        <p>Scheduling calendar works!</p>
+      </div>
+    </div>
+  `
+})
+export class SchedulingCalendarComponent {}

--- a/front/src/app/features/scheduling/scheduling.module.ts
+++ b/front/src/app/features/scheduling/scheduling.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SchedulingCalendarComponent } from './scheduling-calendar.component';
+
+const routes: Routes = [
+  { path: '', component: SchedulingCalendarComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+})
+export class SchedulingModule {}


### PR DESCRIPTION
## Summary
- add scheduling calendar component and module
- register /scheduling route

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` *(fails: Cannot find module './api-http.service', missing providers, etc.)*
- `npm run build` *(fails: Property 'checked' does not exist on type 'EventTarget')*

------
https://chatgpt.com/codex/tasks/task_e_68ad7e3c683c8320b33c80d6a209bccc