### PR TITLE
feat(front): add courses list page with filters and modal

### DIFF
--- a/front/src/app/features/courses/courses-list.page.html
+++ b/front/src/app/features/courses/courses-list.page.html
@@ -1,0 +1,60 @@
+<div class="page">
+  <div class="page-header">
+    <h1>{{ 'courses.title' | translate }}</h1>
+  </div>
+
+  <div class="tabs row gap">
+    <button
+      type="button"
+      class="btn"
+      *ngFor="let tab of statusTabs"
+      [class.active]="selectedTab === tab"
+      (click)="selectTab(tab)"
+    >
+      {{ ('courses.tabs.' + tab) | translate }}
+    </button>
+  </div>
+
+  <form [formGroup]="filtersForm" class="filters row gap">
+    <input type="text" formControlName="search" [placeholder]="'courses.search' | translate" />
+    <input type="text" formControlName="sport" [placeholder]="'courses.sport' | translate" />
+    <select formControlName="type">
+      <option value="">{{ 'common.all' | translate }}</option>
+      <option value="collective">{{ 'courses.type.collective' | translate }}</option>
+      <option value="private">{{ 'courses.type.private' | translate }}</option>
+    </select>
+  </form>
+
+  <table>
+    <thead>
+      <tr>
+        <th>{{ 'courses.table.name' | translate }}</th>
+        <th>{{ 'courses.table.sport' | translate }}</th>
+        <th>{{ 'courses.table.type' | translate }}</th>
+        <th>{{ 'courses.table.level' | translate }}</th>
+        <th>{{ 'courses.table.status' | translate }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let course of filteredCourses" (click)="openCourse(course)" tabindex="0">
+        <td>{{ course.name }}</td>
+        <td>{{ course.sport }}</td>
+        <td>{{ course.type }}</td>
+        <td>{{ course.level }}</td>
+        <td>{{ course.status }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="preview-overlay" *ngIf="selectedCourse" (click)="closeCourse()">
+    <div class="preview-drawer" (click)="$event.stopPropagation()">
+      <h2>{{ selectedCourse.name }}</h2>
+      <p>{{ selectedCourse.description }}</p>
+      <p><strong>{{ 'courses.table.sport' | translate }}:</strong> {{ selectedCourse.sport }}</p>
+      <p><strong>{{ 'courses.table.type' | translate }}:</strong> {{ selectedCourse.type }}</p>
+      <p><strong>{{ 'courses.table.level' | translate }}:</strong> {{ selectedCourse.level }}</p>
+      <p><strong>{{ 'courses.table.status' | translate }}:</strong> {{ selectedCourse.status }}</p>
+      <button class="btn" type="button" (click)="closeCourse()">{{ 'common.close' | translate }}</button>
+    </div>
+  </div>
+</div>

--- a/front/src/app/features/courses/courses-list.page.scss
+++ b/front/src/app/features/courses/courses-list.page.scss
@@ -1,0 +1,48 @@
+@import '../../../styles/tokens.css';
+
+.page {
+  padding: var(--space-4);
+}
+
+.page-header {
+  margin-bottom: var(--space-4);
+}
+
+.tabs {
+  margin-bottom: var(--space-4);
+}
+
+.filters {
+  margin-bottom: var(--space-4);
+}
+
+table {
+  width: 100%;
+}
+
+th,
+td {
+  padding: var(--space-2);
+  text-align: left;
+}
+
+.tabs .btn.active {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+.preview-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-drawer {
+  background: var(--color-background);
+  padding: var(--space-4);
+  max-width: 400px;
+  width: 100%;
+}

--- a/front/src/app/features/courses/courses-list.page.ts
+++ b/front/src/app/features/courses/courses-list.page.ts
@@ -1,0 +1,124 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { TranslatePipe } from '@shared/pipes/translate.pipe';
+
+interface Course {
+  name: string;
+  sport: string;
+  type: 'collective' | 'private';
+  level: string;
+  status: 'active' | 'finished' | 'ongoing';
+  description: string;
+}
+
+@Component({
+  selector: 'app-courses-list-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  templateUrl: './courses-list.page.html',
+  styleUrls: ['./courses-list.page.scss'],
+})
+export class CoursesListPageComponent {
+  private readonly fb = inject(FormBuilder);
+
+  courses: Course[] = [
+    {
+      name: 'Ski Basics',
+      sport: 'Ski',
+      type: 'collective',
+      level: 'Beginner',
+      status: 'active',
+      description: 'Introductory group lessons for skiing',
+    },
+    {
+      name: 'Advanced Ski',
+      sport: 'Ski',
+      type: 'private',
+      level: 'Advanced',
+      status: 'ongoing',
+      description: 'One-on-one coaching for advanced skiers',
+    },
+    {
+      name: 'Snowboard Fun',
+      sport: 'Snowboard',
+      type: 'collective',
+      level: 'Intermediate',
+      status: 'finished',
+      description: 'Group snowboarding sessions for intermediate riders',
+    },
+    {
+      name: 'Kids Ski Camp',
+      sport: 'Ski',
+      type: 'collective',
+      level: 'Beginner',
+      status: 'ongoing',
+      description: 'Ski camp tailored for kids',
+    },
+    {
+      name: 'Freestyle Snowboard',
+      sport: 'Snowboard',
+      type: 'private',
+      level: 'Advanced',
+      status: 'active',
+      description: 'Private freestyle training sessions',
+    },
+    {
+      name: 'Racing Ski',
+      sport: 'Ski',
+      type: 'collective',
+      level: 'Expert',
+      status: 'finished',
+      description: 'High-performance racing course',
+    },
+  ];
+
+  filteredCourses: Course[] = [...this.courses];
+
+  statusTabs: Array<'active' | 'finished' | 'ongoing' | 'all'> = [
+    'active',
+    'finished',
+    'ongoing',
+    'all',
+  ];
+  selectedTab: 'active' | 'finished' | 'ongoing' | 'all' = 'active';
+
+  filtersForm = this.fb.group({
+    type: [''],
+    sport: [''],
+    search: [''],
+  });
+
+  selectedCourse: Course | null = null;
+
+  constructor() {
+    this.filtersForm.valueChanges.subscribe(() => this.applyFilters());
+    this.applyFilters();
+  }
+
+  selectTab(tab: 'active' | 'finished' | 'ongoing' | 'all'): void {
+    this.selectedTab = tab;
+    this.applyFilters();
+  }
+
+  openCourse(course: Course): void {
+    this.selectedCourse = course;
+  }
+
+  closeCourse(): void {
+    this.selectedCourse = null;
+  }
+
+  private applyFilters(): void {
+    const { type, sport, search } = this.filtersForm.value;
+    this.filteredCourses = this.courses.filter((course) => {
+      const matchesTab = this.selectedTab === 'all' || course.status === this.selectedTab;
+      const matchesType = !type || course.type === type;
+      const matchesSport =
+        !sport || course.sport.toLowerCase().includes((sport as string).toLowerCase());
+      const matchesSearch =
+        !search || course.name.toLowerCase().includes((search as string).toLowerCase());
+      return matchesTab && matchesType && matchesSport && matchesSearch;
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone courses list page with mock data, filters, status tabs and modal
- style page with existing tokens and class conventions

## Testing
- `npm test` (fails: Test Suites: 16 failed, 7 passed, 23 total)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb7430df08320ada33fa15a7901ae