### PR TITLE
feat: add client profile component

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -89,6 +89,13 @@ export const routes: Routes = [
               import('./features/clients/client-form.page').then((c) => c.ClientFormPage),
           },
           {
+            path: ':id/profile',
+            loadComponent: () =>
+              import('./features/clients/client-profile/client-profile.component').then(
+                (c) => c.ClientProfileComponent
+              ),
+          },
+          {
             path: ':id',
             loadComponent: () =>
               import('./features/clients/client-detail.page').then(

--- a/front/src/app/features/clients/client-profile/client-profile.component.html
+++ b/front/src/app/features/clients/client-profile/client-profile.component.html
@@ -1,0 +1,75 @@
+<div class="client-profile">
+  <h2>Client Profile</h2>
+
+  <div class="view-toggle">
+    <button (click)="switchMode('client')" [class.active]="viewMode() === 'client'">
+      Client
+    </button>
+    <button (click)="switchMode('utilizer')" [class.active]="viewMode() === 'utilizer'">
+      Utilizer
+    </button>
+  </div>
+
+  <form [formGroup]="personalForm" class="personal-form">
+    <label>
+      First name
+      <input type="text" formControlName="first_name" />
+    </label>
+    <label>
+      Last name
+      <input type="text" formControlName="last_name" />
+    </label>
+    <label>
+      Email
+      <input type="email" formControlName="email" />
+    </label>
+  </form>
+
+  <div class="tabs">
+    <button (click)="switchTab('sport')" [class.active]="activeTab() === 'sport'">
+      Sport progress
+    </button>
+    <button
+      (click)="switchTab('evaluations')"
+      [class.active]="activeTab() === 'evaluations'"
+    >
+      Evaluations
+    </button>
+  </div>
+
+  <div *ngIf="activeTab() === 'sport'" class="tab-content">
+    <ul>
+      <li *ngFor="let item of sportProgress">
+        {{ item.sport }} - {{ item.level }}
+      </li>
+    </ul>
+  </div>
+
+  <div *ngIf="activeTab() === 'evaluations'" class="tab-content">
+    <ul>
+      <li *ngFor="let item of evaluations">
+        {{ item.date }} - {{ item.result }}
+      </li>
+    </ul>
+  </div>
+
+  <h3>Booking history</h3>
+  <table class="booking-history">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Service</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let booking of bookingHistory">
+        <td>{{ booking.date }}</td>
+        <td>{{ booking.service }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="actions">
+    <button (click)="newBooking()">New booking</button>
+  </div>
+</div>

--- a/front/src/app/features/clients/client-profile/client-profile.component.scss
+++ b/front/src/app/features/clients/client-profile/client-profile.component.scss
@@ -1,0 +1,36 @@
+.client-profile {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.view-toggle button,
+.tabs button {
+  margin-right: 0.5rem;
+}
+
+.view-toggle button.active,
+.tabs button.active {
+  font-weight: bold;
+}
+
+.personal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.booking-history {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.booking-history th,
+.booking-history td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+}
+
+.actions {
+  margin-top: 1rem;
+}

--- a/front/src/app/features/clients/client-profile/client-profile.component.ts
+++ b/front/src/app/features/clients/client-profile/client-profile.component.ts
@@ -1,0 +1,78 @@
+import { Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+
+interface SportProgressItem {
+  sport: string;
+  level: string;
+}
+
+interface EvaluationItem {
+  date: string;
+  result: string;
+}
+
+interface BookingHistoryItem {
+  id: number;
+  date: string;
+  service: string;
+}
+
+@Component({
+  selector: 'app-client-profile',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './client-profile.component.html',
+  styleUrls: ['./client-profile.component.scss'],
+})
+export class ClientProfileComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly router = inject(Router);
+
+  viewMode = signal<'client' | 'utilizer'>('client');
+  activeTab = signal<'sport' | 'evaluations'>('sport');
+
+  currentClient = {
+    id: 1,
+    first_name: 'Alice',
+    last_name: 'Johnson',
+    email: 'alice@example.com',
+  };
+
+  personalForm: FormGroup = this.fb.group({
+    first_name: [this.currentClient.first_name],
+    last_name: [this.currentClient.last_name],
+    email: [this.currentClient.email],
+  });
+
+  sportProgress: SportProgressItem[] = [
+    { sport: 'Ski', level: 'Intermediate' },
+    { sport: 'Snowboard', level: 'Beginner' },
+  ];
+
+  evaluations: EvaluationItem[] = [
+    { date: '2024-01-01', result: 'Good' },
+    { date: '2024-02-15', result: 'Excellent' },
+  ];
+
+  bookingHistory: BookingHistoryItem[] = [
+    { id: 1, date: '2024-03-01', service: 'Ski lesson' },
+    { id: 2, date: '2024-04-10', service: 'Snowboard session' },
+  ];
+
+  switchMode(mode: 'client' | 'utilizer'): void {
+    this.viewMode.set(mode);
+  }
+
+  switchTab(tab: 'sport' | 'evaluations'): void {
+    this.activeTab.set(tab);
+  }
+
+  newBooking(): void {
+    this.router.navigate(['/reservations/new'], {
+      queryParams: { clientId: this.currentClient.id },
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add client profile page with mock personal data, sport progress, evaluations, and booking history
- enable navigating to client profiles via new route

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' and other assertion mismatches)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc68e31948320baf112c32f7dbcba