### PR TITLE
feat: add modules registry and seed

### DIFF
--- a/app/Domain/Modules/ModulesRegistry.php
+++ b/app/Domain/Modules/ModulesRegistry.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Domain\Modules;
+
+class ModulesRegistry
+{
+    /**
+     * Retrieve the list of available modules.
+     *
+     * Each module contains:
+     *  - slug: unique identifier
+     *  - name: human readable name
+     *  - deps: array of dependent module slugs
+     *  - priority: core|high|medium|low
+     *
+     * @return array<int, array{slug:string,name:string,deps:array<int,string>,priority:string}>
+     */
+    public static function all(): array
+    {
+        return [
+            ['slug' => 'auth', 'name' => 'Authentication', 'deps' => [], 'priority' => 'core'],
+            ['slug' => 'schools', 'name' => 'Schools', 'deps' => [], 'priority' => 'core'],
+            ['slug' => 'seasons', 'name' => 'Seasons', 'deps' => [], 'priority' => 'core'],
+            ['slug' => 'users_roles', 'name' => 'Users & Roles', 'deps' => [], 'priority' => 'core'],
+            ['slug' => 'feature_flags', 'name' => 'Feature Flags', 'deps' => [], 'priority' => 'core'],
+            ['slug' => 'courses', 'name' => 'Courses', 'deps' => [], 'priority' => 'high'],
+            ['slug' => 'clients', 'name' => 'Clients', 'deps' => [], 'priority' => 'high'],
+            [
+                'slug' => 'bookings',
+                'name' => 'Bookings',
+                'deps' => ['courses', 'clients', 'seasons'],
+                'priority' => 'high',
+            ],
+            [
+                'slug' => 'renting',
+                'name' => 'Renting',
+                'deps' => ['schools', 'auth'],
+                'priority' => 'high',
+            ],
+            ['slug' => 'instructors', 'name' => 'Instructors', 'deps' => [], 'priority' => 'medium'],
+            ['slug' => 'schedules', 'name' => 'Schedules', 'deps' => [], 'priority' => 'medium'],
+            ['slug' => 'vouchers', 'name' => 'Vouchers', 'deps' => [], 'priority' => 'medium'],
+            ['slug' => 'finance', 'name' => 'Finance', 'deps' => [], 'priority' => 'low'],
+            ['slug' => 'analytics', 'name' => 'Analytics', 'deps' => [], 'priority' => 'low'],
+            ['slug' => 'comms', 'name' => 'Communications', 'deps' => [], 'priority' => 'low'],
+        ];
+    }
+}

--- a/database/migrations/2025_08_31_000000_create_modules_table.php
+++ b/database/migrations/2025_08_31_000000_create_modules_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('modules', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->json('deps')->nullable();
+            $table->enum('priority', ['core', 'high', 'medium', 'low']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('modules');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,14 +13,15 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            ModulesSeeder::class,
             // Basic data
             SportsTableSeeder::class,
             SchoolSalaryLevelsTableSeeder::class,
-            
+
             // V5 Enhanced Test Setup - Comprehensive testing scenarios
             V5EnhancedUsersSeeder::class,
             V5TestDataSeeder::class,
-            
+
             // Additional V5 modules
             V5RentingDemoSeeder::class,
         ]);

--- a/database/seeders/ModulesSeeder.php
+++ b/database/seeders/ModulesSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Domain\Modules\ModulesRegistry;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ModulesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach (ModulesRegistry::all() as $module) {
+            DB::table('modules')->updateOrInsert(
+                ['slug' => $module['slug']],
+                [
+                    'name' => $module['name'],
+                    'deps' => json_encode($module['deps']),
+                    'priority' => $module['priority'],
+                    'updated_at' => now(),
+                    'created_at' => now(),
+                ]
+            );
+        }
+    }
+}

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -1,0 +1,34 @@
+# Modules Catalog
+
+This document lists the application modules and their relationships.
+
+## Modules
+
+| Slug | Name | Priority | Dependencies |
+| ---- | ---- | -------- | ------------ |
+| auth | Authentication | core | - |
+| schools | Schools | core | - |
+| seasons | Seasons | core | - |
+| users_roles | Users & Roles | core | - |
+| feature_flags | Feature Flags | core | - |
+| courses | Courses | high | - |
+| clients | Clients | high | - |
+| bookings | Bookings | high | courses, clients, seasons |
+| renting | Renting | high | schools, auth |
+| instructors | Instructors | medium | - |
+| schedules | Schedules | medium | - |
+| vouchers | Vouchers | medium | - |
+| finance | Finance | low | - |
+| analytics | Analytics | low | - |
+| comms | Communications | low | - |
+
+## Dependency Diagram
+
+```mermaid
+graph TD;
+    auth --> renting;
+    schools --> renting;
+    courses --> bookings;
+    clients --> bookings;
+    seasons --> bookings;
+```

--- a/tests/Unit/Domain/Modules/ModulesRegistryTest.php
+++ b/tests/Unit/Domain/Modules/ModulesRegistryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit\Domain\Modules;
+
+use App\Domain\Modules\ModulesRegistry;
+use PHPUnit\Framework\TestCase;
+
+class ModulesRegistryTest extends TestCase
+{
+    public function testSlugsAreUnique(): void
+    {
+        $slugs = array_map(fn ($module) => $module['slug'], ModulesRegistry::all());
+        $this->assertSame($slugs, array_values(array_unique($slugs)));
+    }
+
+    public function testDependenciesHaveNoCycles(): void
+    {
+        $modules = ModulesRegistry::all();
+        $graph = [];
+        foreach ($modules as $module) {
+            $graph[$module['slug']] = $module['deps'];
+        }
+
+        $visited = [];
+
+        $visit = function ($node) use (&$visit, &$graph, &$visited) {
+            if (isset($visited[$node]) && $visited[$node] === 1) {
+                return true; // cycle
+            }
+            if (($visited[$node] ?? 0) === 2) {
+                return false;
+            }
+            $visited[$node] = 1;
+            foreach ($graph[$node] as $dep) {
+                if ($visit($dep)) {
+                    return true;
+                }
+            }
+            $visited[$node] = 2;
+
+            return false;
+        };
+
+        foreach (array_keys($graph) as $node) {
+            if ($visit($node)) {
+                $this->fail('Cycle detected in module dependencies');
+            }
+        }
+
+        $this->assertTrue(true); // no cycles
+    }
+}


### PR DESCRIPTION
## Summary
- add `ModulesRegistry` to centralize module metadata and dependencies
- create `modules` migration and seeder wired into `DatabaseSeeder`
- document module catalog and provide dependency diagram

## Testing
- `vendor/bin/pint --test app/Domain/Modules/ModulesRegistry.php database/migrations/2025_08_31_000000_create_modules_table.php database/seeders/ModulesSeeder.php database/seeders/DatabaseSeeder.php tests/Unit/Domain/Modules/ModulesRegistryTest.php`
- `vendor/bin/phpunit tests/Unit/Domain/Modules/ModulesRegistryTest.php`
- `vendor/bin/phpunit` *(fails: syntax error in tests/Feature/SeasonApiTest.php:154)*

------
https://chatgpt.com/codex/tasks/task_e_68b584358b6c83208ef21ee7c0e46964