### PR TITLE
feat: responsive scheduling calendar with smooth animations

### DIFF
--- a/front/src/app/features/scheduling/components/create-session-modal.component.ts
+++ b/front/src/app/features/scheduling/components/create-session-modal.component.ts
@@ -1,15 +1,17 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { animate, style, transition, trigger } from '@angular/animations';
 import { SchedulingSession } from './session-detail-modal.component';
 
 @Component({
   selector: 'app-create-session-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, MatButtonModule],
   template: `
-    <div class="modal-overlay" (click)="cancel.emit()">
-      <div class="modal-container" (click)="$event.stopPropagation()">
+    <div class="modal-overlay" (click)="cancel.emit()" [@fade]>
+      <div class="modal-container" (click)="$event.stopPropagation()" [@scale]>
         <h2>Create Session</h2>
         <form (ngSubmit)="onSubmit()" #form="ngForm">
           <label>
@@ -29,8 +31,8 @@ import { SchedulingSession } from './session-detail-modal.component';
             <input name="endTime" type="time" [(ngModel)]="session.endTime" required />
           </label>
           <div class="actions">
-            <button type="button" (click)="cancel.emit()">Cancel</button>
-            <button type="submit" [disabled]="form.invalid">Create</button>
+            <button mat-stroked-button type="button" (click)="cancel.emit()">Cancel</button>
+            <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid">Create</button>
           </div>
         </form>
       </div>
@@ -64,6 +66,26 @@ import { SchedulingSession } from './session-detail-modal.component';
         margin-top: var(--space-4);
       }
     `,
+  ],
+  animations: [
+    trigger('fade', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('200ms ease-out', style({ opacity: 1 })),
+      ]),
+      transition(':leave', [
+        animate('200ms ease-in', style({ opacity: 0 })),
+      ]),
+    ]),
+    trigger('scale', [
+      transition(':enter', [
+        style({ transform: 'scale(0.95)', opacity: 0 }),
+        animate('200ms ease-out', style({ transform: 'scale(1)', opacity: 1 })),
+      ]),
+      transition(':leave', [
+        animate('200ms ease-in', style({ transform: 'scale(0.95)', opacity: 0 })),
+      ]),
+    ]),
   ],
 })
 export class CreateSessionModalComponent implements OnChanges {

--- a/front/src/app/features/scheduling/components/session-block.component.ts
+++ b/front/src/app/features/scheduling/components/session-block.component.ts
@@ -50,6 +50,7 @@ import { Instructor } from '../services/instructor-availability.service';
         border-radius: var(--radius-2);
         color: var(--text-inverse);
         font-size: var(--font-size-sm);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
       }
 
       .session-block.confirmed {

--- a/front/src/app/features/scheduling/components/session-detail-modal.component.ts
+++ b/front/src/app/features/scheduling/components/session-detail-modal.component.ts
@@ -1,5 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { animate, style, transition, trigger } from '@angular/animations';
 
 export interface SchedulingSession {
   course: string;
@@ -11,10 +13,10 @@ export interface SchedulingSession {
 @Component({
   selector: 'app-session-detail-modal',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatButtonModule],
   template: `
-    <div class="modal-overlay" (click)="close.emit()">
-      <div class="modal-container" (click)="$event.stopPropagation()">
+    <div class="modal-overlay" (click)="close.emit()" [@fade]>
+      <div class="modal-container" (click)="$event.stopPropagation()" [@scale]>
         <h2>Session Details</h2>
         <div class="details">
           <p><strong>Course:</strong> {{ session?.course }}</p>
@@ -22,10 +24,10 @@ export interface SchedulingSession {
           <p><strong>Time:</strong> {{ session?.startTime }} - {{ session?.endTime }}</p>
         </div>
         <div class="actions">
-          <button type="button" (click)="edit.emit(session)">Edit</button>
-          <button type="button" (click)="reschedule.emit(session)">Reschedule</button>
-          <button type="button" (click)="remove.emit(session)">Delete</button>
-          <button type="button" (click)="close.emit()">Close</button>
+          <button mat-stroked-button type="button" (click)="edit.emit(session)">Edit</button>
+          <button mat-stroked-button type="button" (click)="reschedule.emit(session)">Reschedule</button>
+          <button mat-stroked-button color="warn" type="button" (click)="remove.emit(session)">Delete</button>
+          <button mat-flat-button color="primary" type="button" (click)="close.emit()">Close</button>
         </div>
       </div>
     </div>
@@ -53,6 +55,26 @@ export interface SchedulingSession {
         margin-top: var(--space-4);
       }
     `,
+  ],
+  animations: [
+    trigger('fade', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('200ms ease-out', style({ opacity: 1 })),
+      ]),
+      transition(':leave', [
+        animate('200ms ease-in', style({ opacity: 0 })),
+      ]),
+    ]),
+    trigger('scale', [
+      transition(':enter', [
+        style({ transform: 'scale(0.95)', opacity: 0 }),
+        animate('200ms ease-out', style({ transform: 'scale(1)', opacity: 1 })),
+      ]),
+      transition(':leave', [
+        animate('200ms ease-in', style({ transform: 'scale(0.95)', opacity: 0 })),
+      ]),
+    ]),
   ],
 })
 export class SessionDetailModalComponent {

--- a/front/src/app/features/scheduling/scheduling-calendar.component.ts
+++ b/front/src/app/features/scheduling/scheduling-calendar.component.ts
@@ -19,15 +19,22 @@ import { Instructor } from './services/instructor-availability.service';
   template: `
     <div class="page" data-cy="scheduling-calendar">
       <div class="page-header">
-        <h1>Scheduling Calendar</h1>
+        <h1 class="text-2xl font-semibold">Scheduling Calendar</h1>
       </div>
-      <div class="page-content">
-        <app-instructor-sidebar></app-instructor-sidebar>
-        <div class="calendar">
-          <div class="day-header" *ngFor="let day of days">{{ day }}</div>
+      <div class="page-content flex flex-col lg:flex-row gap-4">
+        <app-instructor-sidebar class="lg:w-64"></app-instructor-sidebar>
+        <div
+          class="calendar flex-1 grid bg-surface border border-border"
+        >
+          <div
+            class="day-header p-2 text-center font-medium bg-surface-2 border-r border-b border-border"
+            *ngFor="let day of days"
+          >
+            {{ day }}
+          </div>
           <ng-container *ngFor="let hour of hours">
             <div
-              class="time-slot"
+              class="time-slot min-h-10 border-r border-b border-border transition-colors"
               *ngFor="let day of days"
               (dblclick)="onEmptySlotDblClick(day, hour)"
             >
@@ -62,31 +69,22 @@ import { Instructor } from './services/instructor-availability.service';
   `,
   styles: [
     `
-      .page-content {
-        display: flex;
-      }
-
       .calendar {
         flex: 1;
-        display: grid;
-        grid-template-columns: repeat(7, 1fr);
-        background: var(--surface);
-        border: 1px solid var(--border);
+        grid-template-columns: repeat(1, 1fr);
+        transition: grid-template-columns 0.3s ease;
       }
 
-      .day-header {
-        padding: var(--space-2);
-        text-align: center;
-        font-weight: 500;
-        background: var(--surface-2);
-        border-right: 1px solid var(--border);
-        border-bottom: 1px solid var(--border);
+      @media (min-width: 768px) {
+        .calendar {
+          grid-template-columns: repeat(4, 1fr);
+        }
       }
 
-      .time-slot {
-        min-height: 40px;
-        border-right: 1px solid var(--border);
-        border-bottom: 1px solid var(--border);
+      @media (min-width: 1024px) {
+        .calendar {
+          grid-template-columns: repeat(7, 1fr);
+        }
       }
 
       .calendar > :nth-child(7n) {


### PR DESCRIPTION
## Summary
- make scheduling calendar responsive with Tailwind layout and breakpoints
- add transitions for session drag/drop
- animate session detail and creation modals using Angular Material

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` *(fails: Property 'toBe' does not exist on type 'Assertion', etc.)*
- `npm run build` *(fails: Parser Error in sports-degrees.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68adb721816c8320963a1a2b342381c4