### PR TITLE
feat(courses): redesign management screen with Boukii design

### DIFF
--- a/front/src/app/features/courses/courses-list.component.html
+++ b/front/src/app/features/courses/courses-list.component.html
@@ -1,60 +1,215 @@
-<div class="page">
-  <div class="page-header">
-    <h1>{{ 'courses.title' | translate }}</h1>
-  </div>
-
-  <div class="tabs row gap">
-    <button
-      type="button"
-      class="btn"
-      *ngFor="let tab of statusTabs"
-      [class.active]="selectedTab === tab"
-      (click)="selectTab(tab)"
-    >
-      {{ ('courses.tabs.' + tab) | translate }}
-    </button>
-  </div>
-
-  <form [formGroup]="filtersForm" class="filters row gap">
-    <input type="text" formControlName="search" [placeholder]="'courses.search' | translate" />
-    <input type="text" formControlName="sport" [placeholder]="'courses.sport' | translate" />
-    <select formControlName="type">
-      <option value="">{{ 'common.all' | translate }}</option>
-      <option value="collective">{{ 'courses.type.collective' | translate }}</option>
-      <option value="private">{{ 'courses.type.private' | translate }}</option>
-    </select>
-  </form>
-
-  <table>
-    <thead>
-      <tr>
-        <th>{{ 'courses.table.name' | translate }}</th>
-        <th>{{ 'courses.table.sport' | translate }}</th>
-        <th>{{ 'courses.table.type' | translate }}</th>
-        <th>{{ 'courses.table.level' | translate }}</th>
-        <th>{{ 'courses.table.status' | translate }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let course of filteredCourses" (click)="openCourse(course)" tabindex="0">
-        <td>{{ course.name }}</td>
-        <td>{{ course.sport }}</td>
-        <td>{{ course.type }}</td>
-        <td>{{ course.level }}</td>
-        <td>{{ course.status }}</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <div class="preview-overlay" *ngIf="selectedCourse" (click)="closeCourse()">
-    <div class="preview-drawer" (click)="$event.stopPropagation()">
-      <h2>{{ selectedCourse.name }}</h2>
-      <p>{{ selectedCourse.description }}</p>
-      <p><strong>{{ 'courses.table.sport' | translate }}:</strong> {{ selectedCourse.sport }}</p>
-      <p><strong>{{ 'courses.table.type' | translate }}:</strong> {{ selectedCourse.type }}</p>
-      <p><strong>{{ 'courses.table.level' | translate }}:</strong> {{ selectedCourse.level }}</p>
-      <p><strong>{{ 'courses.table.status' | translate }}:</strong> {{ selectedCourse.status }}</p>
-      <button class="btn" type="button" (click)="closeCourse()">{{ 'common.close' | translate }}</button>
+<div class="courses-page">
+  <!-- Header -->
+  <header class="page-header">
+    <div class="header-content">
+      <h1 class="page-title">
+        <svg class="title-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+          <path d="M6.5 2H20v15H6.5A2.5 2.5 0 0 0 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+        </svg>
+        Gestión de Cursos
+      </h1>
+      <p class="page-subtitle">Administra los cursos y programas de formación</p>
     </div>
-  </div>
+    <div class="header-actions">
+      <button class="action-btn action-btn--secondary" (click)="exportCourses()">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+          <polyline points="14,2 14,8 20,8"></polyline>
+          <line x1="16" y1="13" x2="8" y2="13"></line>
+          <line x1="16" y1="17" x2="8" y2="17"></line>
+        </svg>
+        Exportar Lista
+      </button>
+      <button class="action-btn action-btn--primary" (click)="createCourse()">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M12 5v14"></path>
+          <path d="M5 12h14"></path>
+        </svg>
+        Nuevo Curso
+      </button>
+    </div>
+  </header>
+
+  <!-- Filters -->
+  <section class="filters-section">
+    <div class="search-box">
+      <svg class="search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="11" cy="11" r="8"></circle>
+        <path d="m21 21-4.35-4.35"></path>
+      </svg>
+      <input
+        type="text"
+        class="search-input"
+        [formControl]="searchControl"
+        placeholder="Buscar curso..."
+      />
+    </div>
+
+    <div class="filter-controls">
+      <select class="filter-select" [(ngModel)]="typeFilter" (ngModelChange)="applyFilters()">
+        <option value="">Tipo</option>
+        <option value="ski">Esquí</option>
+        <option value="snow">Snow</option>
+      </select>
+
+      <select class="filter-select" [(ngModel)]="levelFilter" (ngModelChange)="applyFilters()">
+        <option value="">Nivel</option>
+        <option value="beginner">Principiante</option>
+        <option value="intermediate">Intermedio</option>
+        <option value="advanced">Avanzado</option>
+      </select>
+
+      <select class="filter-select" [(ngModel)]="statusFilter" (ngModelChange)="applyFilters()">
+        <option value="">Estado</option>
+        <option value="active">Activo</option>
+        <option value="paused">En pausa</option>
+        <option value="inactive">Inactivo</option>
+      </select>
+
+      <div class="view-toggle">
+        <button
+          class="toggle-btn"
+          [class.active]="viewMode === 'cards'"
+          (click)="viewMode = 'cards'"
+          title="Vista en tarjetas"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="3" y="3" width="7" height="7"></rect>
+            <rect x="14" y="3" width="7" height="7"></rect>
+            <rect x="14" y="14" width="7" height="7"></rect>
+            <rect x="3" y="14" width="7" height="7"></rect>
+          </svg>
+        </button>
+        <button
+          class="toggle-btn"
+          [class.active]="viewMode === 'table'"
+          (click)="viewMode = 'table'"
+          title="Vista en tabla"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="8" y1="6" x2="21" y2="6"></line>
+            <line x1="8" y1="12" x2="21" y2="12"></line>
+            <line x1="8" y1="18" x2="21" y2="18"></line>
+            <line x1="3" y1="6" x2="3.01" y2="6"></line>
+            <line x1="3" y1="12" x2="3.01" y2="12"></line>
+            <line x1="3" y1="18" x2="3.01" y2="18"></line>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Loading -->
+  <main class="loading-state" *ngIf="loading">
+    <div class="courses-grid">
+      <div class="course-card skeleton" *ngFor="let _ of skeletonCourses"></div>
+    </div>
+  </main>
+
+  <!-- Error -->
+  <main class="error-state" *ngIf="!loading && error">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="10"></circle>
+      <line x1="12" y1="8" x2="12" y2="12"></line>
+      <line x1="12" y1="16" x2="12" y2="16"></line>
+    </svg>
+    <p>{{ error }}</p>
+  </main>
+
+  <!-- Empty state -->
+  <main class="empty-state" *ngIf="!loading && !error && filteredCourses.length === 0">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+      <line x1="3" y1="9" x2="21" y2="9"></line>
+      <line x1="9" y1="21" x2="9" y2="9"></line>
+    </svg>
+    <p>No hay cursos disponibles</p>
+  </main>
+
+  <!-- Content -->
+  <main *ngIf="!loading && !error && filteredCourses.length > 0">
+    <!-- Cards View -->
+    <div class="courses-grid" *ngIf="viewMode === 'cards'">
+      <article class="course-card" *ngFor="let course of filteredCourses; trackBy: trackByCourseId">
+        <div class="course-visual">
+          <div class="course-icon" [attr.data-type]="course.type">
+            <svg *ngIf="course.type === 'ski'" width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M2 2h2v18L2 22l1-1v-1h1v-2H3V4h1V2H2zm18 0h2v2h-1v14h1v2h-1l-2-2V2zm-8 6l-2 2v6l2-2V8zm4 0v6l2 2V8l-2-2z"/>
+            </svg>
+            <svg *ngIf="course.type === 'snow'" width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C8 2 5 5 5 9v6c0 4 3 7 7 7s7-3 7-7V9c0-4-3-7-7-7zm3 13c0 1.7-1.3 3-3 3s-3-1.3-3-3V9c0-1.7 1.3-3 3-3s3 1.3 3 3v6z"/>
+            </svg>
+          </div>
+        </div>
+        <div class="course-info">
+          <h3 class="course-name">{{ course.name }}</h3>
+          <span class="level-badge" [ngClass]="getLevelClass(course.level)">{{ getLevelLabel(course.level) }}</span>
+          <div class="course-meta">
+            <span class="course-price">{{ course.price | currency:'EUR':'symbol':'1.0-0' }}/persona</span>
+            <span class="course-duration">{{ course.duration }}</span>
+          </div>
+          <div class="course-monitor">Monitor: {{ course.instructor }}</div>
+          <div class="course-status" [ngClass]="getStatusClass(course.status)">{{ getStatusLabel(course.status) }}</div>
+        </div>
+        <div class="course-actions">
+          <button class="action-button action-button--primary" (click)="viewDetails(course)">Ver Detalles</button>
+          <button class="action-button action-button--secondary" (click)="editCourse(course)">Editar</button>
+          <button class="action-button action-button--secondary" (click)="manageReservations(course)">Reservas</button>
+        </div>
+      </article>
+    </div>
+
+    <!-- Table View -->
+    <div class="courses-table-container" *ngIf="viewMode === 'table'">
+      <div class="table-wrapper">
+        <table class="courses-table">
+          <thead>
+            <tr>
+              <th>Curso</th>
+              <th>Nivel</th>
+              <th>Precio</th>
+              <th>Monitor</th>
+              <th>Capacidad</th>
+              <th>Reservas</th>
+              <th>Estado</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let course of filteredCourses; trackBy: trackByCourseId" class="table-row">
+              <td class="course-cell">
+                <div class="course-summary">
+                  <div class="course-icon-small" [attr.data-type]="course.type">
+                    <svg *ngIf="course.type === 'ski'" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M2 2h2v18L2 22l1-1v-1h1v-2H3V4h1V2H2zm18 0h2v2h-1v14h1v2h-1l-2-2V2zm-8 6l-2 2v6l2-2V8zm4 0v6l2 2V8l-2-2z"/>
+                    </svg>
+                    <svg *ngIf="course.type === 'snow'" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M12 2C8 2 5 5 5 9v6c0 4 3 7 7 7s7-3 7-7V9c0-4-3-7-7-7zm3 13c0 1.7-1.3 3-3 3s-3-1.3-3-3V9c0-1.7 1.3-3 3-3s3 1.3 3 3v6z"/>
+                    </svg>
+                  </div>
+                  <div class="course-basic-info">
+                    <span class="course-name-table">{{ course.name }}</span>
+                    <span class="course-type-table">{{ getTypeLabel(course.type) }}</span>
+                  </div>
+                </div>
+              </td>
+              <td><span class="level-badge" [ngClass]="getLevelClass(course.level)">{{ getLevelLabel(course.level) }}</span></td>
+              <td>{{ course.price | currency:'EUR':'symbol':'1.0-0' }}</td>
+              <td>{{ course.instructor }}</td>
+              <td>{{ course.capacity }}</td>
+              <td>{{ course.reservations }}</td>
+              <td><span class="course-status" [ngClass]="getStatusClass(course.status)">{{ getStatusLabel(course.status) }}</span></td>
+              <td class="actions-cell">
+                <button class="action-button action-button--primary" (click)="viewDetails(course)">Detalles</button>
+                <button class="action-button action-button--secondary" (click)="editCourse(course)">Editar</button>
+                <button class="action-button action-button--secondary" (click)="manageReservations(course)">Reservas</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </main>
 </div>
+

--- a/front/src/app/features/courses/courses-list.component.scss
+++ b/front/src/app/features/courses/courses-list.component.scss
@@ -1,48 +1,441 @@
-@import '../../../styles/tokens.css';
-
-.page {
-  padding: var(--space-4);
+// Professional Courses Management Styles
+.courses-page {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
+// Header
 .page-header {
-  margin-bottom: var(--space-4);
+  background: white;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 2rem 2.5rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+
+  .header-content {
+    flex: 1;
+
+    .page-title {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 2rem;
+      font-weight: 700;
+      color: #1e293b;
+      margin: 0 0 0.5rem 0;
+
+      .title-icon {
+        color: #3b82f6;
+        width: 32px;
+        height: 32px;
+      }
+    }
+
+    .page-subtitle {
+      color: #64748b;
+      font-size: 1.1rem;
+      margin: 0;
+      font-weight: 400;
+    }
+  }
+
+  .header-actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
 }
 
-.tabs {
-  margin-bottom: var(--space-4);
+.action-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+  border: none;
+  cursor: pointer;
+
+  &--primary {
+    background: linear-gradient(135deg, #3b82f6, #2563eb);
+    color: white;
+    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.3);
+
+    &:hover {
+      box-shadow: 0 6px 12px -1px rgba(59, 130, 246, 0.4);
+      transform: translateY(-1px);
+    }
+  }
+
+  &--secondary {
+    background: white;
+    color: #475569;
+    border: 1px solid #d1d5db;
+
+    &:hover {
+      background: #f8fafc;
+      border-color: #9ca3af;
+      transform: translateY(-1px);
+    }
+  }
 }
 
-.filters {
-  margin-bottom: var(--space-4);
+// Filters
+.filters-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 2.5rem;
+  margin-bottom: 2rem;
+  gap: 2rem;
+  flex-wrap: wrap;
 }
 
-table {
-  width: 100%;
+.search-box {
+  position: relative;
+  flex: 1;
+  max-width: 400px;
+
+  .search-icon {
+    position: absolute;
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #9ca3af;
+    pointer-events: none;
+  }
+
+  .search-input {
+    width: 100%;
+    padding: 0.75rem 1rem 0.75rem 3rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    background: white;
+    transition: all 0.2s ease;
+
+    &:focus {
+      outline: none;
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+
+    &::placeholder {
+      color: #9ca3af;
+    }
+  }
 }
 
-th,
-td {
-  padding: var(--space-2);
-  text-align: left;
+.filter-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
-.tabs .btn.active {
-  font-weight: bold;
-  text-decoration: underline;
+.filter-select {
+  padding: 0.5rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: white;
+  color: #475569;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
 }
 
-.preview-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+.view-toggle {
+  display: flex;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.toggle-btn {
+  padding: 0.5rem;
+  border: none;
+  background: transparent;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &:hover {
+    background: #f8fafc;
+  }
+
+  &.active {
+    background: #3b82f6;
+    color: white;
+  }
 }
 
-.preview-drawer {
-  background: var(--color-background);
-  padding: var(--space-4);
-  max-width: 400px;
-  width: 100%;
+// States
+.loading-state,
+.empty-state,
+.error-state {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: #64748b;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
 }
+
+.loading-state .course-card.skeleton {
+  height: 220px;
+  border-radius: 1rem;
+  background: linear-gradient(90deg, #e2e8f0 25%, #f8fafc 50%, #e2e8f0 75%);
+  background-size: 400% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+// Cards view
+.courses-grid {
+  padding: 0 2.5rem 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 1.5rem;
+}
+
+.course-card {
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.course-visual {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f1f5f9;
+  border-radius: 0.5rem;
+  height: 100px;
+}
+
+.course-icon[data-type='ski'] {
+  color: #3b82f6;
+}
+
+.course-icon[data-type='snow'] {
+  color: #8b5cf6;
+}
+
+.course-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.course-name {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0;
+}
+
+.level-badge {
+  align-self: flex-start;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+
+  &.badge--beginner {
+    background: #dbeafe;
+    color: #1e3a8a;
+  }
+
+  &.badge--intermediate {
+    background: #fef3c7;
+    color: #92400e;
+  }
+
+  &.badge--advanced {
+    background: #ede9fe;
+    color: #5b21b6;
+  }
+}
+
+.course-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.course-monitor {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.course-status {
+  margin-top: auto;
+  align-self: flex-start;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+
+  &.status--active {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  &.status--paused {
+    background: #fef3c7;
+    color: #92400e;
+  }
+
+  &.status--inactive {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+}
+
+.course-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.action-button {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &--primary {
+    background: linear-gradient(135deg, #3b82f6, #2563eb);
+    color: white;
+
+    &:hover {
+      box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.4);
+      transform: translateY(-1px);
+    }
+  }
+
+  &--secondary {
+    background: white;
+    color: #475569;
+    border: 1px solid #d1d5db;
+
+    &:hover {
+      background: #f8fafc;
+      border-color: #9ca3af;
+      transform: translateY(-1px);
+    }
+  }
+}
+
+// Table view
+.courses-table-container {
+  padding: 0 2.5rem 2.5rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  background: white;
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.courses-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  thead {
+    background: #f1f5f9;
+  }
+
+  th,
+  td {
+    padding: 1rem 1.25rem;
+    text-align: left;
+    font-size: 0.9rem;
+    color: #475569;
+  }
+
+  tbody tr:nth-child(even) {
+    background: #f8fafc;
+  }
+}
+
+.course-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.course-icon-small {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f1f5f9;
+  border-radius: 0.5rem;
+
+  &[data-type='ski'] {
+    color: #3b82f6;
+  }
+
+  &[data-type='snow'] {
+    color: #8b5cf6;
+  }
+}
+
+.course-basic-info {
+  display: flex;
+  flex-direction: column;
+  .course-name-table {
+    font-weight: 600;
+    color: #1e293b;
+  }
+  .course-type-table {
+    font-size: 0.75rem;
+    color: #64748b;
+  }
+}
+
+.actions-cell {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+


### PR DESCRIPTION
## Summary
- redesign courses management page with professional Boukii header, filters and actions
- add card and table views with level and status badges
- style course statuses and levels with design system colors

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68addc0b551c8320a38dfd0f59211220