### PR TITLE
feat(reservations): add routes for new and edit

### DIFF
--- a/front/src/app/features/reservations/reservations-list/reservations-list.component.html
+++ b/front/src/app/features/reservations/reservations-list/reservations-list.component.html
@@ -1,3 +1,7 @@
+<div class="actions">
+  <button mat-raised-button color="primary" routerLink="new">New Reservation</button>
+</div>
+
 <div class="filters">
   <mat-form-field>
     <mat-label>Reservation Type</mat-label>
@@ -68,6 +72,7 @@
     <th mat-header-cell *matHeaderCellDef> Actions </th>
     <td mat-cell *matCellDef="let r">
       <button mat-button (click)="openDetail(r); $event.stopPropagation()">View</button>
+      <button mat-button [routerLink]="[r.id, 'edit']" (click)="$event.stopPropagation()">Edit</button>
     </td>
   </ng-container>
 

--- a/front/src/app/features/reservations/reservations-list/reservations-list.component.ts
+++ b/front/src/app/features/reservations/reservations-list/reservations-list.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatTableModule } from '@angular/material/table';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -16,6 +17,7 @@ import { ReservationDetailComponent } from '../reservation-detail.component';
   standalone: true,
   imports: [
     CommonModule,
+    RouterModule,
     FormsModule,
     MatTabsModule,
     MatTableModule,

--- a/front/src/app/features/reservations/reservations.module.ts
+++ b/front/src/app/features/reservations/reservations.module.ts
@@ -5,7 +5,8 @@ import { ReservationFormComponent } from './reservation-form/reservation-form.co
 
 const routes: Routes = [
   { path: '', component: ReservationsListComponent },
-  { path: 'new', component: ReservationFormComponent }
+  { path: 'new', component: ReservationFormComponent },
+  { path: ':id/edit', component: ReservationFormComponent }
 ];
 
 @NgModule({


### PR DESCRIPTION
## Summary
- add routes for creating and editing reservations
- include router link helpers in reservations list
- allow list component to use RouterModule

## Testing
- `npm test` *(fails: Test Suites: 18 failed, 7 passed, 25 total)*

------
https://chatgpt.com/codex/tasks/task_e_68adc9280fac83209733ed2f86d1dd28