### PR TITLE
feat(scheduling): add session modals

### DIFF
--- a/front/src/app/features/scheduling/components/create-session-modal.component.ts
+++ b/front/src/app/features/scheduling/components/create-session-modal.component.ts
@@ -1,0 +1,91 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SchedulingSession } from './session-detail-modal.component';
+
+@Component({
+  selector: 'app-create-session-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="modal-overlay" (click)="cancel.emit()">
+      <div class="modal-container" (click)="$event.stopPropagation()">
+        <h2>Create Session</h2>
+        <form (ngSubmit)="onSubmit()" #form="ngForm">
+          <label>
+            Course
+            <input name="course" [(ngModel)]="session.course" required />
+          </label>
+          <label>
+            Instructor
+            <input name="instructor" [(ngModel)]="session.instructor" required />
+          </label>
+          <label>
+            Start Time
+            <input name="startTime" type="time" [(ngModel)]="session.startTime" required />
+          </label>
+          <label>
+            End Time
+            <input name="endTime" type="time" [(ngModel)]="session.endTime" required />
+          </label>
+          <div class="actions">
+            <button type="button" (click)="cancel.emit()">Cancel</button>
+            <button type="submit" [disabled]="form.invalid">Create</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .modal-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .modal-container {
+        background: var(--surface);
+        padding: var(--space-4);
+        border-radius: var(--radius-2);
+        width: 320px;
+      }
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--space-2);
+        margin-top: var(--space-4);
+      }
+    `,
+  ],
+})
+export class CreateSessionModalComponent implements OnChanges {
+  @Input() day = '';
+  @Input() startTime = '';
+  @Output() create = new EventEmitter<SchedulingSession>();
+  @Output() cancel = new EventEmitter<void>();
+
+  session: SchedulingSession = {
+    course: '',
+    instructor: '',
+    startTime: this.startTime,
+    endTime: '',
+  };
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['startTime']) {
+      this.session.startTime = this.startTime;
+    }
+  }
+
+  onSubmit(): void {
+    this.create.emit({ ...this.session });
+  }
+}

--- a/front/src/app/features/scheduling/components/session-block.component.ts
+++ b/front/src/app/features/scheduling/components/session-block.component.ts
@@ -24,6 +24,7 @@ import { SessionValidationService } from '../services/session-validation.service
       [@dragAnimation]="dragging ? 'dragging' : 'dropped'"
       (cdkDragStarted)="dragging = true"
       (cdkDragEnded)="onDrop($event)"
+      (click)="sessionClick.emit()"
     >
       <img class="avatar" [src]="instructorAvatar" alt="Instructor" />
       <div class="info">
@@ -94,6 +95,7 @@ export class SessionBlockComponent {
     endTime: string;
     status: 'confirmed' | 'conflict';
   }>();
+  @Output() sessionClick = new EventEmitter<void>();
 
   dragging = false;
 

--- a/front/src/app/features/scheduling/components/session-detail-modal.component.ts
+++ b/front/src/app/features/scheduling/components/session-detail-modal.component.ts
@@ -1,0 +1,64 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+export interface SchedulingSession {
+  course: string;
+  instructor: string;
+  startTime: string;
+  endTime: string;
+}
+
+@Component({
+  selector: 'app-session-detail-modal',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="modal-overlay" (click)="close.emit()">
+      <div class="modal-container" (click)="$event.stopPropagation()">
+        <h2>Session Details</h2>
+        <div class="details">
+          <p><strong>Course:</strong> {{ session?.course }}</p>
+          <p><strong>Instructor:</strong> {{ session?.instructor }}</p>
+          <p><strong>Time:</strong> {{ session?.startTime }} - {{ session?.endTime }}</p>
+        </div>
+        <div class="actions">
+          <button type="button" (click)="edit.emit(session)">Edit</button>
+          <button type="button" (click)="reschedule.emit(session)">Reschedule</button>
+          <button type="button" (click)="remove.emit(session)">Delete</button>
+          <button type="button" (click)="close.emit()">Close</button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .modal-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .modal-container {
+        background: var(--surface);
+        padding: var(--space-4);
+        border-radius: var(--radius-2);
+        width: 320px;
+      }
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--space-2);
+        margin-top: var(--space-4);
+      }
+    `,
+  ],
+})
+export class SessionDetailModalComponent {
+  @Input() session: SchedulingSession | null = null;
+  @Output() edit = new EventEmitter<SchedulingSession | null>();
+  @Output() reschedule = new EventEmitter<SchedulingSession | null>();
+  @Output() remove = new EventEmitter<SchedulingSession | null>();
+  @Output() close = new EventEmitter<void>();
+}

--- a/front/src/app/features/scheduling/scheduling-calendar.component.ts
+++ b/front/src/app/features/scheduling/scheduling-calendar.component.ts
@@ -1,10 +1,13 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { SessionBlockComponent } from './components/session-block.component';
+import { SessionDetailModalComponent, SchedulingSession } from './components/session-detail-modal.component';
+import { CreateSessionModalComponent } from './components/create-session-modal.component';
 
 @Component({
   selector: 'app-scheduling-calendar',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, SessionBlockComponent, SessionDetailModalComponent, CreateSessionModalComponent],
   template: `
     <div class="page" data-cy="scheduling-calendar">
       <div class="page-header">
@@ -14,11 +17,37 @@ import { CommonModule } from '@angular/common';
         <div class="calendar">
           <div class="day-header" *ngFor="let day of days">{{ day }}</div>
           <ng-container *ngFor="let hour of hours">
-            <div class="time-slot" *ngFor="let day of days"></div>
+            <div
+              class="time-slot"
+              *ngFor="let day of days"
+              (dblclick)="onEmptySlotDblClick(day, hour)"
+            >
+              <ng-container *ngIf="getSession(day, hour) as session">
+                <app-session-block
+                  [courseName]="session.course"
+                  [instructorAvatar]="session.instructorAvatar"
+                  [startTime]="session.startTime"
+                  [endTime]="session.endTime"
+                  [status]="session.status"
+                  (sessionClick)="openSessionDetail(session)"
+                ></app-session-block>
+              </ng-container>
+            </div>
           </ng-container>
         </div>
       </div>
     </div>
+    <app-session-detail-modal
+      *ngIf="selectedSession"
+      [session]="selectedSession"
+      (close)="selectedSession = null"
+    ></app-session-detail-modal>
+    <app-create-session-modal
+      *ngIf="creatingSlot"
+      [startTime]="creatingSlot.startTime"
+      (create)="addSession($event)"
+      (cancel)="creatingSlot = null"
+    ></app-create-session-modal>
   `,
   styles: [
     `
@@ -56,7 +85,58 @@ export class SchedulingCalendarComponent {
 
   days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
+  sessions: (SchedulingSession & {
+    day: string;
+    instructorAvatar: string;
+    status: 'confirmed' | 'pending' | 'conflict';
+  })[] = [
+    {
+      course: 'Math 101',
+      instructor: 'John Doe',
+      startTime: '09:00',
+      endTime: '10:00',
+      day: 'Monday',
+      instructorAvatar: 'https://via.placeholder.com/24',
+      status: 'confirmed',
+    },
+  ];
+
+  selectedSession: (SchedulingSession & {
+    day: string;
+    instructorAvatar: string;
+    status: 'confirmed' | 'pending' | 'conflict';
+  }) | null = null;
+
+  creatingSlot: { day: string; startTime: string } | null = null;
+
   get hours(): number[] {
     return Array.from({ length: this.endHour - this.startHour }, (_, i) => this.startHour + i);
+  }
+
+  getSession(day: string, hour: number) {
+    return this.sessions.find(
+      (s) =>
+        s.day === day && parseInt(s.startTime.split(':')[0], 10) === hour,
+    );
+  }
+
+  openSessionDetail(session: any) {
+    this.selectedSession = session;
+  }
+
+  onEmptySlotDblClick(day: string, hour: number) {
+    this.creatingSlot = { day, startTime: `${hour.toString().padStart(2, '0')}:00` };
+  }
+
+  addSession(session: SchedulingSession) {
+    if (this.creatingSlot) {
+      this.sessions.push({
+        ...session,
+        day: this.creatingSlot.day,
+        instructorAvatar: '',
+        status: 'pending',
+      });
+      this.creatingSlot = null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add session click handling and modal triggers in calendar
- introduce SessionDetailModal and CreateSessionModal components

## Testing
- `npm test` *(fails: missing TestBed providers and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68adabff40308320a928ace3812a062f