### PR TITLE
feat(reservations): add mock reservation form

### DIFF
--- a/front/src/app/features/reservations/reservation-form/reservation-form.component.html
+++ b/front/src/app/features/reservations/reservation-form/reservation-form.component.html
@@ -1,0 +1,126 @@
+<ng-container *ngIf="!finalReservation; else summary">
+  <mat-horizontal-stepper linear>
+    <mat-step [stepControl]="clientGroup">
+      <form [formGroup]="clientGroup" class="step-content">
+        <ng-template matStepLabel>Selección de cliente</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Cliente</mat-label>
+          <mat-select formControlName="client">
+            <mat-option *ngFor="let c of clients" [value]="c.id">{{ c.name }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <div>
+          <button mat-button matStepperNext [disabled]="clientGroup.invalid">Siguiente</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step [stepControl]="participantsGroup">
+      <form [formGroup]="participantsGroup" class="step-content">
+        <ng-template matStepLabel>Participantes</ng-template>
+        <div formArrayName="participants">
+          <div *ngFor="let p of participants.controls; let i = index" class="participant-row">
+            <mat-form-field appearance="fill">
+              <mat-label>Participante {{ i + 1 }}</mat-label>
+              <input matInput [formControlName]="i" />
+            </mat-form-field>
+            <button mat-icon-button color="warn" type="button" (click)="removeParticipant(i)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
+        </div>
+        <button mat-button type="button" (click)="addParticipant()">Añadir participante</button>
+        <div>
+          <button mat-button matStepperPrevious>Anterior</button>
+          <button mat-button matStepperNext>Siguiente</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step [stepControl]="courseGroup">
+      <form [formGroup]="courseGroup" class="step-content">
+        <ng-template matStepLabel>Deporte y curso</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Deporte</mat-label>
+          <mat-select formControlName="sport">
+            <mat-option *ngFor="let sport of sports" [value]="sport">{{ sport }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Curso</mat-label>
+          <mat-select formControlName="course">
+            <mat-option *ngFor="let course of filteredCourses" [value]="course.id">{{ course.name }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <div>
+          <button mat-button matStepperPrevious>Anterior</button>
+          <button mat-button matStepperNext [disabled]="courseGroup.invalid">Siguiente</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step [stepControl]="dateExtrasGroup">
+      <form [formGroup]="dateExtrasGroup" class="step-content">
+        <ng-template matStepLabel>Fechas y extras</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Fecha</mat-label>
+          <input matInput [matDatepicker]="picker" formControlName="date" />
+          <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+          <mat-datepicker #picker></mat-datepicker>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Extras</mat-label>
+          <mat-select formControlName="extras" multiple>
+            <mat-option *ngFor="let extra of extras" [value]="extra.id">
+              {{ extra.name }} ({{ extra.price | currency:'EUR' }})
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <div>
+          <button mat-button matStepperPrevious>Anterior</button>
+          <button mat-button matStepperNext [disabled]="dateExtrasGroup.invalid">Siguiente</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step [stepControl]="priceGroup">
+      <form [formGroup]="priceGroup" class="step-content">
+        <ng-template matStepLabel>Resumen de precios</ng-template>
+        <p>Curso: {{ selectedCourse?.name }} - {{ selectedCourse?.price | currency:'EUR' }}</p>
+        <p>Extras:</p>
+        <ul>
+          <li *ngFor="let extra of selectedExtras">{{ extra.name }} - {{ extra.price | currency:'EUR' }}</li>
+        </ul>
+        <p><strong>Total: {{ totalPrice | currency:'EUR' }}</strong></p>
+        <div>
+          <button mat-button matStepperPrevious>Anterior</button>
+          <button mat-button matStepperNext>Siguiente</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step [stepControl]="confirmGroup">
+      <form [formGroup]="confirmGroup" class="step-content">
+        <ng-template matStepLabel>Confirmación</ng-template>
+        <p>Revise los datos y confirme la reserva.</p>
+        <div>
+          <button mat-button matStepperPrevious>Anterior</button>
+          <button mat-button type="button" (click)="confirm()">Confirmar</button>
+        </div>
+      </form>
+    </mat-step>
+  </mat-horizontal-stepper>
+</ng-container>
+
+<ng-template #summary>
+  <div class="summary">
+    <h2>Resumen de la reserva</h2>
+    <p>Cliente: {{ finalReservation.client }}</p>
+    <p>Participantes: {{ finalReservation.participants.join(', ') }}</p>
+    <p>Deporte: {{ finalReservation.sport }}</p>
+    <p>Curso: {{ finalReservation.course }}</p>
+    <p>Fecha: {{ finalReservation.date | date }}</p>
+    <p>Extras: {{ finalReservation.extras.join(', ') || 'Ninguno' }}</p>
+    <p>Total: {{ finalReservation.total | currency:'EUR' }}</p>
+  </div>
+</ng-template>

--- a/front/src/app/features/reservations/reservation-form/reservation-form.component.scss
+++ b/front/src/app/features/reservations/reservation-form/reservation-form.component.scss
@@ -1,0 +1,15 @@
+.step-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.participant-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.summary {
+  margin-top: 24px;
+}

--- a/front/src/app/features/reservations/reservation-form/reservation-form.component.ts
+++ b/front/src/app/features/reservations/reservation-form/reservation-form.component.ts
@@ -1,0 +1,139 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormArray, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatStepperModule } from '@angular/material/stepper';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+
+interface Client { id: number; name: string; }
+interface Course { id: number; sport: string; name: string; price: number; }
+interface Extra { id: number; name: string; price: number; }
+
+@Component({
+  selector: 'app-reservation-form',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatStepperModule,
+    MatInputModule,
+    MatSelectModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatButtonModule,
+    MatIconModule,
+    MatListModule,
+    MatCheckboxModule
+  ],
+  templateUrl: './reservation-form.component.html',
+  styleUrl: './reservation-form.component.scss'
+})
+export class ReservationFormComponent {
+  clients: Client[] = [
+    { id: 1, name: 'Alice Johnson' },
+    { id: 2, name: 'Bob Smith' },
+    { id: 3, name: 'Carlos Ruiz' }
+  ];
+
+  courses: Course[] = [
+    { id: 1, sport: 'Tennis', name: 'Beginner', price: 50 },
+    { id: 2, sport: 'Tennis', name: 'Advanced', price: 70 },
+    { id: 3, sport: 'Yoga', name: 'Morning Flow', price: 40 },
+    { id: 4, sport: 'Yoga', name: 'Power Yoga', price: 60 }
+  ];
+
+  extras: Extra[] = [
+    { id: 1, name: 'Equipment rental', price: 10 },
+    { id: 2, name: 'Locker', price: 5 },
+    { id: 3, name: 'Refreshments', price: 8 }
+  ];
+
+  clientGroup = this.fb.group({
+    client: ['', Validators.required]
+  });
+
+  participantsGroup = this.fb.group({
+    participants: this.fb.array([])
+  });
+
+  courseGroup = this.fb.group({
+    sport: ['', Validators.required],
+    course: ['', Validators.required]
+  });
+
+  dateExtrasGroup = this.fb.group({
+    date: ['', Validators.required],
+    extras: [[] as number[]]
+  });
+
+  priceGroup = this.fb.group({});
+
+  confirmGroup = this.fb.group({});
+
+  finalReservation?: {
+    client: string | undefined;
+    participants: string[];
+    sport: string | undefined;
+    course: string | undefined;
+    date: Date | string;
+    extras: string[];
+    total: number;
+  };
+
+  constructor(private fb: FormBuilder) {}
+
+  get participants(): FormArray {
+    return this.participantsGroup.get('participants') as FormArray;
+  }
+
+  addParticipant(): void {
+    this.participants.push(this.fb.control('', Validators.required));
+  }
+
+  removeParticipant(index: number): void {
+    this.participants.removeAt(index);
+  }
+
+  get sports(): string[] {
+    return Array.from(new Set(this.courses.map(c => c.sport)));
+  }
+
+  get filteredCourses(): Course[] {
+    const sport = this.courseGroup.value.sport;
+    return this.courses.filter(c => !sport || c.sport === sport);
+  }
+
+  get selectedCourse(): Course | undefined {
+    return this.courses.find(c => c.id === this.courseGroup.value.course);
+  }
+
+  get selectedExtras(): Extra[] {
+    const ids: number[] = this.dateExtrasGroup.value.extras || [];
+    return this.extras.filter(e => ids.includes(e.id));
+  }
+
+  get totalPrice(): number {
+    const coursePrice = this.selectedCourse?.price || 0;
+    const extrasPrice = this.selectedExtras.reduce((sum, e) => sum + e.price, 0);
+    return coursePrice + extrasPrice;
+  }
+
+  confirm(): void {
+    this.finalReservation = {
+      client: this.clients.find(c => c.id === this.clientGroup.value.client)?.name,
+      participants: this.participants.value,
+      sport: this.selectedCourse?.sport,
+      course: this.selectedCourse?.name,
+      date: this.dateExtrasGroup.value.date,
+      extras: this.selectedExtras.map(e => e.name),
+      total: this.totalPrice
+    };
+  }
+}
+

--- a/front/src/app/features/reservations/reservations.module.ts
+++ b/front/src/app/features/reservations/reservations.module.ts
@@ -1,8 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ReservationsListComponent } from './reservations-list/reservations-list.component';
+import { ReservationFormComponent } from './reservation-form/reservation-form.component';
 
-const routes: Routes = [{ path: '', component: ReservationsListComponent }];
+const routes: Routes = [
+  { path: '', component: ReservationsListComponent },
+  { path: 'new', component: ReservationFormComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)]


### PR DESCRIPTION
## Summary
- build multi-step reservation form using Angular Material stepper and reactive forms
- provide mock data arrays for clients, courses and extras
- expose reservation creation route under `/reservations/new`

## Testing
- `npm run lint`
- `npm test` *(fails: missing HttpClient providers and assertion methods in multiple spec files)*

------
https://chatgpt.com/codex/tasks/task_e_68adc770065883209d28e1805497236d