### PR TITLE
Document Payyo setup and add payment tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,24 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Payyo configuration
+
+This project supports payments through **Payyo** in addition to Payrexx. To
+use Payyo you need to provide API credentials and mark the relevant school as
+using this provider.
+
+1. Add your Payyo credentials to the application environment:
+
+   ```env
+   PAYYO_INSTANCE=your-instance.payyo.com
+   PAYYO_KEY=your-payyo-api-key
+   ```
+
+2. In the `schools` table set the columns `payment_provider` to `payyo` and
+   fill `payyo_instance` and `payyo_key` with the merchant credentials for that
+   school. Other schools will continue to fall back to the default Payrexx
+   integration.
+
+With these settings the `bookings/payments` endpoint will generate Payyo links
+for the configured school while all other schools keep using Payrexx.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/storage/api-docs/payments.md
+++ b/storage/api-docs/payments.md
@@ -1,0 +1,28 @@
+# Payments API examples
+
+## Environment variables
+
+Configure Payyo credentials in your `.env` file:
+
+```env
+PAYYO_INSTANCE=your-instance.payyo.com
+PAYYO_KEY=your-payyo-api-key
+```
+
+Assign a school to Payyo by setting `payment_provider` to `payyo` and storing
+`payyo_instance` and `payyo_key` for that school. Schools without these values
+will use Payrexx instead.
+
+## Sample API call
+
+Create a payment link for a booking:
+
+```bash
+curl -X POST http://localhost/api/slug/bookings/payments/1 \
+  -H 'slug: your-school-slug' \
+  -H 'Content-Type: application/json' \
+  -d '{"redirectUrl": "https://example.com/return"}'
+```
+
+The endpoint returns a URL to the hosted payment page. If the school is not
+configured for Payyo, the request falls back to generating a Payrexx link.

--- a/tests/Feature/PaymentProviderTest.php
+++ b/tests/Feature/PaymentProviderTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\School;
+use App\Models\Booking;
+use App\Models\Client;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class PaymentProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Disable activity logging to simplify testing
+        config(['activitylog.enabled' => false]);
+
+        // Run only the migrations required for these tests
+        $this->artisan('migrate', ['--path' => 'tests/database/migrations/2023_11_08_110720_create_schools_table.php', '--force' => true]);
+        $this->artisan('migrate', ['--path' => 'database/migrations/2025_08_28_082703_add_payment_provider_columns_to_schools_table.php', '--force' => true]);
+        $this->artisan('migrate', ['--path' => 'tests/database/migrations/2023_11_08_110721_create_languages_table.php', '--force' => true]);
+        $this->artisan('migrate', ['--path' => 'tests/database/migrations/2023_11_08_110722_create_users_table.php', '--force' => true]);
+        $this->artisan('migrate', ['--path' => 'tests/database/migrations/2023_11_08_110723_create_clients_table.php', '--force' => true]);
+        $this->artisan('migrate', ['--path' => 'tests/database/migrations/2023_11_08_110724_create_bookings_table.php', '--force' => true]);
+    }
+
+    protected function tearDown(): void
+    {
+        // Roll back migrations
+        $this->artisan('migrate:reset', ['--path' => 'tests/database/migrations/2023_11_08_110724_create_bookings_table.php', '--force' => true]);
+        $this->artisan('migrate:reset', ['--path' => 'tests/database/migrations/2023_11_08_110723_create_clients_table.php', '--force' => true]);
+        $this->artisan('migrate:reset', ['--path' => 'tests/database/migrations/2023_11_08_110722_create_users_table.php', '--force' => true]);
+        $this->artisan('migrate:reset', ['--path' => 'tests/database/migrations/2023_11_08_110721_create_languages_table.php', '--force' => true]);
+        $this->artisan('migrate:reset', ['--path' => 'database/migrations/2025_08_28_082703_add_payment_provider_columns_to_schools_table.php', '--force' => true]);
+        $this->artisan('migrate:reset', ['--path' => 'tests/database/migrations/2023_11_08_110720_create_schools_table.php', '--force' => true]);
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_pay_booking_uses_payyo_when_configured()
+    {
+        $school = School::withoutEvents(function () {
+            $school = School::factory()->create([
+                'payment_provider' => 'payyo',
+                'slug' => 'payyo-school',
+                'active' => 1,
+                'settings' => '{}',
+            ]);
+            $school->setPayyoInstance('merchant');
+            $school->setPayyoKey('secret');
+            $school->save();
+            return $school;
+        });
+
+        $client = new Client([
+            'email' => 'client@example.com',
+            'first_name' => 'Test',
+            'last_name' => 'User',
+            'birth_date' => '2000-01-01',
+        ]);
+        $client->id = 1;
+        $client->save();
+
+        $booking = new Booking([
+            'school_id' => $school->id,
+            'client_main_id' => $client->id,
+            'price_total' => 100,
+            'currency' => 'CHF',
+            'payment_method_id' => 1,
+            'paid' => false,
+        ]);
+        $booking->id = 1;
+        $booking->save();
+
+        Mockery::mock('overload:App\\Http\\Controllers\\PayyoHelpers')
+            ->shouldReceive('createPayLink')
+            ->once()
+            ->andReturn('https://payyo.test/link');
+
+        Mockery::mock('overload:App\\Http\\Controllers\\PayrexxHelpers')
+            ->shouldReceive('createGatewayLink')
+            ->never();
+
+        $response = $this->postJson('/api/slug/bookings/payments/' . $booking->id, [], ['slug' => $school->slug]);
+
+        $response->assertStatus(200)
+            ->assertJson(['data' => 'https://payyo.test/link']);
+    }
+
+    public function test_pay_booking_falls_back_to_payrexx_for_other_schools()
+    {
+        $school = School::withoutEvents(function () {
+            return School::factory()->create([
+                'payment_provider' => 'payrexx',
+                'slug' => 'payrexx-school',
+                'active' => 1,
+                'settings' => '{}',
+            ]);
+        });
+
+        $client = new Client([
+            'email' => 'client@example.com',
+            'first_name' => 'Test',
+            'last_name' => 'User',
+            'birth_date' => '2000-01-01',
+        ]);
+        $client->id = 1;
+        $client->save();
+
+        $booking = new Booking([
+            'school_id' => $school->id,
+            'client_main_id' => $client->id,
+            'price_total' => 100,
+            'currency' => 'CHF',
+            'payment_method_id' => 1,
+            'paid' => false,
+        ]);
+        $booking->id = 1;
+        $booking->save();
+
+        Mockery::mock('overload:App\\Http\\Controllers\\PayyoHelpers')
+            ->shouldReceive('createPayLink')
+            ->never();
+
+        Mockery::mock('overload:App\\Http\\Controllers\\PayrexxHelpers')
+            ->shouldReceive('createGatewayLink')
+            ->once()
+            ->andReturn('https://payrexx.test/link');
+
+        $response = $this->postJson('/api/slug/bookings/payments/' . $booking->id, [], ['slug' => $school->slug]);
+
+        $response->assertStatus(200)
+            ->assertJson(['data' => 'https://payrexx.test/link']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- document Payyo configuration and school setup
- provide sample env entries and API call
- add tests for Payyo and Payrexx payment flows

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' ./vendor/bin/phpunit tests/Feature/PaymentProviderTest.php` *(fails: no such table: index image already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68b05b03c204832084ea34ed8c729641