### PR TITLE
feat(front): add communications route

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -109,30 +109,43 @@ export const routes: Routes = [
         path: 'renting',
         loadComponent: () =>
           import('./features/renting/renting.component').then(c => c.RentingComponent),
-        canActivate: [requireCompleteAuthGuard]
+        canActivate: [requireCompleteAuthGuard],
       },
       {
         path: 'chat',
         loadComponent: () =>
           import('./features/chat/chat.component').then(c => c.ChatComponent),
-       canActivate: [requireCompleteAuthGuard],
-      }
-        path: 'courses',
         canActivate: [requireCompleteAuthGuard],
-        loadComponent: () =>
-          import('./features/courses/courses-list.page').then(c => c.CoursesListPageComponent),
-           canActivate: [requireCompleteAuthGuard]
       },
+      {
+        path: 'communications',
+        loadComponent: () =>
+          import('./features/communications/communications.component').then(
+            c => c.CommunicationsComponent,
+          ),
+        canActivate: [requireCompleteAuthGuard],
+      },
+      {
+        path: 'courses',
+        loadComponent: () =>
+          import('./features/courses/courses-list.page').then(
+            c => c.CoursesListPageComponent,
+          ),
+        canActivate: [requireCompleteAuthGuard],
+      },
+      {
         path: 'statistics',
         loadComponent: () =>
-          import('./features/statistics/statistics.component').then(c => c.StatisticsComponent),
-        canActivate: [requireCompleteAuthGuard]
+          import('./features/statistics/statistics.component').then(
+            c => c.StatisticsComponent,
+          ),
+        canActivate: [requireCompleteAuthGuard],
       },
       {
         path: 'settings',
         loadChildren: () => import('./features/settings').then(m => m.routes),
-           canActivate: [requireCompleteAuthGuard]
-      }
+        canActivate: [requireCompleteAuthGuard],
+      },
     ]
   },
   

--- a/front/src/app/features/communications/communications.component.ts
+++ b/front/src/app/features/communications/communications.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-communications',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="page">
+      <div class="page-header">
+        <h1>Comunicación</h1>
+      </div>
+      <p>Página de comunicaciones</p>
+    </div>
+  `,
+})
+export class CommunicationsComponent {}

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -408,15 +408,18 @@ interface Notification {
           </a>
 
           <!-- Comunicación -->
-          <a href="#" class="nav-item item" role="menuitem" [title]="ui.sidebarCollapsed() ? translationService.instant('nav.comunicacion') : null">
-            <div class="nav-icon">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h4v6l4-3 4 3v-6h4c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
-              </svg>
-            </div>
-            <span class="nav-text label">{{ translationService.instant('nav.comunicacion') }}</span>
-            <span class="badge counter counter--red">3</span>
-          </a>
+            <a routerLink="/communications"
+               routerLinkActive="active"
+               class="nav-item item"
+               [title]="ui.sidebarCollapsed() ? translationService.instant('nav.comunicacion') : null">
+              <div class="nav-icon">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h4v6l4-3 4 3v-6h4c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
+                </svg>
+              </div>
+              <span class="nav-text label">{{ translationService.instant('nav.comunicacion') }}</span>
+              <span class="badge counter counter--red">3</span>
+            </a>
 
           <!-- Pagos -->
           <a href="#" class="nav-item item" role="menuitem" [title]="ui.sidebarCollapsed() ? translationService.instant('nav.pagos') : null">


### PR DESCRIPTION
## Summary
- add communications placeholder component and route
- link navigation item to communications section

## Testing
- `npm test` *(fails: TS errors across spec files)*

------
https://chatgpt.com/codex/tasks/task_e_68adbc17dd8483209c3f71c325c44a2b