### PR TITLE
feat: switch to dark class variant

### DIFF
--- a/front/cypress/support/e2e.ts
+++ b/front/cypress/support/e2e.ts
@@ -42,7 +42,8 @@ beforeEach(() => {
 
   // 3) tema por defecto coherente con la app
   window.localStorage.setItem('theme', 'light');
-  document.body.dataset['theme'] = 'light';
+  document.documentElement.classList.remove('dark');
+  document.body.classList.remove('dark');
 
   // 4) Basic auth endpoints with deterministic timing for CI
   cy.intercept('GET', '**/me', { fixture: 'auth/me.json', delay: 0 }).as('me');

--- a/front/src/app/core/services/theme.service.ts
+++ b/front/src/app/core/services/theme.service.ts
@@ -131,14 +131,14 @@ export class ThemeService {
     }
 
     const root = document.body;
+    const htmlEl = document.documentElement;
+    const isDark = theme === 'dark';
 
-    // Remover clases de tema anteriores
-    delete root.dataset['theme'];
+    // Aplicar clase dark a elementos raíz
+    htmlEl.classList.toggle('dark', isDark);
+    root.classList.toggle('dark', isDark);
 
-    // Aplicar nuevo tema
-    root.dataset['theme'] = theme;
-
-    // También agregar clase para compatibilidad con CSS que use clases
+    // Mantener clases auxiliares de tema
     root.classList.remove('theme-light', 'theme-dark');
     root.classList.add(`theme-${theme}`);
 
@@ -148,9 +148,9 @@ export class ThemeService {
     });
     document.dispatchEvent(event);
 
-    // Propagar data-theme al contenedor de overlays para que herede las variables
+    // Propagar clase al contenedor de overlays para que herede las variables
     const el = this.overlay.getContainerElement();
-    el.dataset['theme'] = theme;
+    el.classList.toggle('dark', isDark);
   }
 
   /**

--- a/front/src/app/core/stores/ui.store.spec.ts
+++ b/front/src/app/core/stores/ui.store.spec.ts
@@ -3,14 +3,15 @@ import { UiStore } from './ui.store';
 describe('UiStore theme persistence', () => {
   beforeEach(() => {
     localStorage.clear();
-    delete document.body.dataset['theme'];
+    document.documentElement.classList.remove('dark');
+    document.body.classList.remove('dark');
   });
 
-  it('setTheme persists to localStorage and dataset.theme', () => {
+  it('setTheme persists to localStorage and applies class', () => {
     const store = new UiStore();
     store.setTheme('dark');
     expect(localStorage.getItem('theme')).toBe('dark');
-    expect(document.body.dataset['theme']).toBe('dark');
+    expect(document.body.classList.contains('dark')).toBe(true);
   });
 
   it('toggleTheme persists changes', () => {
@@ -18,13 +19,13 @@ describe('UiStore theme persistence', () => {
     store.setTheme('light');
     store.toggleTheme();
     expect(localStorage.getItem('theme')).toBe('dark');
-    expect(document.body.dataset['theme']).toBe('dark');
+    expect(document.body.classList.contains('dark')).toBe(true);
   });
 
   it('initTheme applies stored theme', () => {
     localStorage.setItem('theme', 'dark');
     const store = new UiStore();
     store.initTheme();
-    expect(document.body.dataset['theme']).toBe('dark');
+    expect(document.body.classList.contains('dark')).toBe(true);
   });
 });

--- a/front/src/app/core/stores/ui.store.ts
+++ b/front/src/app/core/stores/ui.store.ts
@@ -52,8 +52,9 @@ export class UiStore {
     this._theme.set(nextTheme);
     try {
       if (typeof document !== 'undefined') {
-        document.documentElement.dataset['theme'] = nextTheme;
-        document.body.dataset['theme'] = nextTheme;
+        const isDark = nextTheme === 'dark';
+        document.documentElement.classList.toggle('dark', isDark);
+        document.body.classList.toggle('dark', isDark);
       }
       if (typeof localStorage !== 'undefined') {
         localStorage.setItem('theme', nextTheme);
@@ -76,8 +77,9 @@ export class UiStore {
     this._theme.set(v);
     try {
       if (typeof document !== 'undefined') {
-        document.documentElement.dataset['theme'] = v;
-        document.body.dataset['theme'] = v;
+        const isDark = v === 'dark';
+        document.documentElement.classList.toggle('dark', isDark);
+        document.body.classList.toggle('dark', isDark);
       }
     } catch {}
   }

--- a/front/src/app/features/auth/pages/forgot-password.page.stories.ts
+++ b/front/src/app/features/auth/pages/forgot-password.page.stories.ts
@@ -61,7 +61,7 @@ const mockToastService = {
 const themeDecorator = (theme: 'light' | 'dark') =>
   componentWrapperDecorator(
     (story) => `
-      <div data-theme="${theme}" style="min-height: 100vh; background: var(--bg);">
+      <div class="${theme === 'dark' ? 'dark' : ''}" style="min-height: 100vh; background: var(--bg);">
         ${story}
       </div>
     `

--- a/front/src/app/features/auth/pages/login.page.stories.ts
+++ b/front/src/app/features/auth/pages/login.page.stories.ts
@@ -70,7 +70,7 @@ const mockToastService = {
 const themeDecorator = (theme: 'light' | 'dark') =>
   componentWrapperDecorator(
     (story) => `
-      <div data-theme="${theme}" style="min-height: 100vh; background: var(--bg);">
+      <div class="${theme === 'dark' ? 'dark' : ''}" style="min-height: 100vh; background: var(--bg);">
         ${story}
       </div>
     `
@@ -248,7 +248,7 @@ export const HighContrast: Story = {
   decorators: [
     componentWrapperDecorator(
       (story) => `
-        <div data-theme="light" style="min-height: 100vh; background: var(--bg); filter: contrast(1.5);">
+        <div style="min-height: 100vh; background: var(--bg); filter: contrast(1.5);">
           ${story}
         </div>
       `

--- a/front/src/app/features/auth/pages/register.page.stories.ts
+++ b/front/src/app/features/auth/pages/register.page.stories.ts
@@ -70,7 +70,7 @@ const mockToastService = {
 const themeDecorator = (theme: 'light' | 'dark') =>
   componentWrapperDecorator(
     (story) => `
-      <div data-theme="${theme}" style="min-height: 100vh; background: var(--bg);">
+      <div class="${theme === 'dark' ? 'dark' : ''}" style="min-height: 100vh; background: var(--bg);">
         ${story}
       </div>
     `

--- a/front/src/app/features/auth/ui/auth-shell/auth-shell.stories.ts
+++ b/front/src/app/features/auth/ui/auth-shell/auth-shell.stories.ts
@@ -15,20 +15,20 @@ class MockTranslationService {
 }
 
 const lightDecorator = componentWrapperDecorator((story) => {
-  document.body.dataset['theme'] = 'light';
+  document.body.classList.remove('dark');
   localStorage.setItem('theme', 'light');
   return `
-    <div data-theme="light" style="min-height:100vh;background:var(--bg);padding:1rem;">
+    <div style="min-height:100vh;background:var(--bg);padding:1rem;">
       ${story}
     </div>
   `;
 });
 
 const darkDecorator = componentWrapperDecorator((story) => {
-  document.body.dataset['theme'] = 'dark';
+  document.body.classList.add('dark');
   localStorage.setItem('theme', 'dark');
   return `
-    <div data-theme="dark" style="min-height:100vh;background:var(--bg);padding:1rem;">
+    <div class="dark" style="min-height:100vh;background:var(--bg);padding:1rem;">
       ${story}
     </div>
   `;

--- a/front/src/app/features/school-selection/select-school.stories.ts
+++ b/front/src/app/features/school-selection/select-school.stories.ts
@@ -353,7 +353,7 @@ export const DarkTheme: Story = {
   name: '🌙 Tema Oscuro',
   decorators: [
     (story) => {
-      document.body.dataset['theme'] = 'dark';
+      document.body.classList.add('dark');
       return story();
     },
   ],

--- a/front/src/app/shared/components/feature-flag-panel/feature-flag-panel.component.ts
+++ b/front/src/app/shared/components/feature-flag-panel/feature-flag-panel.component.ts
@@ -206,7 +206,7 @@ import { FeatureFlagDirective } from '@shared/directives/feature-flag.directive'
         border-color: var(--color-border-subtle);
       }
 
-      [data-theme='dark'] .feature-item.enabled {
+      .dark .feature-item.enabled {
         background: var(--color-success-900);
         border-color: var(--color-success-700);
       }

--- a/front/src/app/shared/components/feature-flag-panel/feature-flag-panel.stories.ts
+++ b/front/src/app/shared/components/feature-flag-panel/feature-flag-panel.stories.ts
@@ -137,7 +137,7 @@ export const Expanded: Story = {
 export const DarkTheme: Story = {
   render: () => ({
     template: `
-      <div data-theme="dark" style="position: relative; height: 100vh; background: var(--color-background); padding: 1rem;">
+      <div class="dark" style="position: relative; height: 100vh; background: var(--color-background); padding: 1rem;">
         <div style="max-width: 600px; margin: 0 auto;">
           <h2>Feature Flag Panel - Dark Theme</h2>
           <p>The feature flag panel adapts to the current theme automatically.</p>

--- a/front/src/app/shared/components/language-selector/language-selector.component.ts
+++ b/front/src/app/shared/components/language-selector/language-selector.component.ts
@@ -229,7 +229,7 @@ import { TranslationService, SupportedLanguage } from '@core/services/translatio
         color: var(--color-primary-700);
       }
 
-      [data-theme='dark'] .language-option.active {
+      .dark .language-option.active {
         background: var(--color-primary-900);
         color: var(--color-primary-200);
       }
@@ -275,7 +275,7 @@ import { TranslationService, SupportedLanguage } from '@core/services/translatio
         white-space: nowrap;
       }
 
-      [data-theme='dark'] .error-message {
+      .dark .error-message {
         background: var(--color-error-900);
         border-color: var(--color-error-700);
         color: var(--color-error-200);

--- a/front/src/app/shared/components/toast/toast.component.ts
+++ b/front/src/app/shared/components/toast/toast.component.ts
@@ -449,7 +449,7 @@ import { Toast, ToastPosition } from '@core/models/toast.models';
       }
 
       /* Dark theme adjustments */
-      [data-theme='dark'] .toast {
+      .dark .toast {
         box-shadow:
           var(--shadow-xl),
           0 0 0 1px rgba(255, 255, 255, 0.05);

--- a/front/src/app/ui/app-shell/app-shell.component.spec.ts
+++ b/front/src/app/ui/app-shell/app-shell.component.spec.ts
@@ -59,7 +59,9 @@ class MockUiStore {
   setTheme(theme: 'light' | 'dark'): void {
     this.theme.set(theme);
     localStorage.setItem('theme', theme);
-    document.body.dataset['theme'] = theme;
+    const isDark = theme === 'dark';
+    document.documentElement.classList.toggle('dark', isDark);
+    document.body.classList.toggle('dark', isDark);
   }
 
   toggleTheme(): void {
@@ -73,7 +75,8 @@ describe('AppShellComponent interactions', () => {
 
   beforeEach(async () => {
     localStorage.clear();
-    delete document.body.dataset['theme'];
+    document.documentElement.classList.remove('dark');
+    document.body.classList.remove('dark');
     logoutSpy.mockReset();
     await TestBed.configureTestingModule({
       imports: [AppShellComponent],
@@ -124,17 +127,17 @@ describe('AppShellComponent interactions', () => {
     fixture.nativeElement.remove();
   });
 
-  it('setTheme() propagates data-theme to OverlayContainer', async () => {
+  it('setTheme() propagates class to OverlayContainer', async () => {
     const fixture = renderComponent();
     const overlay = TestBed.inject(OverlayContainer);
     const themeService = TestBed.inject(ThemeService);
     themeService.setTheme('dark');
     await Promise.resolve();
-    expect(overlay.getContainerElement().dataset['theme']).toBe('dark');
+    expect(overlay.getContainerElement().classList.contains('dark')).toBe(true);
     fixture.nativeElement.remove();
   });
 
-  it('theme toggle persists selection and updates document dataset', async () => {
+  it('theme toggle persists selection and updates document class', async () => {
     const fixture = renderComponent();
     const user = userEvent.setup();
     const button = screen.getByTitle('theme.toggle');
@@ -142,12 +145,12 @@ describe('AppShellComponent interactions', () => {
     await user.click(button); // light -> dark
     fixture.detectChanges();
     expect(localStorage.getItem('theme')).toBe('dark');
-    expect(document.body.dataset['theme']).toBe('dark');
+    expect(document.body.classList.contains('dark')).toBe(true);
 
     await user.click(button); // dark -> light
     fixture.detectChanges();
     expect(localStorage.getItem('theme')).toBe('light');
-    expect(document.body.dataset['theme']).toBe('light');
+    expect(document.body.classList.contains('dark')).toBe(false);
 
     fixture.nativeElement.remove();
   });

--- a/front/src/app/ui/app-shell/app-shell.stories.ts
+++ b/front/src/app/ui/app-shell/app-shell.stories.ts
@@ -46,8 +46,9 @@ class MockUiStore {
   toggleTheme() {
     const newTheme = this.themeSignal() === 'light' ? 'dark' : 'light';
     this.themeSignal.set(newTheme);
-    document.body.dataset['theme'] = newTheme;
-    document.documentElement.dataset['theme'] = newTheme;
+    const isDark = newTheme === 'dark';
+    document.documentElement.classList.toggle('dark', isDark);
+    document.body.classList.toggle('dark', isDark);
   }
 
   toggleSidebar() {
@@ -56,11 +57,13 @@ class MockUiStore {
 
   
   initTheme() {
-    document.body.dataset['theme'] = this.themeSignal();
+    const isDark = this.themeSignal() === 'dark';
+    document.body.classList.toggle('dark', isDark);
   }
 
   initializeTheme() {
-    document.documentElement.dataset['theme'] = this.themeSignal();
+    const isDark = this.themeSignal() === 'dark';
+    document.documentElement.classList.toggle('dark', isDark);
   }
 }
 

--- a/front/src/app/ui/app-shell/app-shell.styles.scss
+++ b/front/src/app/ui/app-shell/app-shell.styles.scss
@@ -586,7 +586,7 @@
 .app-sidebar .collapse:focus-visible { outline: 2px solid var(--ski-accent); outline-offset: 2px; }
 
 /* dark: evita que se “pierda” */
-:root[data-theme="dark"] .app-sidebar .collapse{
+.dark .app-sidebar .collapse{
   background: var(--surface-2);
   border-color: var(--border);
 }

--- a/front/src/app/ui/theme-toggle/theme-toggle.component.ts
+++ b/front/src/app/ui/theme-toggle/theme-toggle.component.ts
@@ -219,7 +219,7 @@ import { TranslatePipe } from '@shared/pipes/translate.pipe';
         color: var(--color-primary-700);
       }
 
-      [data-theme='dark'] .dropdown-item.active {
+      .dark .dropdown-item.active {
         background: var(--color-primary-900);
         color: var(--color-primary-200);
       }

--- a/front/src/app/ui/theme-toggle/theme-toggle.stories.ts
+++ b/front/src/app/ui/theme-toggle/theme-toggle.stories.ts
@@ -69,7 +69,7 @@ export const Default: Story = {
 export const LightTheme: Story = {
   render: () => ({
     template: `
-      <div class="story-container" data-theme="light">
+      <div class="story-container">
         <div class="component-showcase">
           <h3>Light Theme</h3>
           <p>Theme toggle in light mode</p>
@@ -91,7 +91,7 @@ export const LightTheme: Story = {
 export const DarkTheme: Story = {
   render: () => ({
     template: `
-      <div class="story-container" data-theme="dark">
+      <div class="story-container dark">
         <div class="component-showcase">
           <h3>Dark Theme</h3>
           <p>Theme toggle in dark mode</p>

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -1,7 +1,8 @@
-/* ============================================= 
-   BOUKII V5 - DESIGN SYSTEM 
+/* =============================================
+   BOUKII V5 - DESIGN SYSTEM
    Sistema de tokens CSS con temas light/dark
    ============================================= */
+@custom-variant dark (&:is(.dark *));
 
 @import "./styles/utilities.css";
 /* DESIGN TOKENS */
@@ -16,8 +17,7 @@
   --z-overlay: 1000;
 }
 
-:root,
-:root[data-theme='light'] {
+:root {
   /* Background & Surfaces */
   --bg: #f6f7f9;
   --surface: #ffffff;
@@ -91,7 +91,7 @@
   --color-text-tertiary: var(--muted);
 }
 
-:root[data-theme='dark'] {
+.dark {
   /* Background & Surfaces */
   --bg: #0b1220;
   --surface: #0e1626;
@@ -415,7 +415,7 @@ html {
 }
 
 /* Dark theme specific adjustments */
-[data-theme='dark'] {
+.dark {
   .chip--yellow {
     color: #fbbf24;
   }
@@ -512,8 +512,8 @@ html {
   z-index: 1000;
 }
 
-[data-theme] .mat-mdc-menu-panel,
-[data-theme] .cdk-overlay-pane .menu-panel,
+.mat-mdc-menu-panel,
+.cdk-overlay-pane .menu-panel,
 .language-dropdown,
 .user-dropdown,
 .notifications-dropdown {

--- a/front/src/styles/dark.css
+++ b/front/src/styles/dark.css
@@ -1,5 +1,5 @@
 /* Dark Theme - Overrides para tema oscuro */
-[data-theme='dark'] {
+.dark {
   /* Base semantic colors */
   --bg: var(--color-gray-900);
   --surface: var(--color-gray-800);
@@ -66,7 +66,7 @@
 
 /* Dark theme media query para detección automática */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) {
+  :root:not(.dark) {
     /* Surface Colors */
     --color-background: var(--color-gray-900);
     --color-surface: var(--color-gray-800);

--- a/front/src/styles/light.css
+++ b/front/src/styles/light.css
@@ -1,6 +1,5 @@
 /* Light Theme - Overrides para tema claro */
-:root,
-[data-theme='light'] {
+:root {
   /* Base semantic colors - already defined in tokens.css but can be overridden */
   /* --bg, --surface, --surface-2, --border, --text-1, --text-2, --muted are inherited */
   


### PR DESCRIPTION
## Summary
- declare custom `@custom-variant` that activates when `.dark` is present
- toggle `.dark` class from UI store and theme service instead of `data-theme`
- update component styles, tests and stories to use the new variant

## Testing
- `npm test` *(fails: Cannot find module './api-http.service' in context.service.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0a5dc7ac83209843113e116624f1