### PR TITLE
Add Payyo reference and transaction fields

### DIFF
--- a/app/Http/Resources/API/BookingResource.php
+++ b/app/Http/Resources/API/BookingResource.php
@@ -27,6 +27,8 @@ class BookingResource extends JsonResource
             'paid' => $this->paid,
             'payrexx_reference' => $this->payrexx_reference,
             'payrexx_transaction' => $this->payrexx_transaction,
+            'payyo_reference' => $this->payyo_reference,
+            'payyo_transaction' => $this->payyo_transaction,
             'attendance' => $this->attendance,
             'payrexx_refund' => $this->payrexx_refund,
             'notes' => $this->notes,

--- a/app/Http/Resources/API/VoucherResource.php
+++ b/app/Http/Resources/API/VoucherResource.php
@@ -25,6 +25,8 @@ class VoucherResource extends JsonResource
             'school_id' => $this->school_id,
             'payrexx_reference' => $this->payrexx_reference,
             'payrexx_transaction' => $this->payrexx_transaction,
+            'payyo_reference' => $this->payyo_reference,
+            'payyo_transaction' => $this->payyo_transaction,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'deleted_at' => $this->deleted_at

--- a/app/Http/Resources/PaymentResource.php
+++ b/app/Http/Resources/PaymentResource.php
@@ -23,6 +23,8 @@ class PaymentResource extends JsonResource
             'notes' => $this->notes,
             'payrexx_reference' => $this->payrexx_reference,
             'payrexx_transaction' => $this->payrexx_transaction,
+            'payyo_reference' => $this->payyo_reference,
+            'payyo_transaction' => $this->payyo_transaction,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'deleted_at' => $this->deleted_at

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -76,6 +76,20 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *          type="string",
  *      ),
  *      @OA\Property(
+ *          property="payyo_reference",
+ *          description="",
+ *          readOnly=false,
+ *          nullable=true,
+ *          type="string",
+ *      ),
+ *      @OA\Property(
+ *          property="payyo_transaction",
+ *          description="",
+ *          readOnly=false,
+ *          nullable=true,
+ *          type="string",
+ *      ),
+ *      @OA\Property(
  *          property="attendance",
  *          description="",
  *          readOnly=false,
@@ -252,6 +266,8 @@ class Booking extends Model
         'paid',
         'payrexx_reference',
         'payrexx_transaction',
+        'payyo_reference',
+        'payyo_transaction',
         'attendance',
         'payrexx_refund',
         'notes',
@@ -285,6 +301,8 @@ class Booking extends Model
         'has_boukii_care' => 'boolean',
         'payrexx_reference' => 'string',
         'payrexx_transaction' => 'string',
+        'payyo_reference' => 'string',
+        'payyo_transaction' => 'string',
         'attendance' => 'boolean',
         'payrexx_refund' => 'boolean',
         'notes' => 'string',
@@ -307,6 +325,8 @@ class Booking extends Model
         'paid' => 'nullable',
         'payrexx_reference' => 'nullable|string|max:65535',
         'payrexx_transaction' => 'nullable|string|max:65535',
+        'payyo_reference' => 'nullable|string|max:65535',
+        'payyo_transaction' => 'nullable|string|max:65535',
         'attendance' => 'nullable',
         'payrexx_refund' => 'nullable|boolean',
         'notes' => 'nullable|string|max:500',
@@ -912,6 +932,32 @@ class Booking extends Model
             try
             {
                 $decrypted = decrypt($this->payrexx_transaction);
+            }
+                // @codeCoverageIgnoreStart
+            catch (\Illuminate\Contracts\Encryption\DecryptException $e)
+            {
+                $decrypted = null;  // Data seems corrupt or tampered
+            }
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $decrypted ? json_decode($decrypted, true) : [];
+    }
+
+    // Special for field "payyo_transaction": store encrypted
+    public function setPayyoTransaction($value)
+    {
+        $this->payyo_transaction = encrypt( json_encode($value) );
+    }
+
+    public function getPayyoTransaction()
+    {
+        $decrypted = null;
+        if ($this->payyo_transaction)
+        {
+            try
+            {
+                $decrypted = decrypt($this->payyo_transaction);
             }
                 // @codeCoverageIgnoreStart
             catch (\Illuminate\Contracts\Encryption\DecryptException $e)

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -48,6 +48,20 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *          type="string",
  *      ),
  *      @OA\Property(
+ *          property="payyo_reference",
+ *          description="",
+ *          readOnly=false,
+ *          nullable=true,
+ *          type="string",
+ *      ),
+ *      @OA\Property(
+ *          property="payyo_transaction",
+ *          description="",
+ *          readOnly=false,
+ *          nullable=true,
+ *          type="string",
+ *      ),
+ *      @OA\Property(
  *          property="created_at",
  *          description="",
  *          readOnly=true,
@@ -85,7 +99,9 @@ class Payment extends Model
         'status',
         'notes',
         'payrexx_reference',
-        'payrexx_transaction'
+        'payrexx_transaction',
+        'payyo_reference',
+        'payyo_transaction'
     ];
 
     protected $casts = [
@@ -93,7 +109,9 @@ class Payment extends Model
         'status' => 'string',
         'notes' => 'string',
         'payrexx_reference' => 'string',
-        'payrexx_transaction' => 'string'
+        'payrexx_transaction' => 'string',
+        'payyo_reference' => 'string',
+        'payyo_transaction' => 'string'
     ];
 
     public static array $rules = [
@@ -104,6 +122,8 @@ class Payment extends Model
         'notes' => 'nullable|string|max:65535',
         'payrexx_reference' => 'nullable|string|max:65535',
         'payrexx_transaction' => 'nullable|string|max:65535',
+        'payyo_reference' => 'nullable|string|max:65535',
+        'payyo_transaction' => 'nullable|string|max:65535',
         'created_at' => 'nullable',
         'updated_at' => 'nullable',
         'deleted_at' => 'nullable'
@@ -138,6 +158,32 @@ class Payment extends Model
             try
             {
                 $decrypted = decrypt($this->payrexx_transaction);
+            }
+                // @codeCoverageIgnoreStart
+            catch (\Illuminate\Contracts\Encryption\DecryptException $e)
+            {
+                $decrypted = null;  // Data seems corrupt or tampered
+            }
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $decrypted ? json_decode($decrypted, true) : [];
+    }
+
+    // Special for field "payyo_transaction": store encrypted
+    public function setPayyoTransaction($value)
+    {
+        $this->payyo_transaction = encrypt( json_encode($value) );
+    }
+
+    public function getPayyoTransaction()
+    {
+        $decrypted = null;
+        if ($this->payyo_transaction)
+        {
+            try
+            {
+                $decrypted = decrypt($this->payyo_transaction);
             }
                 // @codeCoverageIgnoreStart
             catch (\Illuminate\Contracts\Encryption\DecryptException $e)

--- a/app/Models/Voucher.php
+++ b/app/Models/Voucher.php
@@ -75,6 +75,20 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *          type="string",
  *      ),
  *      @OA\Property(
+ *          property="payyo_reference",
+ *          description="The reference related to payment through Payyo",
+ *          readOnly=false,
+ *          nullable=true,
+ *          type="string",
+ *      ),
+ *      @OA\Property(
+ *          property="payyo_transaction",
+ *          description="The transaction related to payment through Payyo",
+ *          readOnly=false,
+ *          nullable=true,
+ *          type="string",
+ *      ),
+ *      @OA\Property(
  *          property="created_at",
  *          description="The timestamp when the voucher was created",
  *          readOnly=true,
@@ -115,6 +129,8 @@ class Voucher extends Model
         'school_id',
         'payrexx_reference',
         'payrexx_transaction',
+        'payyo_reference',
+        'payyo_transaction',
         'old_id'
     ];
 
@@ -126,6 +142,8 @@ class Voucher extends Model
         'is_gift' => 'boolean',
         'payrexx_reference' => 'string',
         'payrexx_transaction' => 'string',
+        'payyo_reference' => 'string',
+        'payyo_transaction' => 'string',
     ];
 
     public static array $rules = [
@@ -138,6 +156,8 @@ class Voucher extends Model
         'school_id' => 'numeric',
         'payrexx_reference' => 'nullable|string|max:65535',
         'payrexx_transaction' => 'nullable|string|max:65535',
+        'payyo_reference' => 'nullable|string|max:65535',
+        'payyo_transaction' => 'nullable|string|max:65535',
         'created_at' => 'nullable',
         'updated_at' => 'nullable',
         'deleted_at' => 'nullable'

--- a/app/Repositories/PaymentRepository.php
+++ b/app/Repositories/PaymentRepository.php
@@ -14,7 +14,9 @@ class PaymentRepository extends BaseRepository
         'status',
         'notes',
         'payrexx_reference',
-        'payrexx_transaction'
+        'payrexx_transaction',
+        'payyo_reference',
+        'payyo_transaction'
     ];
 
     public function getFieldsSearchable(): array

--- a/app/Repositories/VoucherRepository.php
+++ b/app/Repositories/VoucherRepository.php
@@ -17,7 +17,9 @@ class VoucherRepository extends BaseRepository
         'client_id',
         'school_id',
         'payrexx_reference',
-        'payrexx_transaction'
+        'payrexx_transaction',
+        'payyo_reference',
+        'payyo_transaction'
     ];
 
     public function getFieldsSearchable(): array

--- a/database/factories/BookingFactory.php
+++ b/database/factories/BookingFactory.php
@@ -42,6 +42,8 @@ class BookingFactory extends Factory
             'paid' => $this->faker->boolean,
             'payrexx_reference' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'payrexx_transaction' => $this->faker->text($this->faker->numberBetween(5, 65535)),
+            'payyo_reference' => $this->faker->text($this->faker->numberBetween(5, 65535)),
+            'payyo_transaction' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'attendance' => $this->faker->boolean,
             'payrexx_refund' => $this->faker->boolean,
             'notes' => $this->faker->text($this->faker->numberBetween(5, 500)),

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -38,6 +38,8 @@ class PaymentFactory extends Factory
             'notes' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'payrexx_reference' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'payrexx_transaction' => $this->faker->text($this->faker->numberBetween(5, 65535)),
+            'payyo_reference' => $this->faker->text($this->faker->numberBetween(5, 65535)),
+            'payyo_transaction' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'created_at' => $this->faker->date('Y-m-d H:i:s'),
             'updated_at' => $this->faker->date('Y-m-d H:i:s'),
             'deleted_at' => $this->faker->date('Y-m-d H:i:s')

--- a/database/factories/VoucherFactory.php
+++ b/database/factories/VoucherFactory.php
@@ -40,6 +40,8 @@ class VoucherFactory extends Factory
             'school_id' => $this->faker->word,
             'payrexx_reference' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'payrexx_transaction' => $this->faker->text($this->faker->numberBetween(5, 65535)),
+            'payyo_reference' => $this->faker->text($this->faker->numberBetween(5, 65535)),
+            'payyo_transaction' => $this->faker->text($this->faker->numberBetween(5, 65535)),
             'created_at' => $this->faker->date('Y-m-d H:i:s'),
             'updated_at' => $this->faker->date('Y-m-d H:i:s'),
             'deleted_at' => $this->faker->date('Y-m-d H:i:s')

--- a/database/migrations/2025_09_15_000000_add_payyo_fields_to_bookings_payments_vouchers_tables.php
+++ b/database/migrations/2025_09_15_000000_add_payyo_fields_to_bookings_payments_vouchers_tables.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            $table->text('payyo_reference')->nullable()->after('payrexx_reference');
+            $table->text('payyo_transaction')->nullable()->after('payrexx_transaction');
+        });
+
+        Schema::table('payments', function (Blueprint $table) {
+            $table->string('payyo_reference')->nullable()->after('payrexx_reference');
+            $table->string('payyo_transaction')->nullable()->after('payrexx_transaction');
+        });
+
+        Schema::table('vouchers', function (Blueprint $table) {
+            $table->text('payyo_reference')->nullable()->after('payrexx_reference');
+            $table->text('payyo_transaction')->nullable()->after('payrexx_transaction');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            $table->dropColumn(['payyo_reference', 'payyo_transaction']);
+        });
+
+        Schema::table('payments', function (Blueprint $table) {
+            $table->dropColumn(['payyo_reference', 'payyo_transaction']);
+        });
+
+        Schema::table('vouchers', function (Blueprint $table) {
+            $table->dropColumn(['payyo_reference', 'payyo_transaction']);
+        });
+    }
+};

--- a/resources/model_schemas/Booking.json
+++ b/resources/model_schemas/Booking.json
@@ -144,6 +144,30 @@
         "inView": true
     },
     {
+        "name": "payyo_reference",
+        "dbType": "text",
+        "htmlType": "textarea",
+        "validations": "nullable|string|max:65535|nullable|string|max:65535",
+        "searchable": true,
+        "fillable": true,
+        "primary": false,
+        "inForm": true,
+        "inIndex": true,
+        "inView": true
+    },
+    {
+        "name": "payyo_transaction",
+        "dbType": "text",
+        "htmlType": "textarea",
+        "validations": "nullable|string|max:65535|nullable|string|max:65535",
+        "searchable": true,
+        "fillable": true,
+        "primary": false,
+        "inForm": true,
+        "inIndex": true,
+        "inView": true
+    },
+    {
         "name": "attendance",
         "dbType": "boolean",
         "htmlType": "checkbox",

--- a/resources/model_schemas/Payment.json
+++ b/resources/model_schemas/Payment.json
@@ -96,6 +96,30 @@
         "inView": true
     },
     {
+        "name": "payyo_reference",
+        "dbType": "text",
+        "htmlType": "textarea",
+        "validations": "nullable|string|max:65535|nullable|string|max:65535",
+        "searchable": true,
+        "fillable": true,
+        "primary": false,
+        "inForm": true,
+        "inIndex": true,
+        "inView": true
+    },
+    {
+        "name": "payyo_transaction",
+        "dbType": "text",
+        "htmlType": "textarea",
+        "validations": "nullable|string|max:65535|nullable|string|max:65535",
+        "searchable": true,
+        "fillable": true,
+        "primary": false,
+        "inForm": true,
+        "inIndex": true,
+        "inView": true
+    },
+    {
         "name": "created_at",
         "dbType": "datetime",
         "htmlType": "date",

--- a/resources/model_schemas/Voucher.json
+++ b/resources/model_schemas/Voucher.json
@@ -108,6 +108,30 @@
         "inView": true
     },
     {
+        "name": "payyo_reference",
+        "dbType": "text",
+        "htmlType": "textarea",
+        "validations": "nullable|string|max:65535|nullable|string|max:65535",
+        "searchable": true,
+        "fillable": true,
+        "primary": false,
+        "inForm": true,
+        "inIndex": true,
+        "inView": true
+    },
+    {
+        "name": "payyo_transaction",
+        "dbType": "text",
+        "htmlType": "textarea",
+        "validations": "nullable|string|max:65535|nullable|string|max:65535",
+        "searchable": true,
+        "fillable": true,
+        "primary": false,
+        "inForm": true,
+        "inIndex": true,
+        "inView": true
+    },
+    {
         "name": "created_at",
         "dbType": "datetime",
         "htmlType": "date",

--- a/tests/database/migrations/2023_11_08_110724_create_bookings_table.php
+++ b/tests/database/migrations/2023_11_08_110724_create_bookings_table.php
@@ -26,6 +26,8 @@ class CreateBookingsTable extends Migration
             $table->boolean('paid')->default(0);
             $table->text('payrexx_reference')->nullable();
             $table->text('payrexx_transaction')->nullable();
+            $table->text('payyo_reference')->nullable();
+            $table->text('payyo_transaction')->nullable();
             $table->boolean('attendance')->default(1);
             $table->boolean('payrexx_refund')->default(0);
             $table->string('notes', 500)->default('');

--- a/tests/database/migrations/2023_11_08_110800_create_vouchers_table.php
+++ b/tests/database/migrations/2023_11_08_110800_create_vouchers_table.php
@@ -24,6 +24,8 @@ class CreateVouchersTable extends Migration
             $table->bigInteger('school_id');
             $table->text('payrexx_reference')->nullable();
             $table->text('payrexx_transaction')->nullable();
+            $table->text('payyo_reference')->nullable();
+            $table->text('payyo_transaction')->nullable();
             $table->timestamps();
             $table->timestamp('deleted_at')->nullable();
 


### PR DESCRIPTION
## Summary
- extend bookings, payments, and vouchers tables with payyo_reference and payyo_transaction columns
- expose new Payyo fields in Booking, Payment, and Voucher models, repositories, and API resources
- encrypt Payyo transaction data similar to Payrexx handling

## Testing
- `composer install` *(fails: Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1)*
- `touch database/data.sqlite`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b035ddc48483208552a0ae3ad35747