### PR TITLE
feat(front): add courses route

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -112,6 +112,12 @@ export const routes: Routes = [
         canActivate: [requireCompleteAuthGuard]
       },
       {
+        path: 'courses',
+        canActivate: [requireCompleteAuthGuard],
+        loadComponent: () =>
+          import('./features/courses/courses-list.page').then(c => c.CoursesListPageComponent)
+      },
+      {
         path: 'settings',
         loadChildren: () => import('./features/settings').then(m => m.routes)
       }


### PR DESCRIPTION
## Summary
- add courses route with auth guard and lazy-loaded courses list

## Testing
- `npm run lint`
- `npm test` *(fails: No provider for _HttpClient!, Test Suites: 16 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68adb971d67c83209f44805059552d72