### PR TITLE
fix: cast checkbox event target

### DIFF
--- a/front/src/app/features/settings/sports-degrees/sports-degrees.component.ts
+++ b/front/src/app/features/settings/sports-degrees/sports-degrees.component.ts
@@ -14,7 +14,7 @@ import { SportsDegree } from '../data/sports-degrees';
         <input
           type="checkbox"
           [checked]="selectedSportsIds.includes(sport.id)"
-          (change)="onToggleSport(sport.id, $event.target.checked)"
+          (change)="onToggleSport(sport.id, ($event.target as HTMLInputElement).checked)"
         />
         {{ sport.name }}
       </label>

--- a/front/src/app/features/settings/station/station-settings.component.ts
+++ b/front/src/app/features/settings/station/station-settings.component.ts
@@ -14,7 +14,7 @@ import { Station } from '../data/stations';
         <input
           type="checkbox"
           [checked]="selectedStationIds.includes(station.id)"
-          (change)="onToggleStation(station.id, $event.target.checked)"
+          (change)="onToggleStation(station.id, ($event.target as HTMLInputElement).checked)"
         />
         {{ station.name }}
       </label>


### PR DESCRIPTION
## Summary
- cast event target to HTMLInputElement for sports and station checkboxes

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test` *(fails: Property 'toContain' does not exist on type 'Assertion', NullInjectorError: No provider for _HttpClient, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad911349e4832082cc92100264b5ae