### PR TITLE
feat(front): add renting feature and route

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -101,6 +101,12 @@ export const routes: Routes = [
         loadChildren: () => import('./features/scheduling/scheduling.module').then(m => m.SchedulingModule)
       },
       {
+        path: 'renting',
+        loadComponent: () =>
+          import('./features/renting/renting.component').then(c => c.RentingComponent),
+        canActivate: [requireCompleteAuthGuard]
+      },
+      {
         path: 'settings',
         loadChildren: () => import('./features/settings').then(m => m.routes)
       }

--- a/front/src/app/features/renting/renting.component.scss
+++ b/front/src/app/features/renting/renting.component.scss
@@ -1,0 +1,26 @@
+.page {
+  padding: var(--space-4);
+}
+
+.filter {
+  margin-bottom: var(--space-4);
+}
+
+.item-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+
+.reserva-form {
+  margin-top: var(--space-3);
+}
+
+.reserva-form .row {
+  display: flex;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}

--- a/front/src/app/features/renting/renting.component.ts
+++ b/front/src/app/features/renting/renting.component.ts
@@ -1,0 +1,84 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+interface RentingItem {
+  id: number;
+  nombre: string;
+  tipo: 'skis' | 'boards' | 'helmets';
+  disponible: boolean;
+  precio: number;
+}
+
+@Component({
+  selector: 'app-renting',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  styleUrl: './renting.component.scss',
+  template: `
+    <div class="page">
+      <div class="page-header">
+        <h1>Renting</h1>
+        <div class="subtitle">Gestión de material</div>
+      </div>
+
+      <div class="filter">
+        <label for="tipo-select" class="visually-hidden">Filtrar por tipo</label>
+        <select id="tipo-select" [(ngModel)]="filtroTipo">
+          <option value="">Todos</option>
+          <option value="skis">Skis</option>
+          <option value="boards">Boards</option>
+          <option value="helmets">Helmets</option>
+        </select>
+      </div>
+
+      <div class="stack">
+        <div class="card" *ngFor="let item of itemsFiltrados()">
+          <div class="item-header">
+            <strong>{{ item.nombre }}</strong>
+            <span class="chip" [ngClass]="item.disponible ? 'chip--green' : 'chip--red'">
+              {{ item.disponible ? 'Disponible' : 'No disponible' }}
+            </span>
+            <span class="chip chip--blue">€{{ item.precio }}</span>
+            <button class="btn btn--primary" (click)="abrirFormulario(item.id)">
+              Reservar
+            </button>
+          </div>
+
+          <form *ngIf="item.id === reservaAbierta" class="reserva-form">
+            <div class="row gap">
+              <input type="date" name="fecha{{ item.id }}" [(ngModel)]="reserva.fecha" />
+              <input type="time" name="hora{{ item.id }}" [(ngModel)]="reserva.hora" />
+            </div>
+            <label>
+              <input type="checkbox" name="curso{{ item.id }}" [(ngModel)]="reserva.adjuntar" />
+              Adjuntar a curso
+            </label>
+          </form>
+        </div>
+      </div>
+    </div>
+  `
+})
+export class RentingComponent {
+  filtroTipo = '';
+  reservaAbierta: number | null = null;
+  reserva = { fecha: '', hora: '', adjuntar: false };
+
+  items: RentingItem[] = [
+    { id: 1, nombre: 'Ski Atomic', tipo: 'skis', disponible: true, precio: 25 },
+    { id: 2, nombre: 'Snowboard Burton', tipo: 'boards', disponible: false, precio: 30 },
+    { id: 3, nombre: 'Casco Smith', tipo: 'helmets', disponible: true, precio: 10 },
+    { id: 4, nombre: 'Ski Rossignol', tipo: 'skis', disponible: true, precio: 22 },
+    { id: 5, nombre: 'Casco Giro', tipo: 'helmets', disponible: false, precio: 12 },
+  ];
+
+  itemsFiltrados() {
+    return this.filtroTipo ? this.items.filter(i => i.tipo === this.filtroTipo) : this.items;
+  }
+
+  abrirFormulario(id: number) {
+    this.reservaAbierta = this.reservaAbierta === id ? null : id;
+  }
+}
+

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -380,7 +380,13 @@ interface Notification {
           </a>
 
           <!-- Material -->
-          <a href="#" class="nav-item item" role="menuitem" [title]="ui.sidebarCollapsed() ? translationService.instant('nav.material') : null">
+          <a
+            routerLink="/renting"
+            routerLinkActive="active"
+            class="nav-item item"
+            role="menuitem"
+            [title]="ui.sidebarCollapsed() ? translationService.instant('nav.material') : null"
+          >
             <div class="nav-icon">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>


### PR DESCRIPTION
## Summary
- add standalone renting component with filter and inline reservation form
- wire renting route and update sidebar navigation

## Testing
- `npm run lint`
- `npm test` *(fails: 16 failed, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ada2c40a8c8320986afc6c3215d532