### PR TITLE
docs: add only_weekends query param to statistics endpoints

### DIFF
--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -11684,6 +11684,16 @@
                             "type": "string",
                             "format": "date"
                         }
+                    },
+                    {
+                        "name": "only_weekends",
+                        "in": "query",
+                        "description": "Return results for Saturdays and Sundays only",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
                     }
                 ],
                 "responses": {
@@ -11741,6 +11751,16 @@
                         "schema": {
                             "type": "string",
                             "format": "date"
+                        }
+                    },
+                    {
+                        "name": "only_weekends",
+                        "in": "query",
+                        "description": "Return results for Saturdays and Sundays only",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
                         }
                     }
                 ],


### PR DESCRIPTION
## Summary
- document optional `only_weekends` query parameter for `/admin/statistics/monitors/active`
- document optional `only_weekends` query parameter for `/admin/statistics/bookings/monitors`

## Testing
- `php artisan l5-swagger:generate` *(fails: Unable to merge @OA\Post())*
- `vendor/bin/pint --test --no-interaction` *(fails: 833 files, 638 style issues)*
- `vendor/bin/phpunit` *(incomplete: tests produced early termination)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a79e663c8320a7afdd66624ecccd