### PR TITLE
Guard communications route by feature flag

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import {
   seasonSelectionGuard,
   requireCompleteAuthGuard,
 } from './core/guards/season-selection.guard';
+import { featureFlagGuard } from './core/guards/feature-flag.guard';
 
 export const routes: Routes = [
   {
@@ -151,7 +152,7 @@ export const routes: Routes = [
           import('./features/communications/communications.component').then(
             c => c.CommunicationsComponent,
           ),
-        canActivate: [requireCompleteAuthGuard],
+        canActivate: [requireCompleteAuthGuard, featureFlagGuard],
       },
       {
         path: 'courses',

--- a/front/src/app/core/guards/feature-flag.guard.ts
+++ b/front/src/app/core/guards/feature-flag.guard.ts
@@ -22,6 +22,7 @@ export const featureFlagGuard: CanActivateFn = (route: ActivatedRouteSnapshot) =
     'estadisticas': 'useV5Analytics',
     'settings': 'useV5Settings',
     'ajustes': 'useV5Settings',
+    'communications': 'useV5Communications',
     'comunicaciones': 'useV5Communications',
     'chat': 'useV5Chat',
     'renting': 'useV5Renting',


### PR DESCRIPTION
## Summary
- protect communications route using `featureFlagGuard`
- extend feature flag guard mapping for communications path

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68adc25246488320bf4f414a1667d73c