### PR TITLE
feat(front): add ski palette utility classes

### DIFF
--- a/front/src/app/shared/components/no-access/no-access.component.ts
+++ b/front/src/app/shared/components/no-access/no-access.component.ts
@@ -10,7 +10,7 @@ import { RouterLink } from '@angular/router';
     <div class="no-access-page">
       <div class="no-access-container">
         <div class="no-access-card">
-          <div class="error-icon">
+          <div class="error-icon icon-active">
             🔒
           </div>
           <h1 class="error-title">Access Denied</h1>
@@ -20,14 +20,14 @@ import { RouterLink } from '@angular/router';
           <p class="error-description">
             Your account may need additional permissions or you may need to select a different school/season context.
           </p>
-          <div class="error-actions">
-            <button routerLink="/dashboard" class="action-button primary">
-              Return to Dashboard
-            </button>
-            <button routerLink="/select-school" class="action-button secondary">
-              Change School
-            </button>
-          </div>
+            <div class="error-actions">
+              <button routerLink="/dashboard" class="action-button btn-accent">
+                Return to Dashboard
+              </button>
+              <button routerLink="/select-school" class="action-button btn-accent-outline">
+                Change School
+              </button>
+            </div>
         </div>
       </div>
     </div>
@@ -99,24 +99,6 @@ import { RouterLink } from '@angular/router';
       text-align: center;
     }
 
-    .action-button.primary {
-      background: #3b82f6;
-      color: white;
-    }
-
-    .action-button.primary:hover {
-      background: #2563eb;
-    }
-
-    .action-button.secondary {
-      background: #f3f4f6;
-      color: #374151;
-      border: 1px solid #d1d5db;
-    }
-
-    .action-button.secondary:hover {
-      background: #e5e7eb;
-    }
 
     @media (min-width: 480px) {
       .error-actions {

--- a/front/src/app/shared/components/unauthorized/unauthorized.component.ts
+++ b/front/src/app/shared/components/unauthorized/unauthorized.component.ts
@@ -10,7 +10,7 @@ import { RouterLink } from '@angular/router';
     <div class="unauthorized-page">
       <div class="unauthorized-container">
         <div class="unauthorized-card">
-          <div class="error-icon">
+          <div class="error-icon icon-active">
             🚫
           </div>
           <h1 class="error-title">Unauthorized Access</h1>
@@ -20,14 +20,14 @@ import { RouterLink } from '@angular/router';
           <p class="error-description">
             Please contact your administrator if you believe this is an error.
           </p>
-          <div class="error-actions">
-            <button routerLink="/dashboard" class="action-button primary">
-              Go to Dashboard
-            </button>
-            <button routerLink="/auth/login" class="action-button secondary">
-              Login Again
-            </button>
-          </div>
+            <div class="error-actions">
+              <button routerLink="/dashboard" class="action-button btn-accent">
+                Go to Dashboard
+              </button>
+              <button routerLink="/auth/login" class="action-button btn-accent-outline">
+                Login Again
+              </button>
+            </div>
         </div>
       </div>
     </div>
@@ -98,24 +98,6 @@ import { RouterLink } from '@angular/router';
       text-align: center;
     }
 
-    .action-button.primary {
-      background: #3b82f6;
-      color: white;
-    }
-
-    .action-button.primary:hover {
-      background: #2563eb;
-    }
-
-    .action-button.secondary {
-      background: #f3f4f6;
-      color: #374151;
-      border: 1px solid #d1d5db;
-    }
-
-    .action-button.secondary:hover {
-      background: #e5e7eb;
-    }
 
     @media (min-width: 480px) {
       .error-actions {

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -3,6 +3,7 @@
    Sistema de tokens CSS con temas light/dark
    ============================================= */
 
+@import "./styles/utilities.css";
 /* DESIGN TOKENS */
 :root {
   /* Layout Dimensions - Exact Requirements */

--- a/front/src/styles/utilities.css
+++ b/front/src/styles/utilities.css
@@ -1,0 +1,49 @@
+/* Utility classes for ski palette and accent styling */
+:root {
+  --ski-accent: var(--color-ski-blue);
+  --ski-accent-hover: color-mix(in srgb, var(--color-ski-blue) 90%, var(--color-background));
+  --ski-accent-light: color-mix(in srgb, var(--color-ski-blue) 15%, var(--color-background));
+}
+
+.ski-primary {
+  color: var(--color-ski-blue);
+}
+
+.ski-secondary {
+  color: var(--color-ski-green);
+}
+
+.ski-accent {
+  color: var(--ski-accent);
+}
+
+.btn-accent {
+  background-color: var(--ski-accent);
+  color: var(--color-background);
+  border: 1px solid var(--ski-accent);
+}
+.btn-accent:hover {
+  background-color: var(--ski-accent-hover);
+}
+
+.btn-accent-outline {
+  background-color: transparent;
+  color: var(--ski-accent);
+  border: 1px solid var(--ski-accent);
+}
+.btn-accent-outline:hover {
+  background-color: var(--ski-accent-light);
+}
+
+.icon-active {
+  color: var(--ski-accent);
+}
+
+.link-accent {
+  color: var(--ski-accent);
+  text-decoration: none;
+}
+.link-accent:hover {
+  color: var(--ski-accent-hover);
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- add reusable ski palette and accent utility classes
- import utilities into global styles
- refactor no-access and unauthorized pages to use accent helpers

## Testing
- `npm test` *(fails: TS errors in multiple spec files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae02aaefb88320956b735aedc5930c