### PR TITLE
feat(monitors): add monitors list with mock service and routing

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -171,8 +171,17 @@ export const routes: Routes = [
         path: 'statistics',
         loadComponent: () =>
           import('./features/statistics/statistics.component').then(
-            c => c.StatisticsComponent,
+            (c) => c.StatisticsComponent
+          ),
         canActivate: [requireCompleteAuthGuard],
+      },
+      {
+        path: 'monitors',
+        canActivate: [requireCompleteAuthGuard],
+        loadChildren: () =>
+          import('./features/monitors/monitors.routes').then(
+            (m) => m.MONITORS_ROUTES
+          ),
       },
       {
         path: 'settings',

--- a/front/src/app/features/monitors/monitor-profile.component.ts
+++ b/front/src/app/features/monitors/monitor-profile.component.ts
@@ -1,0 +1,26 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { Monitor } from './monitors-mock.service';
+
+@Component({
+  selector: 'app-monitor-profile',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>{{ data.name }}</h2>
+    <div mat-dialog-content>
+      <p><strong>Sports:</strong> {{ data.sports.join(', ') }}</p>
+      <p><strong>Levels:</strong> {{ data.levels.join(', ') }}</p>
+      <p><strong>Status:</strong> {{ data.status }}</p>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button mat-dialog-close>Close</button>
+    </div>
+  `,
+})
+export class MonitorProfileComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: Monitor) {}
+}
+

--- a/front/src/app/features/monitors/monitors-list/monitors-list.component.html
+++ b/front/src/app/features/monitors/monitors-list/monitors-list.component.html
@@ -1,0 +1,36 @@
+<mat-tab-group (selectedIndexChange)="onTabChange($event)">
+  <mat-tab label="Active"></mat-tab>
+  <mat-tab label="Inactive"></mat-tab>
+  <mat-tab label="All"></mat-tab>
+</mat-tab-group>
+
+<mat-select [(ngModel)]="selectedSport" placeholder="Filter by sport">
+  <mat-option value="">All Sports</mat-option>
+  <mat-option *ngFor="let sport of sports" [value]="sport">{{ sport }}</mat-option>
+</mat-select>
+
+<table mat-table [dataSource]="filteredMonitors" class="monitors-table mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Name</th>
+    <td mat-cell *matCellDef="let monitor">{{ monitor.name }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="sports">
+    <th mat-header-cell *matHeaderCellDef>Sports</th>
+    <td mat-cell *matCellDef="let monitor">{{ monitor.sports.join(', ') }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="levels">
+    <th mat-header-cell *matHeaderCellDef>Levels</th>
+    <td mat-cell *matCellDef="let monitor">{{ monitor.levels.join(', ') }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="status">
+    <th mat-header-cell *matHeaderCellDef>Status</th>
+    <td mat-cell *matCellDef="let monitor">{{ monitor.status }}</td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openMonitor(row)"></tr>
+</table>
+

--- a/front/src/app/features/monitors/monitors-list/monitors-list.component.scss
+++ b/front/src/app/features/monitors/monitors-list/monitors-list.component.scss
@@ -1,0 +1,9 @@
+.monitors-table {
+  width: 100%;
+  margin-top: 16px;
+}
+
+mat-select {
+  margin: 16px 0;
+  width: 200px;
+}

--- a/front/src/app/features/monitors/monitors-list/monitors-list.component.ts
+++ b/front/src/app/features/monitors/monitors-list/monitors-list.component.ts
@@ -1,0 +1,58 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatTableModule } from '@angular/material/table';
+import { MatSelectModule } from '@angular/material/select';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MonitorsMockService, Monitor } from '../monitors-mock.service';
+import { MonitorProfileComponent } from '../monitor-profile.component';
+
+@Component({
+  selector: 'app-monitors-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatTabsModule,
+    MatTableModule,
+    MatSelectModule,
+    MatDialogModule,
+    MatButtonModule,
+  ],
+  templateUrl: './monitors-list.component.html',
+  styleUrls: ['./monitors-list.component.scss'],
+})
+export class MonitorsListComponent {
+  displayedColumns = ['name', 'sports', 'levels', 'status'];
+  monitors: Monitor[] = this.monitorsService.getMonitors();
+  statusFilter: 'active' | 'inactive' | 'all' = 'active';
+  selectedSport = '';
+
+  constructor(
+    private monitorsService: MonitorsMockService,
+    private dialog: MatDialog,
+  ) {}
+
+  get sports(): string[] {
+    return Array.from(new Set(this.monitors.flatMap((m) => m.sports)));
+  }
+
+  get filteredMonitors(): Monitor[] {
+    return this.monitors.filter(
+      (m) =>
+        (this.statusFilter === 'all' || m.status === this.statusFilter) &&
+        (!this.selectedSport || m.sports.includes(this.selectedSport)),
+    );
+  }
+
+  onTabChange(index: number): void {
+    this.statusFilter = index === 0 ? 'active' : index === 1 ? 'inactive' : 'all';
+  }
+
+  openMonitor(monitor: Monitor): void {
+    this.dialog.open(MonitorProfileComponent, { data: monitor });
+  }
+}
+

--- a/front/src/app/features/monitors/monitors-mock.service.ts
+++ b/front/src/app/features/monitors/monitors-mock.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+
+export interface Monitor {
+  id: number;
+  name: string;
+  sports: string[];
+  levels: string[];
+  status: 'active' | 'inactive';
+}
+
+@Injectable({ providedIn: 'root' })
+export class MonitorsMockService {
+  private monitors: Monitor[] = [
+    { id: 1, name: 'Alice Johnson', sports: ['Tennis', 'Swimming'], levels: ['Beginner', 'Advanced'], status: 'active' },
+    { id: 2, name: 'Bob Smith', sports: ['Basketball'], levels: ['Intermediate'], status: 'inactive' },
+    { id: 3, name: 'Carol Davis', sports: ['Soccer', 'Running'], levels: ['Beginner'], status: 'active' },
+    { id: 4, name: 'David Wilson', sports: ['Tennis'], levels: ['Advanced'], status: 'inactive' },
+    { id: 5, name: 'Eve Thompson', sports: ['Swimming'], levels: ['Intermediate', 'Advanced'], status: 'active' },
+  ];
+
+  getMonitors(): Monitor[] {
+    return this.monitors;
+  }
+}
+

--- a/front/src/app/features/monitors/monitors.routes.ts
+++ b/front/src/app/features/monitors/monitors.routes.ts
@@ -1,0 +1,11 @@
+import { Routes } from '@angular/router';
+
+export const MONITORS_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./monitors-list/monitors-list.component').then(
+        (m) => m.MonitorsListComponent
+      ),
+  },
+];


### PR DESCRIPTION
## Summary
- add mock monitors service with sample data
- create standalone monitors list with tab and sport filters and profile dialog
- expose monitors routes and register under /monitors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc6b8b7788320af47ed84db2e2277