### PR TITLE
refactor: apply ski palette and layout tokens

### DIFF
--- a/front/src/app/ui/app-shell/app-shell.component.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.ts
@@ -310,7 +310,7 @@ interface Notification {
           <a 
             routerLink="/dashboard" 
             routerLinkActive="active" 
-            class="nav-item item" 
+            class="nav-item" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.dashboard') : null"
           >
@@ -327,7 +327,7 @@ interface Notification {
           <a 
             routerLink="/reservations" 
             routerLinkActive="active" 
-            class="nav-item item" 
+            class="nav-item" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.reservas') : null"
           >
@@ -345,7 +345,7 @@ interface Notification {
           <a
             routerLink="/clients"
             routerLinkActive="active"
-            class="nav-item item"
+            class="nav-item"
             role="menuitem"
             [title]="ui.sidebarCollapsed() ? ('nav.clientes' | translate) : null"
           >
@@ -362,7 +362,7 @@ interface Notification {
           <a 
             routerLink="/scheduling" 
             routerLinkActive="active" 
-            class="nav-item item" 
+            class="nav-item" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.planificador') : null"
           >
@@ -379,7 +379,7 @@ interface Notification {
           <a 
             routerLink="/monitors" 
             routerLinkActive="active" 
-            class="nav-item item" 
+            class="nav-item" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.instructores') : null"
           >
@@ -396,7 +396,7 @@ interface Notification {
           <a 
             routerLink="/courses" 
             routerLinkActive="active" 
-            class="nav-item item" 
+            class="nav-item" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.cursos') : null"
           >
@@ -413,7 +413,7 @@ interface Notification {
           <a
             routerLink="/renting"
             routerLinkActive="active"
-            class="nav-item item"
+            class="nav-item"
             role="menuitem"
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.material') : null"
           >
@@ -430,7 +430,7 @@ interface Notification {
           <a
             routerLink="/vouchers"
             routerLinkActive="active"
-            class="nav-item item"
+            class="nav-item"
             role="menuitem"
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.bonos') : null"
           >
@@ -446,7 +446,7 @@ interface Notification {
           <!-- Comunicación -->
             <a routerLink="/communications"
                routerLinkActive="active"
-               class="nav-item item"
+               class="nav-item"
                [title]="ui.sidebarCollapsed() ? translationService.instant('nav.comunicacion') : null">
               <div class="nav-icon">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -461,7 +461,7 @@ interface Notification {
           <a 
             routerLink="/chat" 
             routerLinkActive="active" 
-            class="nav-item item" 
+            class="nav-item" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.chat') : null"
           >
@@ -477,7 +477,7 @@ interface Notification {
           <!-- Pagos -->
           <a 
             href="#" 
-            class="nav-item item disabled" 
+            class="nav-item disabled" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? (translationService.instant('nav.pagos') + ' (Próximamente)') : null"
           >
@@ -494,7 +494,7 @@ interface Notification {
           <a 
             routerLink="/statistics" 
             routerLinkActive="active" 
-            class="nav-item item" 
+            class="nav-item" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? translationService.instant('nav.reportes') : null"
           >
@@ -510,7 +510,7 @@ interface Notification {
           <!-- Notificaciones -->
           <a 
             href="#" 
-            class="nav-item item disabled" 
+            class="nav-item disabled" 
             role="menuitem" 
             [title]="ui.sidebarCollapsed() ? (translationService.instant('nav.notifications') + ' (Próximamente)') : null"
           >
@@ -527,7 +527,7 @@ interface Notification {
             <a
               routerLink="/settings"
               routerLinkActive="active"
-              class="nav-item item"
+              class="nav-item"
               role="menuitem"
               [title]="ui.sidebarCollapsed() ? translationService.instant('nav.config') : null"
             >

--- a/front/src/app/ui/app-shell/app-shell.styles.scss
+++ b/front/src/app/ui/app-shell/app-shell.styles.scss
@@ -8,9 +8,20 @@
    --sidebar-w: 264px;
    --sidebar-w-collapsed: 72px;
    --bg, --surface, --surface-2, --border, --text-1, --muted,
-   --brand-500, --brand-600, --active, --active-contrast,
-   --red, --yellow, --blue, --green
+   --ski-accent, --ski-accent-hover, --ski-accent-light,
+   --ski-blue, --ski-green, --ski-yellow, --ski-red
 */
+
+:root {
+  --navbar-h: 56px;
+  --sidebar-w: 264px;
+  --sidebar-w-collapsed: 72px;
+
+  /* accent palette */
+  --ski-accent: var(--color-ski-blue);
+  --ski-accent-hover: color-mix(in srgb, var(--color-ski-blue) 90%, var(--color-background));
+  --ski-accent-light: color-mix(in srgb, var(--color-ski-blue) 15%, var(--color-background));
+}
 
 /* === utils (deben ir antes de usarse) === */
 @mixin icon-btn {
@@ -50,7 +61,7 @@
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
-  gap: var(--space-3, 12px);
+  gap: 16px;
   padding-inline: 16px;
   z-index: var(--z-navbar);
 }
@@ -66,8 +77,11 @@
   justify-content: center;
   color: var(--text-1);
   cursor: pointer;
-  transition: background-color 150ms;
-  &:hover { background-color: var(--surface-2); }
+  transition: background-color 150ms, color 150ms;
+  &:hover {
+    background-color: var(--ski-accent-light);
+    color: var(--ski-accent);
+  }
 }
 .collapse-icon {
   transition: transform 0.2s ease;
@@ -98,8 +112,12 @@
   padding: .4rem .8rem;
   border-radius: 6px;
   cursor: pointer;
-  &:hover, &.active {
-    background: var(--hover);
+  &:hover {
+    background: var(--ski-accent-light);
+  }
+  &.active {
+    background: var(--ski-accent);
+    color: var(--ski-accent-light);
   }
   img {
     width: 20px;
@@ -126,8 +144,8 @@
   &::placeholder { color: var(--muted); }
   &:focus {
     outline: none;
-    border-color: var(--brand-500);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand-500) 20%, transparent);
+    border-color: var(--ski-accent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--ski-accent) 20%, transparent);
   }
 }
 
@@ -179,8 +197,8 @@
   text-align: left; font-size: 13px; color: var(--text-1);
   cursor: pointer; transition: background-color 150ms;
   &:hover { background: var(--surface-2); }
-  &.active { background: color-mix(in srgb, var(--brand-500) 10%, transparent); color: var(--brand-600); }
-  &.danger { color: var(--red); }
+  &.active { background: var(--ski-accent); color: var(--ski-accent-light); }
+  &.danger { color: var(--color-ski-red); }
 }
 
 /* =============================================
@@ -205,7 +223,7 @@
 }
 .sidebar-logo { display: inline-flex; align-items: center; }
 .logo-text { font-size: 18px; font-weight: 700; color: var(--text-1); transition: opacity 180ms; }
-.logo-accent { color: var(--brand-600); }
+.logo-accent { color: var(--ski-accent); }
 
 .collapse {
   width: 32px; height: 32px; border: 0; background: transparent; border-radius: 6px;
@@ -229,18 +247,25 @@
 /* Sidebar Navigation */
 .sidebar-nav { flex: 1; padding: 12px 8px; overflow-y: auto; }
 .nav-item {
-  display: flex; align-items: center; gap: 12px;
-  height: 44px; padding: 0 12px; margin-bottom: 2px; border-radius: 12px;
+  display: flex; align-items: center; gap: 8px;
+  height: 40px; padding: 0 16px; margin-bottom: 2px; border-radius: 8px;
   color: var(--text-1); text-decoration: none; font-size: 14px; font-weight: 600;
   position: relative; transition: background-color 150ms, color 150ms;
-  &:hover:not(.active):not(.disabled) { background: var(--surface-2); }
-  
+  &:hover:not(.active):not(.disabled) {
+    background: var(--ski-accent-hover);
+    color: var(--ski-accent);
+  }
+
   &.disabled {
     opacity: 0.5;
     cursor: not-allowed;
     pointer-events: none;
   }
-  &.active { background: var(--active); color: var(--active-contrast); }
+  &.active {
+    background: var(--ski-accent);
+    color: var(--ski-accent-light);
+    .nav-icon { color: var(--ski-accent-light); }
+  }
 }
 .nav-icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
 .nav-text { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; transition: opacity 180ms; }
@@ -261,10 +286,10 @@
     content: attr(data-count);
   }
 }
-.badge--yellow { background: var(--yellow); color: var(--text-1); }
-.badge--blue   { background: var(--blue, var(--brand-500)); color: var(--active-contrast); }
-.badge--green  { background: var(--green); color: var(--active-contrast); }
-.badge--red    { background: var(--red); color: var(--active-contrast); }
+.badge--yellow { background: var(--color-ski-yellow); color: var(--color-text-primary); }
+.badge--blue   { background: var(--color-ski-blue); color: var(--color-background); }
+.badge--green  { background: var(--color-ski-green); color: var(--color-background); }
+.badge--red    { background: var(--color-ski-red); color: var(--color-background); }
 
 /* En colapsado: convertir en punto */
 .app-sidebar.collapsed .badge,
@@ -288,16 +313,16 @@
 .sidebar-support { margin-top: auto; padding: 12px 8px; border-top: 1px solid var(--border); }
 .support-content {
   display: flex; align-items: center; gap: 12px; padding: 8px 12px; border-radius: 8px;
-  background: color-mix(in srgb, var(--brand-500) 8%, transparent); position: relative;
+  background: color-mix(in srgb, var(--ski-accent) 8%, transparent); position: relative;
 }
 .support-icon { width: 20px; height: 20px; display: grid; place-items: center; flex-shrink: 0; }
 .support-text { flex: 1; transition: opacity 180ms; }
 .support-title { font-size: 13px; font-weight: 600; color: var(--text-1); line-height: 1.2; }
-.support-subtitle { font-size: 11px; color: var(--brand-600); margin-top: 1px; }
+.support-subtitle { font-size: 11px; color: var(--ski-accent); margin-top: 1px; }
 .support-btn {
   width: 24px; height: 24px; border: 0; background: transparent; border-radius: 4px;
   display: grid; place-items: center; cursor: pointer; transition: background-color 150ms; flex-shrink: 0;
-  &:hover { background: color-mix(in srgb, var(--brand-500) 15%, transparent); }
+  &:hover { background: color-mix(in srgb, var(--ski-accent) 15%, transparent); }
 }
 
 /* En colapsado: ocultar contenido y mostrar FAB opcional (si lo tienes) */
@@ -315,7 +340,7 @@
   display: grid; place-items: center; z-index: 100;
 }
 .loading-spinner {
-  width: 32px; height: 32px; border: 3px solid transparent; border-top-color: var(--brand-500);
+  width: 32px; height: 32px; border: 3px solid transparent; border-top-color: var(--ski-accent);
   border-radius: 50%; animation: spin 1s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
@@ -323,7 +348,7 @@
 /* Environment Badge */
 .env-badge {
   position: fixed; bottom: 16px; right: 16px; z-index: 50;
-  background: var(--yellow); color: var(--text-1); font: 700 10px/1 Inter;
+  background: var(--color-ski-yellow); color: var(--color-text-primary); font: 700 10px/1 Inter;
   padding: 4px 8px; border-radius: 4px; letter-spacing: .5px;
   box-shadow: var(--elev-1);
 }
@@ -388,7 +413,7 @@
     border: 1px solid var(--border, #e5e7eb);
     background: var(--surface, #fff);
   }
-  .collapse:focus-visible { outline: 2px solid var(--primary, #6366f1); outline-offset: 2px; }
+  .collapse:focus-visible { outline: 2px solid var(--ski-accent); outline-offset: 2px; }
 
   .chev { transition: transform .2s ease; }
   .chev.rot { transform: rotate(180deg); }
@@ -474,21 +499,21 @@
   width:100%; padding:.45rem .75rem; border-radius:8px;
 }
 .language-dropdown .dropdown-option img{ width:20px; height:20px; border-radius:50%; }
-.language-dropdown .dropdown-option:hover,
-.language-dropdown .dropdown-option.active{ background: var(--hover, #f3f4f6); }
+.language-dropdown .dropdown-option:hover{ background: var(--ski-accent-light); }
+.language-dropdown .dropdown-option.active{ background: var(--ski-accent); color: var(--ski-accent-light); }
 
 /* ===== NOTIFICACIONES (campana + badge + lista) ===== */
 .notifications-btn .badge{
   position:absolute; top:-6px; right:-6px;
   min-width: 18px; height: 18px; border-radius: 999px;
-  background:#ef4444; box-shadow: 0 0 0 2px var(--surface-elev);
+  background:var(--color-ski-red); box-shadow: 0 0 0 2px var(--surface-elev);
 }
 .notifications-btn .badge::after{
   content: attr(data-count);
-  display:block; text-align:center; color:#fff;
+  display:block; text-align:center; color:var(--color-background);
   font: 700 11px/18px ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto;
 }
-.badge--red{ background: #ef4444; }
+.badge--red{ background: var(--color-ski-red); }
 
 .notifications-list{ display:grid; gap:.5rem; padding:.5rem; }
 .notification-item{
@@ -496,9 +521,9 @@
   padding:.5rem; border-radius:10px;
 }
 .notification-item.unread{ background: var(--hover, #f9fafb); }
-.notification-icon{ display:grid; place-items:center; width:24px; height:24px; border-radius:8px; color:#6b7280; }
-.notification-time{ font-size:12px; color:#6b7280; }
-.unread-indicator{ width:8px; height:8px; border-radius:999px; background:#ef4444; align-self:center; }
+.notification-icon{ display:grid; place-items:center; width:24px; height:24px; border-radius:8px; color:var(--color-text-secondary); }
+.notification-time{ font-size:12px; color:var(--color-text-secondary); }
+.unread-indicator{ width:8px; height:8px; border-radius:999px; background:var(--color-ski-red); align-self:center; }
 
 /* ===== MENÚ DE USUARIO ===== */
 .user-trigger{
@@ -509,21 +534,21 @@
 .user-trigger .user-avatar{ width:24px; height:24px; border-radius:50%; object-fit:cover; }
 .user-trigger .user-info{ display:flex; flex-direction:column; line-height:1.05; }
 .user-trigger .user-name{ font-weight:600; font-size:12px; }
-.user-trigger .user-role{ font-size:11px; color:#6b7280; }
+.user-trigger .user-role{ font-size:11px; color:var(--color-text-secondary); }
 
 .user-dropdown{ min-width: 320px; }
 .user-dropdown-header{ display:flex; gap:.75rem; padding:.75rem; }
 .user-avatar-large{ width:56px; height:56px; border-radius:14px; object-fit:cover; }
 .user-name-large{ margin:0; font-size:14px; font-weight:700; }
-.user-email{ margin:0; font-size:12px; color:#6b7280; }
-.user-role-badge{ font-size:11px; background:#eef2ff; color:#4338ca; padding:.15rem .4rem; border-radius:999px; }
+.user-email{ margin:0; font-size:12px; color:var(--color-text-secondary); }
+.user-role-badge{ font-size:11px; background:var(--ski-accent-light); color:var(--ski-accent); padding:.15rem .4rem; border-radius:999px; }
 .dropdown-divider{ height:1px; background: var(--border, #e5e7eb); margin:.25rem 0; }
 .user-dropdown .dropdown-option{
   width:100%; display:flex; align-items:center; gap:.5rem;
   padding:.6rem .75rem; border-radius:10px; background:transparent; border:none; text-align:left;
 }
-.user-dropdown .dropdown-option:hover{ background: var(--hover, #f3f4f6); }
-.user-dropdown .dropdown-option.danger{ color:#b91c1c; }
+.user-dropdown .dropdown-option:hover{ background: var(--ski-accent-light); }
+.user-dropdown .dropdown-option.danger{ color:var(--color-ski-red); }
 .user-dropdown .loading-spinner{ animation: spin 1s linear infinite; }
 @keyframes spin{ to{ transform: rotate(360deg); } }
 
@@ -541,15 +566,12 @@
 .badge.counter{
   min-width: 20px; height: 20px; padding: 0 6px;
   border-radius: 999px; display:inline-grid; place-items:center;
-  font: 700 11px/20px ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto; color:#fff;
+  font: 700 11px/20px ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto; color:var(--color-background);
 }
-.counter--blue{background:#2563eb;} .counter--green{background:#16a34a;}
-.counter--yellow{background:#ca8a04;} .counter--red{background:#dc2626;}
-
-:root[data-theme="dark"] .counter--blue{background:#3b82f6;}
-:root[data-theme="dark"] .counter--green{background:#22c55e;}
-:root[data-theme="dark"] .counter--yellow{background:#eab308;}
-:root[data-theme="dark"] .counter--red{background:#ef4444;}
+.counter--blue{background:var(--color-ski-blue);}
+.counter--green{background:var(--color-ski-green);}
+.counter--yellow{background:var(--color-ski-yellow);}
+.counter--red{background:var(--color-ski-red);}
 
 .app-sidebar .collapse { @include icon-btn(); width: 32px; height: 32px; }
 .app-sidebar .collapse .chev{
@@ -560,8 +582,8 @@
 }
 .app-sidebar.collapsed .collapse .chev { transform: rotate(180deg); }
 
-.app-sidebar .collapse:hover { background: var(--color-background); }
-.app-sidebar .collapse:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+.app-sidebar .collapse:hover { background: var(--ski-accent-light); }
+.app-sidebar .collapse:focus-visible { outline: 2px solid var(--ski-accent); outline-offset: 2px; }
 
 /* dark: evita que se “pierda” */
 :root[data-theme="dark"] .app-sidebar .collapse{


### PR DESCRIPTION
## Summary
- define navbar/sidebars dimensions and ski accent variables
- style navigation, badges and support section with ski palette and hover/active states
- clean sidebar link classes

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68adfd52282c832094ade16dc65b6ee2