### PR TITLE
feat(front): add mock vouchers list

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -135,6 +135,12 @@ export const routes: Routes = [
         canActivate: [requireCompleteAuthGuard],
       },
       {
+        path: 'vouchers',
+        canActivate: [requireCompleteAuthGuard],
+        loadChildren: () =>
+          import('./features/vouchers/vouchers.module').then((m) => m.VouchersModule),
+      },
+      {
         path: 'chat',
         loadComponent: () => import('./features/chat/chat.component').then((c) => c.ChatComponent),
         canActivate: [requireCompleteAuthGuard],

--- a/front/src/app/features/vouchers/create-voucher-dialog.component.ts
+++ b/front/src/app/features/vouchers/create-voucher-dialog.component.ts
@@ -1,0 +1,72 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+
+export interface CreateVoucherFormData {
+  type: 'purchase' | 'gift' | 'discount';
+  value: number;
+  expiration: string;
+}
+
+@Component({
+  selector: 'app-create-voucher-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+  ],
+  template: `
+    <h2 mat-dialog-title>Create Voucher</h2>
+    <form [formGroup]="form" (ngSubmit)="submit()" mat-dialog-content class="dialog-content">
+      <mat-form-field>
+        <mat-label>Type</mat-label>
+        <mat-select formControlName="type" required>
+          <mat-option value="purchase">Purchase</mat-option>
+          <mat-option value="gift">Gift</mat-option>
+          <mat-option value="discount">Discount</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Value</mat-label>
+        <input matInput type="number" formControlName="value" required />
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Expiration</mat-label>
+        <input matInput type="date" formControlName="expiration" required />
+      </mat-form-field>
+      <div mat-dialog-actions align="end">
+        <button mat-button type="button" mat-dialog-close>Cancel</button>
+        <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid">Create</button>
+      </div>
+    </form>
+  `,
+  styles: [
+    `.dialog-content { display: flex; flex-direction: column; gap: var(--space-4); color: var(--text-1); }`
+  ],
+})
+export class CreateVoucherDialogComponent {
+  form = this.fb.group({
+    type: ['purchase', Validators.required],
+    value: [0, Validators.required],
+    expiration: ['', Validators.required],
+  });
+
+  constructor(private fb: FormBuilder, private dialogRef: MatDialogRef<CreateVoucherDialogComponent>) {}
+
+  submit(): void {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value as CreateVoucherFormData);
+    }
+  }
+}
+

--- a/front/src/app/features/vouchers/vouchers-list.component.html
+++ b/front/src/app/features/vouchers/vouchers-list.component.html
@@ -1,0 +1,34 @@
+<div class="actions">
+  <button mat-raised-button color="primary" (click)="openCreateDialog()">Create Voucher</button>
+</div>
+
+<table mat-table [dataSource]="vouchers" class="vouchers-table">
+  <ng-container matColumnDef="code">
+    <th mat-header-cell *matHeaderCellDef>Code</th>
+    <td mat-cell *matCellDef="let v">{{ v.code }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="type">
+    <th mat-header-cell *matHeaderCellDef>Type</th>
+    <td mat-cell *matCellDef="let v">{{ v.type }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="client">
+    <th mat-header-cell *matHeaderCellDef>Client</th>
+    <td mat-cell *matCellDef="let v">{{ v.client }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="value">
+    <th mat-header-cell *matHeaderCellDef>Value</th>
+    <td mat-cell *matCellDef="let v">{{ v.value | currency:'EUR':'symbol':'1.0-0' }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="status">
+    <th mat-header-cell *matHeaderCellDef>Status</th>
+    <td mat-cell *matCellDef="let v">{{ v.status }}</td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>
+

--- a/front/src/app/features/vouchers/vouchers-list.component.scss
+++ b/front/src/app/features/vouchers/vouchers-list.component.scss
@@ -1,0 +1,17 @@
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--space-4);
+}
+
+.vouchers-table {
+  width: 100%;
+  background: var(--surface);
+  color: var(--text-1);
+}
+
+.vouchers-table th {
+  background: var(--surface-2);
+  color: var(--text-2);
+}
+

--- a/front/src/app/features/vouchers/vouchers-list.component.spec.ts
+++ b/front/src/app/features/vouchers/vouchers-list.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { VouchersListComponent } from './vouchers-list.component';
+
+describe('VouchersListComponent', () => {
+  let component: VouchersListComponent;
+  let fixture: ComponentFixture<VouchersListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VouchersListComponent],
+      providers: [
+        {
+          provide: MatDialog,
+          useValue: { open: () => ({ afterClosed: () => of(undefined) }) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VouchersListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create with 8 vouchers', () => {
+    expect(component).toBeTruthy();
+    expect(component.vouchers.length).toBe(8);
+  });
+
+  it('should add voucher', () => {
+    const initial = component.vouchers.length;
+    component.addVoucher({ type: 'gift', value: 25, expiration: '2025-06-01' });
+    expect(component.vouchers.length).toBe(initial + 1);
+    expect(component.vouchers[initial].type).toBe('gift');
+  });
+});
+

--- a/front/src/app/features/vouchers/vouchers-list.component.ts
+++ b/front/src/app/features/vouchers/vouchers-list.component.ts
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { CreateVoucherDialogComponent, CreateVoucherFormData } from './create-voucher-dialog.component';
+
+export interface Voucher {
+  code: string;
+  type: 'purchase' | 'gift' | 'discount';
+  client: string;
+  value: number;
+  status: 'active' | 'used' | 'expired';
+  expiration: string;
+}
+
+@Component({
+  selector: 'app-vouchers-list',
+  standalone: true,
+  imports: [CommonModule, MatTableModule, MatButtonModule, MatDialogModule],
+  templateUrl: './vouchers-list.component.html',
+  styleUrls: ['./vouchers-list.component.scss'],
+})
+export class VouchersListComponent {
+  vouchers: Voucher[] = [
+    { code: 'VCH-001', type: 'purchase', client: 'Alice', value: 50, status: 'active', expiration: '2025-12-31' },
+    { code: 'VCH-002', type: 'gift', client: 'Bob', value: 30, status: 'active', expiration: '2024-10-15' },
+    { code: 'VCH-003', type: 'discount', client: 'Charlie', value: 15, status: 'used', expiration: '2024-08-01' },
+    { code: 'VCH-004', type: 'purchase', client: 'Diana', value: 100, status: 'active', expiration: '2025-05-20' },
+    { code: 'VCH-005', type: 'gift', client: 'Eve', value: 25, status: 'expired', expiration: '2023-12-31' },
+    { code: 'VCH-006', type: 'discount', client: 'Frank', value: 20, status: 'active', expiration: '2024-09-30' },
+    { code: 'VCH-007', type: 'purchase', client: 'Grace', value: 40, status: 'used', expiration: '2024-07-15' },
+    { code: 'VCH-008', type: 'gift', client: 'Henry', value: 35, status: 'active', expiration: '2025-02-28' },
+  ];
+
+  displayedColumns = ['code', 'type', 'client', 'value', 'status'];
+
+  constructor(private dialog: MatDialog) {}
+
+  openCreateDialog(): void {
+    const dialogRef = this.dialog.open(CreateVoucherDialogComponent);
+    dialogRef.afterClosed().subscribe((data?: CreateVoucherFormData) => {
+      if (data) {
+        this.addVoucher(data);
+      }
+    });
+  }
+
+  addVoucher(data: CreateVoucherFormData): void {
+    const newVoucher: Voucher = {
+      code: `VCH-${(this.vouchers.length + 1).toString().padStart(3, '0')}`,
+      type: data.type,
+      value: data.value,
+      expiration: data.expiration,
+      client: 'New Client',
+      status: 'active',
+    };
+    this.vouchers = [...this.vouchers, newVoucher];
+  }
+}
+

--- a/front/src/app/features/vouchers/vouchers.module.ts
+++ b/front/src/app/features/vouchers/vouchers.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { VouchersListComponent } from './vouchers-list.component';
+
+const routes: Routes = [{ path: '', component: VouchersListComponent }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+})
+export class VouchersModule {}
+

--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -397,7 +397,13 @@ interface Notification {
           </a>
 
           <!-- Bonos -->
-          <a href="#" class="nav-item item" role="menuitem" [title]="ui.sidebarCollapsed() ? translationService.instant('nav.bonos') : null">
+          <a
+            routerLink="/vouchers"
+            routerLinkActive="active"
+            class="nav-item item"
+            role="menuitem"
+            [title]="ui.sidebarCollapsed() ? translationService.instant('nav.bonos') : null"
+          >
             <div class="nav-icon">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M4 4h16v2H4zm0 5h16v6H4zm0 11h16v-2H4z"/>


### PR DESCRIPTION
## Summary
- add vouchers list with mock data and creation dialog
- wire vouchers route and sidebar navigation

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' and other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68adc2acce88832093bdb7f5f37ec46f