### PR TITLE
feat: add configurable scheduling calendar grid

### DIFF
--- a/front/src/app/features/scheduling/scheduling-calendar.component.ts
+++ b/front/src/app/features/scheduling/scheduling-calendar.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -11,9 +11,52 @@ import { CommonModule } from '@angular/common';
         <h1>Scheduling Calendar</h1>
       </div>
       <div class="page-content">
-        <p>Scheduling calendar works!</p>
+        <div class="calendar">
+          <div class="day-header" *ngFor="let day of days">{{ day }}</div>
+          <ng-container *ngFor="let hour of hours">
+            <div class="time-slot" *ngFor="let day of days"></div>
+          </ng-container>
+        </div>
       </div>
     </div>
-  `
+  `,
+  styles: [
+    `
+      .calendar {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        background: var(--surface);
+        border: 1px solid var(--border);
+      }
+
+      .day-header {
+        padding: var(--space-2);
+        text-align: center;
+        font-weight: 500;
+        background: var(--surface-2);
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+      }
+
+      .time-slot {
+        min-height: 40px;
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+      }
+
+      .calendar > :nth-child(7n) {
+        border-right: none;
+      }
+    `,
+  ],
 })
-export class SchedulingCalendarComponent {}
+export class SchedulingCalendarComponent {
+  @Input() startHour = 7;
+  @Input() endHour = 21;
+
+  days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+  get hours(): number[] {
+    return Array.from({ length: this.endHour - this.startHour }, (_, i) => this.startHour + i);
+  }
+}


### PR DESCRIPTION
## Summary
- display 7xN scheduling calendar grid for Monday through Sunday
- allow configurable start and end hours
- style grid with neutral background and subtle borders using design tokens

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' and multiple TypeScript assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad91284bf48320900c099c9797bfb1