### PR TITLE
feat: add course creation form

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -163,6 +163,22 @@ export const routes: Routes = [
         canActivate: [requireCompleteAuthGuard],
       },
       {
+        path: 'courses/new',
+        loadComponent: () =>
+          import('./features/courses/course-form.component').then(
+            (c) => c.CourseFormComponent
+          ),
+        canActivate: [requireCompleteAuthGuard],
+      },
+      {
+        path: 'courses/:id/edit',
+        loadComponent: () =>
+          import('./features/courses/course-form.component').then(
+            (c) => c.CourseFormComponent
+          ),
+        canActivate: [requireCompleteAuthGuard],
+      },
+      {
         path: 'statistics',
         loadComponent: () =>
           import('./features/statistics/statistics.component').then(

--- a/front/src/app/features/courses/course-form.component.html
+++ b/front/src/app/features/courses/course-form.component.html
@@ -1,0 +1,95 @@
+<form class="course-form" [formGroup]="courseForm" (ngSubmit)="save()">
+  <!-- Sport & Type -->
+  <div class="card" *ngIf="currentStep === 0">
+    <div class="card-header"><h2>Sport &amp; Type</h2></div>
+    <div class="card-body">
+      <select formControlName="sport">
+        <option value="" disabled>Select sport</option>
+        <option *ngFor="let s of sports" [value]="s">{{ s }}</option>
+      </select>
+      <select formControlName="type">
+        <option *ngFor="let t of types" [value]="t">{{ t }}</option>
+      </select>
+    </div>
+  </div>
+
+  <!-- Details -->
+  <div class="card" *ngIf="currentStep === 1">
+    <div class="card-header"><h2>Details</h2></div>
+    <div class="card-body">
+      <input type="text" formControlName="name" placeholder="Course name" />
+      <textarea formControlName="description" placeholder="Description"></textarea>
+      <label>
+        <input type="checkbox" formControlName="flexible" /> Flexible
+      </label>
+    </div>
+  </div>
+
+  <!-- Dates -->
+  <div class="card" *ngIf="currentStep === 2">
+    <div class="card-header"><h2>Dates</h2></div>
+    <div class="card-body">
+      <input type="date" formControlName="date" />
+    </div>
+  </div>
+
+  <!-- Groups & Levels -->
+  <div
+    class="card"
+    *ngIf="currentStep === 3 && courseForm.get('type')!.value === 'collective'"
+  >
+    <div class="card-header"><h2>Groups &amp; Levels</h2></div>
+    <div class="card-body">
+      <input
+        type="number"
+        formControlName="groupSize"
+        placeholder="Group size"
+      />
+      <select formControlName="level">
+        <option value="" disabled>Select level</option>
+        <option *ngFor="let level of levels" [value]="level">{{ level }}</option>
+      </select>
+    </div>
+  </div>
+
+  <!-- Extras -->
+  <div class="card" *ngIf="currentStep === 4">
+    <div class="card-header"><h2>Extras</h2></div>
+    <div class="card-body" formArrayName="extras">
+      <label *ngFor="let extra of extras; let i = index">
+        <input type="checkbox" [formControlName]="i" /> {{ extra }}
+      </label>
+    </div>
+  </div>
+
+  <!-- Translations -->
+  <div class="card" *ngIf="currentStep === 5">
+    <div class="card-header"><h2>Translations</h2></div>
+    <div class="card-body">
+      <button type="button" class="btn" (click)="translate()">
+        Mock Deepl
+      </button>
+      <textarea
+        formControlName="translated"
+        placeholder="Translated description"
+      ></textarea>
+    </div>
+  </div>
+
+  <div class="actions">
+    <button type="button" class="btn" (click)="prevStep()" [disabled]="currentStep === 0">
+      Previous
+    </button>
+    <button
+      type="button"
+      class="btn"
+      (click)="nextStep()"
+      *ngIf="currentStep < lastStep"
+    >
+      Next
+    </button>
+    <button type="submit" class="btn" *ngIf="currentStep === lastStep">
+      Save
+    </button>
+  </div>
+</form>

--- a/front/src/app/features/courses/course-form.component.scss
+++ b/front/src/app/features/courses/course-form.component.scss
@@ -1,0 +1,35 @@
+.course-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.card-header {
+  padding: var(--space-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.card-body {
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--space-md);
+}

--- a/front/src/app/features/courses/course-form.component.ts
+++ b/front/src/app/features/courses/course-form.component.ts
@@ -1,0 +1,145 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormArray,
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+
+@Component({
+  selector: 'app-course-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './course-form.component.html',
+  styleUrls: ['./course-form.component.scss'],
+})
+export class CourseFormComponent {
+  private readonly fb = inject(FormBuilder);
+
+  sports = ['Ski', 'Snowboard'];
+  types: Array<'collective' | 'private'> = ['collective', 'private'];
+  levels = ['Beginner', 'Intermediate', 'Advanced'];
+  extras = ['Equipment', 'Insurance', 'Lunch'];
+
+  currentStep = 0;
+  lastStep = 5;
+
+  courseForm = this.fb.group({
+    sport: ['', Validators.required],
+    type: ['collective', Validators.required],
+    name: ['', Validators.required],
+    description: ['', Validators.required],
+    flexible: [false],
+    date: ['', Validators.required],
+    groupSize: [null],
+    level: [''],
+    extras: this.fb.array(this.extras.map(() => this.fb.control(false))),
+    translated: [''],
+  });
+
+  constructor() {
+    this.courseForm
+      .get('type')!
+      .valueChanges.subscribe((t: 'collective' | 'private') => {
+        const groupSize = this.courseForm.get('groupSize')!;
+        const level = this.courseForm.get('level')!;
+        if (t === 'collective') {
+          groupSize.addValidators(Validators.required);
+          level.addValidators(Validators.required);
+        } else {
+          groupSize.clearValidators();
+          level.clearValidators();
+          groupSize.reset();
+          level.reset();
+        }
+        groupSize.updateValueAndValidity();
+        level.updateValueAndValidity();
+      });
+  }
+
+  get extrasArray(): FormArray {
+    return this.courseForm.get('extras') as FormArray;
+  }
+
+  nextStep(): void {
+    if (!this.isStepValid(this.currentStep)) {
+      this.markStepTouched(this.currentStep);
+      return;
+    }
+    this.currentStep++;
+    if (
+      this.currentStep === 3 &&
+      this.courseForm.get('type')!.value !== 'collective'
+    ) {
+      this.currentStep++;
+    }
+  }
+
+  prevStep(): void {
+    this.currentStep--;
+    if (
+      this.currentStep === 3 &&
+      this.courseForm.get('type')!.value !== 'collective'
+    ) {
+      this.currentStep--;
+    }
+  }
+
+  isStepValid(step: number): boolean {
+    switch (step) {
+      case 0:
+        return (
+          this.courseForm.get('sport')!.valid &&
+          this.courseForm.get('type')!.valid
+        );
+      case 1:
+        return (
+          this.courseForm.get('name')!.valid &&
+          this.courseForm.get('description')!.valid
+        );
+      case 2:
+        return this.courseForm.get('date')!.valid;
+      case 3:
+        if (this.courseForm.get('type')!.value !== 'collective') {
+          return true;
+        }
+        return (
+          this.courseForm.get('groupSize')!.valid &&
+          this.courseForm.get('level')!.valid
+        );
+      default:
+        return true;
+    }
+  }
+
+  markStepTouched(step: number): void {
+    const controls = this.getStepControls(step);
+    controls.forEach((name) => this.courseForm.get(name)?.markAsTouched());
+  }
+
+  getStepControls(step: number): string[] {
+    switch (step) {
+      case 0:
+        return ['sport', 'type'];
+      case 1:
+        return ['name', 'description'];
+      case 2:
+        return ['date'];
+      case 3:
+        return ['groupSize', 'level'];
+      default:
+        return [];
+    }
+  }
+
+  translate(): void {
+    const desc = this.courseForm.get('description')!.value;
+    this.courseForm.get('translated')!.setValue(desc);
+  }
+
+  save(): void {
+    console.log(this.courseForm.value);
+  }
+}
+


### PR DESCRIPTION
## Summary
- build multi-step course form with sport, details, dates, groups, extras and translation mock
- add navigation/validation between steps and simple save handler
- register `/courses/new` and `/courses/:id/edit` routes for the new form

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' and many missing matcher errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc7d051208320adbb886418ed014e