### PR TITLE
feat(front): add reservations feature with mock data and filtering

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -101,6 +101,11 @@ export const routes: Routes = [
         loadChildren: () => import('./features/scheduling/scheduling.module').then(m => m.SchedulingModule)
       },
       {
+        path: 'reservations',
+        canActivate: [requireCompleteAuthGuard],
+        loadChildren: () => import('./features/reservations/reservations.module').then(m => m.ReservationsModule)
+      },
+      {
         path: 'renting',
         loadComponent: () =>
           import('./features/renting/renting.component').then(c => c.RentingComponent),

--- a/front/src/app/features/reservations/README.md
+++ b/front/src/app/features/reservations/README.md
@@ -1,0 +1,15 @@
+# Reservations Feature
+
+This module showcases a reservations list with mock data.
+
+## Development
+- Route is registered under `/reservations`.
+- `ReservationsMockService` provides sample reservations.
+- Filters allow combining reservation type, course, payment and search.
+- Clicking a row opens `ReservationDetailComponent` inside a material dialog.
+
+Run unit tests with:
+```bash
+npm test src/app/features/reservations/reservations-list/reservations-list.component.spec.ts
+```
+

--- a/front/src/app/features/reservations/reservation-detail.component.ts
+++ b/front/src/app/features/reservations/reservation-detail.component.ts
@@ -1,0 +1,32 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { Reservation } from './reservations-mock.service';
+
+@Component({
+  selector: 'app-reservation-detail',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>Reservation {{ data.id }}</h2>
+    <mat-dialog-content class="dialog-content">
+      <p><strong>Client:</strong> {{ data.client }}</p>
+      <p><strong>Course:</strong> {{ data.course }}</p>
+      <p><strong>Date:</strong> {{ data.date }}</p>
+      <p><strong>Status:</strong> {{ data.status }}</p>
+      <p><strong>Paid:</strong> {{ data.paid ? 'Yes' : 'No' }}</p>
+      <p><strong>Type:</strong> {{ data.type }}</p>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Close</button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `.dialog-content { color: var(--text-1); }`
+  ]
+})
+export class ReservationDetailComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: Reservation) {}
+}
+

--- a/front/src/app/features/reservations/reservations-list/reservations-list.component.html
+++ b/front/src/app/features/reservations/reservations-list/reservations-list.component.html
@@ -1,0 +1,77 @@
+<div class="filters">
+  <mat-form-field>
+    <mat-label>Reservation Type</mat-label>
+    <mat-select [(ngModel)]="typeFilter">
+      <mat-option value="">All</mat-option>
+      <mat-option value="individual">Individual</mat-option>
+      <mat-option value="multiple">Multiple</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field>
+    <mat-label>Course</mat-label>
+    <mat-select [(ngModel)]="courseFilter">
+      <mat-option value="">All</mat-option>
+      <mat-option *ngFor="let c of courses" [value]="c">{{ c }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field>
+    <mat-label>Paid</mat-label>
+    <mat-select [(ngModel)]="paidFilter">
+      <mat-option value="">All</mat-option>
+      <mat-option value="paid">Paid</mat-option>
+      <mat-option value="unpaid">Unpaid</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field class="search-field">
+    <mat-label>Search</mat-label>
+    <input matInput placeholder="Client or course" [(ngModel)]="search" />
+  </mat-form-field>
+</div>
+
+<mat-tab-group (selectedIndexChange)="onTabChange($event)">
+  <mat-tab label="Active"></mat-tab>
+  <mat-tab label="Completed"></mat-tab>
+  <mat-tab label="Cancelled"></mat-tab>
+  <mat-tab label="All"></mat-tab>
+</mat-tab-group>
+
+<table mat-table [dataSource]="filteredReservations" class="reservations-table">
+  <ng-container matColumnDef="id">
+    <th mat-header-cell *matHeaderCellDef> Booking ID </th>
+    <td mat-cell *matCellDef="let r"> {{ r.id }} </td>
+  </ng-container>
+
+  <ng-container matColumnDef="client">
+    <th mat-header-cell *matHeaderCellDef> Client </th>
+    <td mat-cell *matCellDef="let r"> {{ r.client }} </td>
+  </ng-container>
+
+  <ng-container matColumnDef="course">
+    <th mat-header-cell *matHeaderCellDef> Course </th>
+    <td mat-cell *matCellDef="let r"> {{ r.course }} </td>
+  </ng-container>
+
+  <ng-container matColumnDef="date">
+    <th mat-header-cell *matHeaderCellDef> Date </th>
+    <td mat-cell *matCellDef="let r"> {{ r.date }} </td>
+  </ng-container>
+
+  <ng-container matColumnDef="status">
+    <th mat-header-cell *matHeaderCellDef> Status </th>
+    <td mat-cell *matCellDef="let r"> {{ r.status }} </td>
+  </ng-container>
+
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef> Actions </th>
+    <td mat-cell *matCellDef="let r">
+      <button mat-button (click)="openDetail(r); $event.stopPropagation()">View</button>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openDetail(row)"></tr>
+</table>
+

--- a/front/src/app/features/reservations/reservations-list/reservations-list.component.scss
+++ b/front/src/app/features/reservations/reservations-list/reservations-list.component.scss
@@ -1,0 +1,31 @@
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.filters mat-form-field {
+  width: 200px;
+}
+
+.search-field {
+  flex: 1;
+  min-width: 200px;
+}
+
+.reservations-table {
+  width: 100%;
+  background: var(--surface);
+  color: var(--text-1);
+}
+
+.reservations-table th {
+  background: var(--surface-2);
+  color: var(--text-2);
+}
+
+.reservations-table tr {
+  cursor: pointer;
+}
+

--- a/front/src/app/features/reservations/reservations-list/reservations-list.component.spec.ts
+++ b/front/src/app/features/reservations/reservations-list/reservations-list.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { expect } from '@jest/globals';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ReservationsListComponent } from './reservations-list.component';
+import { ReservationsMockService } from '../reservations-mock.service';
+
+describe('ReservationsListComponent', () => {
+  let component: ReservationsListComponent;
+  let fixture: ComponentFixture<ReservationsListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReservationsListComponent, NoopAnimationsModule],
+      providers: [ReservationsMockService]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReservationsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should filter by type and payment', () => {
+    component.typeFilter = 'individual';
+    component.paidFilter = 'paid';
+    expect(component.filteredReservations.every(r => r.type === 'individual' && r.paid)).toBe(true);
+  });
+
+  it('should search by client name', () => {
+    component.search = 'alice';
+    expect(component.filteredReservations.every(r => r.client.toLowerCase().includes('alice') || r.course.toLowerCase().includes('alice'))).toBe(true);
+  });
+});
+

--- a/front/src/app/features/reservations/reservations-list/reservations-list.component.ts
+++ b/front/src/app/features/reservations/reservations-list/reservations-list.component.ts
@@ -1,0 +1,69 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Reservation, ReservationsMockService, ReservationStatus } from '../reservations-mock.service';
+import { ReservationDetailComponent } from '../reservation-detail.component';
+
+@Component({
+  selector: 'app-reservations-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatTabsModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatInputModule,
+    MatButtonModule,
+    MatDialogModule
+  ],
+  templateUrl: './reservations-list.component.html',
+  styleUrl: './reservations-list.component.scss'
+})
+export class ReservationsListComponent {
+  reservations: Reservation[] = [];
+  courses: string[] = [];
+
+  currentTab: ReservationStatus | 'all' = 'active';
+  typeFilter = '';
+  courseFilter = '';
+  paidFilter = '';
+  search = '';
+
+  displayedColumns = ['id', 'client', 'course', 'date', 'status', 'actions'];
+
+  constructor(private service: ReservationsMockService, private dialog: MatDialog) {
+    this.reservations = this.service.getReservations();
+    this.courses = Array.from(new Set(this.reservations.map(r => r.course)));
+  }
+
+  get filteredReservations(): Reservation[] {
+    return this.reservations.filter(r => {
+      const matchesStatus = this.currentTab === 'all' || r.status === this.currentTab;
+      const matchesType = !this.typeFilter || r.type === this.typeFilter;
+      const matchesCourse = !this.courseFilter || r.course === this.courseFilter;
+      const matchesPaid = !this.paidFilter || r.paid === (this.paidFilter === 'paid');
+      const term = this.search.toLowerCase();
+      const matchesSearch = !term || r.client.toLowerCase().includes(term) || r.course.toLowerCase().includes(term);
+      return matchesStatus && matchesType && matchesCourse && matchesPaid && matchesSearch;
+    });
+  }
+
+  onTabChange(index: number): void {
+    const map: (ReservationStatus | 'all')[] = ['active', 'completed', 'cancelled', 'all'];
+    this.currentTab = map[index];
+  }
+
+  openDetail(reservation: Reservation): void {
+    this.dialog.open(ReservationDetailComponent, { data: reservation });
+  }
+}
+

--- a/front/src/app/features/reservations/reservations-mock.service.ts
+++ b/front/src/app/features/reservations/reservations-mock.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+
+export type ReservationStatus = 'active' | 'completed' | 'cancelled';
+export type ReservationType = 'individual' | 'multiple';
+
+export interface Reservation {
+  id: number;
+  client: string;
+  course: string;
+  date: string; // ISO string
+  status: ReservationStatus;
+  paid: boolean;
+  type: ReservationType;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ReservationsMockService {
+  private readonly reservations: Reservation[] = [
+    { id: 1, client: 'Alice Johnson', course: 'Yoga Basics', date: '2025-08-20', status: 'active', paid: true, type: 'individual' },
+    { id: 2, client: 'Bob Smith', course: 'Pilates', date: '2025-08-18', status: 'completed', paid: true, type: 'multiple' },
+    { id: 3, client: 'Carlos Ruiz', course: 'Crossfit', date: '2025-08-19', status: 'cancelled', paid: false, type: 'individual' },
+    { id: 4, client: 'Diana Lee', course: 'Swimming', date: '2025-08-21', status: 'active', paid: false, type: 'multiple' },
+    { id: 5, client: 'Ethan Brown', course: 'Tennis', date: '2025-08-22', status: 'completed', paid: true, type: 'individual' },
+    { id: 6, client: 'Fiona Green', course: 'Boxing', date: '2025-08-18', status: 'active', paid: true, type: 'individual' },
+    { id: 7, client: 'George Hall', course: 'Karate', date: '2025-08-17', status: 'cancelled', paid: false, type: 'multiple' },
+    { id: 8, client: 'Hannah Ivers', course: 'Zumba', date: '2025-08-25', status: 'active', paid: false, type: 'individual' },
+    { id: 9, client: 'Ian Jacobs', course: 'Yoga Basics', date: '2025-08-26', status: 'completed', paid: true, type: 'multiple' },
+    { id: 10, client: 'Julia King', course: 'Pilates', date: '2025-08-27', status: 'active', paid: false, type: 'individual' }
+  ];
+
+  getReservations(): Reservation[] {
+    return this.reservations;
+  }
+}
+

--- a/front/src/app/features/reservations/reservations.module.ts
+++ b/front/src/app/features/reservations/reservations.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ReservationsListComponent } from './reservations-list/reservations-list.component';
+
+const routes: Routes = [{ path: '', component: ReservationsListComponent }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)]
+})
+export class ReservationsModule {}
+


### PR DESCRIPTION
## Summary
- add standalone reservations list with filters, tabs and detail dialog
- provide mock reservations service and lazy loaded module
- document usage and add basic unit tests

## Testing
- `npm test src/app/features/reservations/reservations-list/reservations-list.component.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adad184bf48320b227ce731370d055