### PR TITLE
fix: prioritize client profile route

### DIFF
--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -84,16 +84,16 @@ export const routes: Routes = [
               import('./features/clients/client-form.page').then((c) => c.ClientFormPage),
           },
           {
-            path: ':id/edit',
-            loadComponent: () =>
-              import('./features/clients/client-form.page').then((c) => c.ClientFormPage),
-          },
-          {
             path: ':id/profile',
             loadComponent: () =>
               import('./features/clients/client-profile/client-profile.component').then(
                 (c) => c.ClientProfileComponent
               ),
+          },
+          {
+            path: ':id/edit',
+            loadComponent: () =>
+              import('./features/clients/client-form.page').then((c) => c.ClientFormPage),
           },
           {
             path: ':id',


### PR DESCRIPTION
## Summary
- ensure client profile route matches before `:id/edit` and `:id`
- confirm client list rows navigate to profile view

## Testing
- `npm test` *(fails: Test Suites: 17 failed, 8 passed, 25 total)*

------
https://chatgpt.com/codex/tasks/task_e_68adc966a1d08320a6020780d15e6d43