### PR TITLE
Add Payyo payment support with provider switching

### DIFF
--- a/app/Http/Controllers/BookingPage/BookingController.php
+++ b/app/Http/Controllers/BookingPage/BookingController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\BookingPage;
 
 use App\Http\Controllers\AppBaseController;
 use App\Http\Controllers\PayrexxHelpers;
+use App\Http\Controllers\PayyoHelpers;
 use App\Http\Resources\API\BookingResource;
 use App\Mail\BookingCancelMailer;
 use App\Mail\BookingPayMailer;
@@ -466,6 +467,22 @@ class BookingController extends SlugAuthController
 
         $booking->payment_method_id = $paymentMethod;
         $booking->save();
+
+        if ($school->payment_provider === 'payyo') {
+            $payLink = PayyoHelpers::createPayLink(
+                $school,
+                $booking,
+                $request->all(),
+                $booking->clientMain,
+                $request->redirectUrl
+            );
+
+            if ($payLink) {
+                return $this->sendResponse($payLink, 'Link retrieved successfully');
+            }
+
+            return $this->sendError('Link could not be created. Booking has been removed.');
+        }
 
         $payrexxLink = PayrexxHelpers::createGatewayLink(
             $school,

--- a/app/Http/Controllers/PayyoController.php
+++ b/app/Http/Controllers/PayyoController.php
@@ -43,7 +43,7 @@ class PayyoController
 
                 $booking = (strlen($referenceID) > 2)
                     ? Booking::withTrashed()->with(['school', 'bookingUsers'])
-                        ->where('payrexx_reference', '=', $referenceID)
+                        ->where('payyo_reference', '=', $referenceID)
                         ->first()
                     : null;
 
@@ -125,7 +125,7 @@ class PayyoController
                                 // storing some Transaction info for future refunds
                                 // fallback to $data['amount'] (which might been faked)
                                 $booking->paid = true;
-                                $booking->setPayrexxTransaction([
+                                $booking->setPayyoTransaction([
                                     'id' => $transactionID,
                                     'time' => $data2['time'] ?? time(),
                                     'totalAmount' => $data2['amount'] ?? $data['amount'],
@@ -143,8 +143,8 @@ class PayyoController
                                 $payment->amount = ($data2['amount'] ?? $data['amount']) / 100;
                                 $payment->status = 'paid';
                                 $payment->notes = 'Boukii Pay';
-                                $payment->payrexx_reference = $referenceID;
-                                $payment->payrexx_transaction = $booking->payrexx_transaction;
+                                $payment->payyo_reference = $referenceID;
+                                $payment->setPayyoTransaction($booking->getPayyoTransaction());
                                 $payment->save();
 
                                 $booking->save();
@@ -154,11 +154,11 @@ class PayyoController
 
                 } else {
                     $voucher = (strlen($referenceID) > 2)
-                        ? Voucher::with('school')->where('payrexx_reference', '=', $referenceID)->first()
+                        ? Voucher::with('school')->where('payyo_reference', '=', $referenceID)->first()
                         : null;
 
                     if (!$voucher) {
-                        throw new \Exception('No Booking or Voucher found with payrexx_reference: ' . $referenceID);
+                        throw new \Exception('No Booking or Voucher found with payyo_reference: ' . $referenceID);
                     }
 
                     if (!$voucher->payed) {
@@ -194,7 +194,7 @@ class PayyoController
                                 }
 
                                 $voucher->payed = true;
-                                $voucher->setPayrexxTransaction([
+                                $voucher->setPayyoTransaction([
                                     'id' => $transactionID,
                                     'time' => $data2['time'] ?? time(),
                                     'totalAmount' => $data2['amount'] ?? $data['amount'],

--- a/app/Http/Controllers/PayyoHelpers.php
+++ b/app/Http/Controllers/PayyoHelpers.php
@@ -45,7 +45,7 @@ class PayyoHelpers
             $client = new HttpClient();
 
             $payload = [
-                'referenceId' => $bookingData->getOrGeneratePayrexxReference(),
+                'referenceId' => $bookingData->getOrGeneratePayyoReference(),
                 'amount' => $bookingData->price_total * 100,
                 'currency' => $bookingData->currency,
             ];

--- a/app/Mail/BookingPayMailer.php
+++ b/app/Mail/BookingPayMailer.php
@@ -73,7 +73,7 @@ class BookingPayMailer extends Mailable
             'schoolEmail' => $this->schoolData->contact_email,
             'schoolPhone' =>  $this->schoolData->contact_phone,
             'schoolConditionsURL' => $this->schoolData->conditions_url,
-            'reference' => $this->bookingData->payrexx_reference,
+            'reference' => $this->bookingData->payrexx_reference ?? $this->bookingData->payyo_reference,
             'bookingNotes' => $this->bookingData->notes,
             'booking' => $this->bookingData,
             'courses' => $this->bookingData->parseBookedGroupedWithCourses(),

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -918,6 +918,23 @@ class Booking extends Model
         return $this->payrexx_reference;
     }
 
+    /**
+     * Generate an unique reference for Payyo - only for bookings that want to pay this way
+     * (i.e. BoukiiPay or Online)
+     */
+    public function getOrGeneratePayyoReference()
+    {
+        if (!$this->payyo_reference &&
+            ($this->payment_method_id == 2 || $this->payment_method_id == 3))
+        {
+            $ref = 'Boukii #' . $this->id;
+            $this->payyo_reference = (env('APP_ENV') == 'production') ? $ref : 'TEST ' . $ref;
+            $this->save();
+        }
+
+        return $this->payyo_reference;
+    }
+
     // Special for field "payrexx_transaction": store encrypted
     public function setPayrexxTransaction($value)
     {

--- a/app/Models/Voucher.php
+++ b/app/Models/Voucher.php
@@ -182,4 +182,44 @@ class Voucher extends Model
     {
          return LogOptions::defaults();
     }
+
+    // Special for field "payrexx_transaction": store encrypted
+    public function setPayrexxTransaction($value)
+    {
+        $this->payrexx_transaction = encrypt(json_encode($value));
+    }
+
+    public function getPayrexxTransaction()
+    {
+        $decrypted = null;
+        if ($this->payrexx_transaction) {
+            try {
+                $decrypted = decrypt($this->payrexx_transaction);
+            } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+                $decrypted = null; // Data seems corrupt or tampered
+            }
+        }
+
+        return $decrypted ? json_decode($decrypted, true) : [];
+    }
+
+    // Special for field "payyo_transaction": store encrypted
+    public function setPayyoTransaction($value)
+    {
+        $this->payyo_transaction = encrypt(json_encode($value));
+    }
+
+    public function getPayyoTransaction()
+    {
+        $decrypted = null;
+        if ($this->payyo_transaction) {
+            try {
+                $decrypted = decrypt($this->payyo_transaction);
+            } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+                $decrypted = null; // Data seems corrupt or tampered
+            }
+        }
+
+        return $decrypted ? json_decode($decrypted, true) : [];
+    }
 }


### PR DESCRIPTION
## Summary
- add Payyo reference handling and helper integration
- switch booking payment flow to Payyo when school's provider is payyo
- update Payyo webhook controller to store payyo transaction data

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Tests: 2, Assertions: 1, Errors: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f4674a48320ae8e73c5a0b4dea8